### PR TITLE
Add namespace option to for csharp protoc plugin

### DIFF
--- a/protocols/frontend/google/api/annotations.proto
+++ b/protocols/frontend/google/api/annotations.proto
@@ -19,6 +19,7 @@ package google.api;
 import "google/api/http.proto";
 import "google/protobuf/descriptor.proto";
 
+option csharp_namespace = "Google.Protobuf";
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;
 option java_outer_classname = "AnnotationsProto";

--- a/protocols/frontend/google/api/http.proto
+++ b/protocols/frontend/google/api/http.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 
 package google.api;
 
+option csharp_namespace = "Google.Protobuf";
 option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;


### PR DESCRIPTION
In support of #97 protoc needs to know about the `Google.Protobuf` C# namespace.