### PR TITLE
Upgrade paradox to version 0.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
     - cd node-support && npm install && cd -
     - cd docs/src/test/js && npm install && cd -
     script:
-    - sbt 'set concurrentRestrictions in Global += Tags.limitAll(1)' docs/paradox docs/test
+    - sbt 'set concurrentRestrictions in Global += Tags.limitAll(1)' docs/paradoxValidateInternalLinks docs/test
     - cd docs/src/test/js && npm test && cd -
   
   - stage: TCK

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,4 +19,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
 
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.4")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.5")


### PR DESCRIPTION
This gives us the new links validation feature, which allows us to verify that all links to javadocs/jsdocs are valid.