### PR TITLE
Fixed protobuf package import in load generator

### DIFF
--- a/samples/js-shopping-cart-load-generator/src/main/scala/io/cloudstate/loadgenerator/GenerateLoad.scala
+++ b/samples/js-shopping-cart-load-generator/src/main/scala/io/cloudstate/loadgenerator/GenerateLoad.scala
@@ -1,6 +1,6 @@
 package io.cloudstate.loadgenerator
 
-import java.time.{Instant, ZonedDateTime}
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 import akka.Done
@@ -9,7 +9,7 @@ import akka.grpc.GrpcClientSettings
 import akka.pattern.{BackoffOpts, BackoffSupervisor}
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
-import com.example.shoppingcart._
+import com.example.shoppingcart.shoppingcart._
 import com.google.protobuf.empty.Empty
 
 import scala.concurrent.duration._


### PR DESCRIPTION
I guess this update simply got missed from a595d55f

Question to maintainers, should `load-generator` (well, any extra sources) be added as a _compile-time_ dependency to the project's root? Helps to catch errors when rarely used code simply falls of the radar...