### PR TITLE
Upgrading the HttpApi support to cover more of the GCP featureset

### DIFF
--- a/node-support/package-lock.json
+++ b/node-support/package-lock.json
@@ -2651,9 +2651,9 @@
       }
     },
     "handlebars": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5337,9 +5337,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
@@ -53,6 +53,10 @@ import io.cloudstate.proxy.eventsourced.EventSourcedSupportFactory
 
 import scala.concurrent.duration._
 
+//import io.cloudstate.protocol.entity.{ClientAction, EntityDiscovery, Failure, Reply, UserFunctionError}
+import io.cloudstate.protocol.entity.EntityDiscovery
+import io.cloudstate.proxy.EntityDiscoveryManager.ServableEntity
+
 object EntityDiscoveryManager {
   final case class Configuration(
       devMode: Boolean,

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
@@ -688,7 +688,7 @@ private object PathTemplateParser extends Parsers {
           found += fieldPath
           TemplateVariable(
             fieldPath,
-            segments.fold(false)(segments => segments.length > 1 || segments.head.isInstanceOf[MultiSegmentMatcher])
+            segments.exists(segments => segments.length > 1 || segments.head.isInstanceOf[MultiSegmentMatcher])
           )
       }
     }

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
@@ -94,10 +94,10 @@ object Serve {
       mat: Materializer,
       ec: ExecutionContext
   ): PartialFunction[HttpRequest, Future[HttpResponse]] = {
-    val grpcRoutes = compileProxy(entities, router, statsCollector, entityDiscoveryClient)
+    val grpcProxy = compileProxy(entities, router, statsCollector, entityDiscoveryClient)
 
-    grpcRoutes orElse // Fast path
-    HttpApi.serve(entities.map(_.serviceDescriptor -> grpcRoutes).toList) orElse
+    grpcProxy orElse // Fast path
+    HttpApi.serve(entities.map(_.serviceDescriptor -> grpcProxy).toList) orElse
     handleNetworkProbe() orElse
     Reflection.serve(fileDescriptors, entities.map(_.serviceName).toList) orElse
     NotFound // No match. TODO: Consider having the caller of this method deal with this condition
@@ -139,11 +139,10 @@ object Serve {
        ))
     }).toMap
 
