### PR TITLE
Issue-197: js-shopping-cart Graal VM integration on Docker

### DIFF
--- a/samples/js-shopping-cart/package.json
+++ b/samples/js-shopping-cart/package.json
@@ -38,9 +38,10 @@
     "prestart": "compile-descriptor ../../protocols/example/shoppingcart/shoppingcart.proto",
     "pretest": "compile-descriptor ../../protocols/example/shoppingcart/shoppingcart.proto",
     "postinstall": "compile-descriptor ../../protocols/example/shoppingcart/shoppingcart.proto",
+    "prepare-node-support": "cd ../../node-support && npm install && cd ../samples/js-shopping-cart",
     "start": "node index.js",
     "start-no-prestart": "node index.js",
-    "dockerbuild": "docker build -f ../../Dockerfile.js-shopping-cart -t ${DOCKER_PUBLISH_TO:-cloudstateio}/js-shopping-cart:latest ../..",
+    "dockerbuild": "npm run prepare-node-support && docker build -f ../../Dockerfile.js-shopping-cart -t ${DOCKER_PUBLISH_TO:-cloudstateio}/js-shopping-cart:latest ../..",
     "dockerpush": "docker push ${DOCKER_PUBLISH_TO:-cloudstateio}/js-shopping-cart:latest",
     "dockerbuildpush": "npm run dockerbuild && npm run dockerpush"
   }


### PR DESCRIPTION
Add npm task for preparing node-support to be able to build the `js-shopping-cart` docker image