### PR TITLE
Update to the documentation regarding client languages + mention of the CLI

### DIFF
--- a/docs/src/main/paradox/user/lang/index.md
+++ b/docs/src/main/paradox/user/lang/index.md
@@ -25,16 +25,14 @@ Here is a list of other, **non-official** libraries in various other languages:
 | [scala-support](https://github.com/cloudstateio/cloudstate/tree/master/scala-support/src/main) | Scala | :warning: | :warning: |
 | [kotlin-support](https://github.com/cloudstateio/kotlin-support) | Kotlin | :warning: | :warning: |
 | [cloudstate-csharp](https://github.com/nagytech/cloudstate-csharp)| C# | :heavy_check_mark: | :heavy_check_mark: | 
-| [python-support](https://github.com/marcellanz/cloudstate_python-support/tree/feature/python-support)| Python | | |
-| | Elixir | | |
-| | F# | | |
-| | Ruby | | |
-| | Rust | | |
+| [python-support](https://github.com/marcellanz/cloudstate_python-support/tree/feature/python-support)| Python | :question: | :question: |
+| [cloudstate-rust](https://github.com/sleipnir/cloudstate-rust)| Rust | :question: | :question: |
 
 ### Legend:
 - :heavy_check_mark: Supported
 - :x: Not supported
 - :warning: Partial support / Unstable (see details on the website)
+- :question: Support status unknown
 
 ## Cloudstate CLI
 :point_up_2: Please be aware that the **CloudState CLI** project allows you to easily kick-start a new client project. 

--- a/docs/src/main/paradox/user/lang/index.md
+++ b/docs/src/main/paradox/user/lang/index.md
@@ -20,7 +20,7 @@ We are aware of external libraries implementing the **client Cloudstate protocol
  
 Here is a list of other, **non-official** libraries in various other languages:
 
-| Library Name | Language | Event-based support? | CRDT support? |
+| Library Name | Language | Event-sourcing support? | CRDT support? |
 |--------------|----------|----------------------|---------------|
 | [scala-support](https://github.com/cloudstateio/cloudstate/tree/master/scala-support/src/main) | Scala | :warning: | :warning: |
 | [kotlin-support](https://github.com/cloudstateio/kotlin-support) | Kotlin | :warning: | :warning: |

--- a/docs/src/main/paradox/user/lang/index.md
+++ b/docs/src/main/paradox/user/lang/index.md
@@ -1,6 +1,5 @@
 # Languages
 
-## Officially supported client libraries
 Cloudstate user functions can be implemented in any language that supports gRPC. That said, the Cloudstate gRPC protocol is typically too low level for user functions to effectively implement their business logic in. Hence, Cloudstate provides support libraries for multiple languages to allow developers to implement entities using idiomatic APIs.
 
 @@toc { depth=1 }
@@ -13,20 +12,20 @@ Cloudstate user functions can be implemented in any language that supports gRPC.
 
 @@@
 
-## Unofficial client libraries
+## 3rd party libraries
 We are aware of external libraries implementing the **client Cloudstate protocol** in various other languages.
 
 :warning: **Though they are mentioned here, these libraries are often not directly maintained by the Cloudstate dev team and are therefore not supported**.
  
 Here is a list of other, **non-official** libraries in various other languages:
 
-| Library Name | Language | Event-sourcing support? | CRDT support? |
-|--------------|----------|----------------------|---------------|
-| [scala-support](https://github.com/cloudstateio/cloudstate/tree/master/scala-support/src/main) | Scala | :warning: | :warning: |
-| [kotlin-support](https://github.com/cloudstateio/kotlin-support) | Kotlin | :warning: | :warning: |
-| [cloudstate-csharp](https://github.com/nagytech/cloudstate-csharp)| C# | :heavy_check_mark: | :heavy_check_mark: | 
-| [python-support](https://github.com/marcellanz/cloudstate_python-support/tree/feature/python-support)| Python | :question: | :question: |
-| [cloudstate-rust](https://github.com/sleipnir/cloudstate-rust)| Rust | :question: | :question: |
+| Library Name                                                                                          | Language  | Event-sourcing support?   | CRDT support?         | Stateless support?    |
+|-------------------------------------------------------------------------------------------------------|-----------|---------------------------|-----------------------|-----------------------|
+| [scala-support](https://github.com/cloudstateio/cloudstate/tree/master/scala-support/src/main)        | Scala     | :warning:                 | :warning:             | :x:                   |
+| [kotlin-support](https://github.com/cloudstateio/kotlin-support)                                      | Kotlin    | :warning:                 | :warning:             | :x:                   |
+| [cloudstate-csharp](https://github.com/nagytech/cloudstate-csharp)                                    | C#        | :heavy_check_mark:        | :heavy_check_mark:    | :x:                   |
+| [python-support](https://github.com/marcellanz/cloudstate_python-support/tree/feature/python-support) | Python    | :question:                | :question:            | :x:                   |
+| [cloudstate-rust](https://github.com/sleipnir/cloudstate-rust)                                        | Rust      | :question:                | :question:            | :x:                   |
 
 ### Legend:
 - :heavy_check_mark: Supported

--- a/docs/src/main/paradox/user/lang/index.md
+++ b/docs/src/main/paradox/user/lang/index.md
@@ -1,5 +1,6 @@
 # Languages
 
+## Officially supported client libraries
 Cloudstate user functions can be implemented in any language that supports gRPC. That said, the Cloudstate gRPC protocol is typically too low level for user functions to effectively implement their business logic in. Hence, Cloudstate provides support libraries for multiple languages to allow developers to implement entities using idiomatic APIs.
 
 @@toc { depth=1 }
@@ -11,3 +12,30 @@ Cloudstate user functions can be implemented in any language that supports gRPC.
 * [Go](go/index.md)
 
 @@@
+
+## Unofficial client libraries
+We are aware of external libraries implementing the **client CloudState protocol** in various other languages.
+
+:warning: **Though they are mentioned here, these libraries are often not directly maintained by the CloudState dev team and are therefore not supported**.
+ 
+Here is a list of other, **non-official** libraries in various other languages:
+
+| Library Name | Language | Event-based support? | CRDT support? |
+|--------------|----------|----------------------|---------------|
+| [scala-support](https://github.com/cloudstateio/cloudstate/tree/master/scala-support/src/main) | Scala | :warning: | :warning: |
+| [kotlin-support](https://github.com/cloudstateio/kotlin-support) | Kotlin | :warning: | :warning: |
+| [cloudstate-csharp](https://github.com/nagytech/cloudstate-csharp)| C# | :heavy_check_mark: | :heavy_check_mark: | 
+| [python-support](https://github.com/marcellanz/cloudstate_python-support/tree/feature/python-support)| Python | | |
+| | Elixir | | |
+| | F# | | |
+| | Ruby | | |
+| | Rust | | |
+
+### Legend:
+- :heavy_check_mark: Supported
+- :x: Not supported
+- :warning: Partial support / Unstable (see details on the website)
+
+## Cloudstate CLI
+:point_up_2: Please be aware that the **CloudState CLI** project allows you to easily kick-start a new client project. 
+You can currently find it at https://github.com/sleipnir/cloudstate-cli

--- a/docs/src/main/paradox/user/lang/index.md
+++ b/docs/src/main/paradox/user/lang/index.md
@@ -14,9 +14,9 @@ Cloudstate user functions can be implemented in any language that supports gRPC.
 @@@
 
 ## Unofficial client libraries
-We are aware of external libraries implementing the **client CloudState protocol** in various other languages.
+We are aware of external libraries implementing the **client Cloudstate protocol** in various other languages.
 
-:warning: **Though they are mentioned here, these libraries are often not directly maintained by the CloudState dev team and are therefore not supported**.
+:warning: **Though they are mentioned here, these libraries are often not directly maintained by the Cloudstate dev team and are therefore not supported**.
  
 Here is a list of other, **non-official** libraries in various other languages:
 
@@ -35,5 +35,5 @@ Here is a list of other, **non-official** libraries in various other languages:
 - :question: Support status unknown
 
 ## Cloudstate CLI
-:point_up_2: Please be aware that the **CloudState CLI** project allows you to easily kick-start a new client project. 
+:point_up_2: Please be aware that the **Cloudstate CLI** project allows you to easily kick-start a new client project. 
 You can currently find it at https://github.com/sleipnir/cloudstate-cli


### PR DESCRIPTION
Following discussion on Dec 17th with @viktorklang during the status meeting call, added list of known client libraries with links to these libraries and basic support matrix.
Also, mentioned the existence of the CLI for generating new projects.