### PR TITLE
Upgrading to sbt 1.3.0

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,6 @@
+-Dsbt.classloader.close=false
+-J-XX:ReservedCodeCacheSize=128M
+-J-Xmx1512M
+-J-Xss2M
+-J-XX:+UseCompressedOops
+-J-XX:+CMSClassUnloadingEnabled

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0


### PR DESCRIPTION
This updates SBT to 1.3.0. If you have an sbt launcher script which does not use the ".sbtopts" file, you need to either add "-Dsbt.classloader.close=false" in your SBT_OPTS env variable or pass it in manually when starting sbt. This shouldn't be any problem unless you're running your own sbt launcher script(s).