### PR TITLE
Consolidate format checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,8 @@ env:
 jobs:
   include:
   - stage: Format checks
-    name: "Code format check (address by running `sbt scalafmtAll`)"
-    before_script: sbt update
-    script: sbt scalafmtCheckAll || { echo "[error] Code not formatted prior to commit. Run 'sbt scalafmtAll' then commit the reformatted code."; false; }
-
-  - name: "Build code format check (address by running `sbt scalafmtSbt`)"
-    before_script: sbt update
-    script: sbt scalafmtSbtCheck || { echo "[error] Build definition code not formatted prior to commit. Run 'sbt scalafmtSbt' then commit the reformatted code."; false; }
+    name: "Code format check (address by running `sbt scalafmtAll scalafmtSbt`)"
+    script: sbt scalafmtCheckAll scalafmtSbtCheck || { echo "[error] Code not formatted prior to commit. Run 'sbt scalafmtAll scalafmtSbt' then commit the reformatted code."; false; }
 
   - stage: Unit tests
     name: npm tests


### PR DESCRIPTION
It takes less than a second to run scalafmtSbtCheck as part of another sbt run, but as its own job, it takes almost 2 minutes, and particularly if our travis build queue is deep, with only 3 workers available to us, that's a long time to hold up the queue for if someone is waiting for the PR to be validated.