-    val mapRequestFailureExceptions: ActorSystem => PartialFunction[Throwable, Status] = {
-      val pf: PartialFunction[Throwable, Status] = {
+    val mapRequestFailureExceptions: ActorSystem => PartialFunction[Throwable, Status] = { _ =>
+      {
         case CommandException(msg) => Status.UNKNOWN.augmentDescription(msg)
       }
-      _ => pf
     }
 
     {
@@ -157,38 +156,44 @@ object Serve {
         }
         unmarshalStream(req)(handler.serializer, mat)
           .map { commands =>
-            val pipeline: Source[ProtobufByteString, NotUsed] = commands
-              .via(handler.flow)
-              .map { reply =>
-                reply.clientAction match {
-                  case Some(ClientAction(ClientAction.Action.Reply(Reply(Some(payload))))) =>
-                    if (payload.typeUrl != handler.expectedReplyTypeUrl) {
-                      val msg =
-                        s"${handler.fullCommandName}: Expected reply type_url to be [${handler.expectedReplyTypeUrl}] but was [${payload.typeUrl}]."
-                      log.warn(msg)
-                      entityDiscoveryClient.reportError(UserFunctionError("Warning: " + msg))
-                    }
-                    Some(payload.value)
-                  case Some(ClientAction(ClientAction.Action.Forward(_))) =>
-                    log.error("Cannot serialize forward reply, this should have been handled by the UserFunctionRouter")
-                    None
-                  case Some(ClientAction(ClientAction.Action.Failure(Failure(_, message)))) =>
-                    throw CommandException(message)
-                  case _ =>
-                    None
-                }
-              }
-              .collect(Function.unlift(identity))
-              .watchTermination() { (_, complete) =>
-                if (handler.unary) {
-                  complete.onComplete { _ =>
-                    statsCollector ! StatsCollector.ResponseSent(System.nanoTime() - startTime)
+            val actionHandler =
+              handler.flow
+                .map { reply =>
+                  reply.clientAction match {
+                    case Some(ClientAction(ClientAction.Action.Reply(Reply(Some(payload))))) =>
+                      if (payload.typeUrl != handler.expectedReplyTypeUrl) {
+                        val msg =
+                          s"${handler.fullCommandName}: Expected reply type_url to be [${handler.expectedReplyTypeUrl}] but was [${payload.typeUrl}]."
+                        log.warn(msg)
+                        entityDiscoveryClient.reportError(UserFunctionError("Warning: " + msg))
+                      }
+                      Some(payload.value)
+                    case Some(ClientAction(ClientAction.Action.Forward(_))) =>
+                      log.error(
+                        "Cannot serialize forward reply, this should have been handled by the UserFunctionRouter"
+                      )
+                      None
+                    case Some(ClientAction(ClientAction.Action.Failure(Failure(_, message)))) =>
+                      throw CommandException(message)
+                    case _ =>
+                      None
                   }
                 }
-                NotUsed
-              }
+                .collect(Function.unlift(identity))
 
-            marshalStream(pipeline, mapRequestFailureExceptions)(ReplySerializer, mat, responseCodec, sys)
+            val pipeline =
+              if (handler.unary) {
+                actionHandler.watchTermination() { (_, complete) =>
+                  if (handler.unary) {
+                    complete.onComplete { _ =>
+                      statsCollector ! StatsCollector.ResponseSent(System.nanoTime() - startTime)
+                    }
+                  }
+                  NotUsed
+                }
+              } else actionHandler
+
+            marshalStream(commands via pipeline, mapRequestFailureExceptions)(ReplySerializer, mat, responseCodec, sys)
           }
           .recoverWith(GrpcExceptionHandler.default(GrpcExceptionHandler.defaultMapper(sys)))
     }

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/HttpApiSpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/HttpApiSpec.scala
@@ -30,35 +30,25 @@ import com.google.protobuf.Descriptors.{FileDescriptor, ServiceDescriptor}
 import com.google.protobuf.empty.Empty
 import io.cloudstate.protocol.entity.{EntityDiscovery, EntityDiscoveryClient, EntitySpec, ProxyInfo, UserFunctionError}
 import io.cloudstate.proxy.EntityDiscoveryManager.ServableEntity
+import io.cloudstate.proxy.PathTemplateParser.PathTemplateParseException
 import io.cloudstate.proxy.entity.{UserFunctionCommand, UserFunctionReply}
 
 import scala.concurrent.Future
 
 class HttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest {
-  implicit val timeout = Timeout(10.seconds)
-  import akka.pattern.ask
-
-  private val mockEntityDiscovery = new EntityDiscovery {
-    override def discover(in: ProxyInfo): Future[EntitySpec] = ???
-    override def reportError(in: UserFunctionError): Future[Empty] = ???
-  }
 
   def assertConfigurationFailure(d: FileDescriptor, n: String, msg: String): Assertion =
     intercept[ConfigurationException] {
       val service = d.findServiceByName(n)
       service must not be (null)
-      val probe = TestProbe().ref
-      val entity = ServableEntity(
-        service.getFullName,
-        service,
-        new UserFunctionTypeSupport {
-          override def handler(command: String): Flow[UserFunctionCommand, UserFunctionReply, NotUsed] =
-            Flow[UserFunctionCommand].mapAsync(1)(handleUnary)
-          override def handleUnary(command: UserFunctionCommand): Future[UserFunctionReply] =
-            (probe ? command).mapTo[UserFunctionReply]
-        }
-      )
-      HttpApi.serve(new UserFunctionRouter(Seq(entity), mockEntityDiscovery), Seq(entity), mockEntityDiscovery)
+      HttpApi.serve(List(service -> PartialFunction.empty))
+    }.getMessage must equal(msg)
+
+  def assertPathTemplateParseFailure(d: FileDescriptor, n: String, msg: String): Assertion =
+    intercept[PathTemplateParseException] {
+      val service = d.findServiceByName(n)
+      service must not be (null)
+      HttpApi.serve(List(service -> PartialFunction.empty))
     }.getMessage must equal(msg)
 
   "HTTP API" must {
@@ -79,10 +69,10 @@ class HttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest {
     }
 
     "not allow patterns which do not start with slash" in {
-      assertConfigurationFailure(
+      assertPathTemplateParseFailure(
         IllegalHttpConfig2.IllegalHttpConfig2Proto.javaDescriptor,
         "IllegalHttpConfig2",
-        "HTTP API Config: Configured pattern [no/initial/slash] does not start with slash"
+        "Template must start with a slash at character 1 of 'no/initial/slash'"
       )
     }
 
@@ -97,10 +87,10 @@ class HttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest {
     "not allow path extractors which refer to map fields" in pending
 
     "not allow path extractors to be duplicated in the same rule" in {
-      assertConfigurationFailure(
+      assertPathTemplateParseFailure(
         IllegalHttpConfig4.IllegalHttpConfig4Proto.javaDescriptor,
         "IllegalHttpConfig4",
-        "HTTP API Config: Path parameter [duplicated] occurs more than once"
+        "Duplicate path in template at character 16 of '/{duplicated}/{duplicated}'"
       )
     }
 

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/PathTemplateParserSpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/PathTemplateParserSpec.scala
@@ -1,0 +1,96 @@
+package io.cloudstate.proxy
+
+import io.cloudstate.proxy.PathTemplateParser.{PathTemplateParseException, TemplateVariable}
+import org.scalatest.{Matchers, WordSpec}
+
+class PathTemplateParserSpec extends WordSpec with Matchers {
+
+  private def matches(template: PathTemplateParser.ParsedTemplate, path: String): Option[List[String]] = {
+    val m = template.regex.pattern.matcher(path)
+    if (m.matches()) {
+      Some((1 to m.groupCount()).map(m.group).toList)
+    } else None
+  }
+
+  private def failParse(path: String) = {
+    val e = the[PathTemplateParseException] thrownBy PathTemplateParser.parse(path)
+    // Uncomment to sanity check the user friendliness of error messages
+    // println(e.prettyPrint + "\n")
+    e
+  }
+
+  "The path template parse" should {
+    "parse a simple path template" in {
+      val template = PathTemplateParser.parse("/foo")
+      template.fields shouldBe empty
+      matches(template, "/foo") shouldBe Some(Nil)
+      matches(template, "/bar") shouldBe None
+    }
+
+    "parse a path template with variables" in {
+      val template = PathTemplateParser.parse("/foo/{bar}/baz")
+      template.fields shouldBe List(TemplateVariable(List("bar"), false))
+      matches(template, "/foo") shouldBe None
+      matches(template, "/foo/bl/ah/baz") shouldBe None
+      matches(template, "/foo/blah/baz") shouldBe Some(List("blah"))
+    }
+
+    "parse a path template with multiple variables" in {
+      val template = PathTemplateParser.parse("/foo/{bar}/baz/{other}")
+      template.fields shouldBe List(TemplateVariable(List("bar"), false), TemplateVariable(List("other"), false))
+      matches(template, "/foo/blah/baz") shouldBe None
+      matches(template, "/foo/blah/baz/blah2") shouldBe Some(List("blah", "blah2"))
+    }
+
+    "support variable templates" in {
+      val template = PathTemplateParser.parse("/foo/{bar=*/a/*}/baz")
+      template.fields shouldBe List(TemplateVariable(List("bar"), true))
+      matches(template, "/foo/blah/baz") shouldBe None
+      matches(template, "/foo/bl/a/h/baz") shouldBe Some(List("bl/a/h"))
+    }
+
+    "support rest of path glob matching" in {
+      val template = PathTemplateParser.parse("/foo/{bar=**}")
+      template.fields shouldBe List(TemplateVariable(List("bar"), true))
+      matches(template, "/foo/blah/baz") shouldBe Some(List("blah/baz"))
+    }
+
+    "support verbs" in {
+      val template = PathTemplateParser.parse("/foo/{bar}:watch")
+      template.fields shouldBe List(TemplateVariable(List("bar"), false))
+      matches(template, "/foo/blah") shouldBe None
+      matches(template, "/foo/blah:watch") shouldBe Some(List("blah"))
+    }
+
+    "fail to parse nested variables" in {
+      val e = failParse("/foo/{bar={baz}}")
+      e.column shouldBe 11
+    }
+
+    "fail to parse templates that don't start with a slash" in {
+      val e = failParse("foo")
+      e.column shouldBe 1
+    }
+
+    "fail to parse templates with missing equals" in {
+      val e = failParse("/foo/{bar*}")
+      e.column shouldBe 10
+    }
+
+    "fail to parse templates with no closing bracket" in {
+      val e = failParse("/foo/{bar")
+      e.column shouldBe 10
+    }
+
+    "fail to parse templates with badly placed stars" in {
+      val e = failParse("/f*o")
+      e.column shouldBe 3
+    }
+
+    "fail to parse templates with bad variable patterns" in {
+      val e = failParse("/foo/{bar=ba*}")
+      e.column shouldBe 13
+    }
+  }
+
+}


### PR DESCRIPTION
@jroper came up with some great improvements to the HttpApi—and I have integrated them in this PR. One big benefit of this approach is that the HttpAPI layer acts as a translator and then forwards the requests to the gRPC route, leading to a much cleaner pipeline.