### PR TITLE
Update to Akka 2.5.29

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ name := "cloudstate"
 
 val GrpcJavaVersion = "1.22.1"
 val GraalAkkaVersion = "0.4.1"
-val AkkaVersion = "2.5.26"
+val AkkaVersion = "2.5.29"
 val AkkaHttpVersion = "10.1.11"
 val AkkaManagementVersion = "1.0.5"
 val AkkaPersistenceCassandraVersion = "0.102"


### PR DESCRIPTION
Increment Akka to current `2.5.x.`
Http, Management and Persistence remain current.
Reviewed release notes for `.27` and `.29` (there was no `.28)