### PR TITLE
Use Debian 10.3 buster as docker base

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -210,6 +210,8 @@ def dockerSettings: Seq[Setting[_]] = Seq(
   dockerUpdateLatest := true,
   dockerRepository := sys.props.get("docker.registry"),
   dockerUsername := sys.props.get("docker.username").orElse(Some("cloudstateio")).filter(_ != ""),
+  dockerBaseImage := "openjdk:8-jre-slim-buster",
+//  dockerBuildOptions += "--no-cache",
   dockerAlias := {
     val old = dockerAlias.value
     proxyDockerBuild.value match {
@@ -323,7 +325,7 @@ def nativeImageDockerSettings: Seq[Setting[_]] = dockerSettings ++ Seq(
         }
       }
     }.value,
-  dockerBaseImage := "bitnami/java:11-prod",
+  dockerBaseImage := "openjdk:8-jre-slim-buster",
   // Need to make sure it has group execute permission
   // Note I think this is leading to quite large docker images :(
   dockerChmodType := {
@@ -603,7 +605,7 @@ lazy val operator = (project in file("operator"))
         "ch.qos.logback" % "logback-classic" % "1.2.3" // Doesn't work well with SubstrateVM, use "org.slf4j"           % "slf4j-simple"     % "1.7.26" instead
       ),
     dockerSettings,
-    dockerBaseImage := "adoptopenjdk/openjdk8",
+    dockerBaseImage := "openjdk:8-jre-slim-buster",
     dockerExposedPorts := Nil,
     compileK8sDescriptors := {
       val tag = version.value
@@ -767,7 +769,7 @@ lazy val `java-shopping-cart` = (project in file("samples/java-shopping-cart"))
   .settings(
     name := "java-shopping-cart",
     dockerSettings,
-    dockerBaseImage := "adoptopenjdk/openjdk8",
+    dockerBaseImage := "openjdk:8-jre-slim-buster",
     mainClass in Compile := Some("io.cloudstate.samples.shoppingcart.Main"),
     PB.generate in Compile := (PB.generate in Compile).dependsOn(PB.generate in (`java-support`, Compile)).value,
     akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
@@ -798,7 +800,7 @@ lazy val `java-pingpong` = (project in file("samples/java-pingpong"))
   .settings(
     name := "java-pingpong",
     dockerSettings,
-    dockerBaseImage := "adoptopenjdk/openjdk8",
+    dockerBaseImage := "openjdk:8-jre-slim-buster",
     mainClass in Compile := Some("io.cloudstate.samples.pingpong.Main"),
     PB.generate in Compile := (PB.generate in Compile).dependsOn(PB.generate in (`java-support`, Compile)).value,
     akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ val PrometheusClientVersion = "0.6.0"
 val ScalaTestVersion = "3.0.5"
 val ProtobufVersion = "3.9.0"
 val GraalVersion = "19.3.0"
-
+val DockerBaseImageVersion = "openjdk:8-jre-slim-buster"
 val svmGroupId = if (GraalVersion startsWith "19.2") "com.oracle.substratevm" else "org.graalvm.nativeimage"
 
 def excludeTheseDependencies = Seq(
@@ -210,8 +210,9 @@ def dockerSettings: Seq[Setting[_]] = Seq(
   dockerUpdateLatest := true,
   dockerRepository := sys.props.get("docker.registry"),
   dockerUsername := sys.props.get("docker.username").orElse(Some("cloudstateio")).filter(_ != ""),
-  dockerBaseImage := "openjdk:8-jre-slim-buster",
-//  dockerBuildOptions += "--no-cache",
+  dockerBaseImage := DockerBaseImageVersion,
+  // when using tags like latest, uncomment below line, so that local cache will not be used.
+  //  dockerBuildOptions += "--no-cache",
   dockerAlias := {
     val old = dockerAlias.value
     proxyDockerBuild.value match {
@@ -325,7 +326,6 @@ def nativeImageDockerSettings: Seq[Setting[_]] = dockerSettings ++ Seq(
         }
       }
     }.value,
-  dockerBaseImage := "openjdk:8-jre-slim-buster",
   // Need to make sure it has group execute permission
   // Note I think this is leading to quite large docker images :(
   dockerChmodType := {
@@ -605,7 +605,6 @@ lazy val operator = (project in file("operator"))
         "ch.qos.logback" % "logback-classic" % "1.2.3" // Doesn't work well with SubstrateVM, use "org.slf4j"           % "slf4j-simple"     % "1.7.26" instead
       ),
     dockerSettings,
-    dockerBaseImage := "openjdk:8-jre-slim-buster",
     dockerExposedPorts := Nil,
     compileK8sDescriptors := {
       val tag = version.value
@@ -769,7 +768,6 @@ lazy val `java-shopping-cart` = (project in file("samples/java-shopping-cart"))
   .settings(
     name := "java-shopping-cart",
     dockerSettings,
-    dockerBaseImage := "openjdk:8-jre-slim-buster",
     mainClass in Compile := Some("io.cloudstate.samples.shoppingcart.Main"),
     PB.generate in Compile := (PB.generate in Compile).dependsOn(PB.generate in (`java-support`, Compile)).value,
     akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
@@ -800,7 +798,6 @@ lazy val `java-pingpong` = (project in file("samples/java-pingpong"))
   .settings(
     name := "java-pingpong",
     dockerSettings,
-    dockerBaseImage := "openjdk:8-jre-slim-buster",
     mainClass in Compile := Some("io.cloudstate.samples.pingpong.Main"),
     PB.generate in Compile := (PB.generate in Compile).dependsOn(PB.generate in (`java-support`, Compile)).value,
     akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),


### PR DESCRIPTION
Moving dockerBaseImage from `openjdk:8` to `openjdk:8-jre-slim-buster`. 
`buster` Debain 10.3 contains the fixes for following `high severity` vulnerabilities:

[CVE-2016-2779](https://security-tracker.debian.org/tracker/CVE-2016-2779)
[CVE-2019-9169](https://security-tracker.debian.org/tracker/CVE-2019-9169)
[CVE-2017-12424](https://security-tracker.debian.org/tracker/CVE-2017-12424)
[CVE-2018-1000001](https://security-tracker.debian.org/tracker/CVE-2018-1000001)
[CVE-2018-6485](https://security-tracker.debian.org/tracker/CVE-2018-6485)
[CVE-2019-12900](https://security-tracker.debian.org/tracker/CVE-2019-12900)