### PR TITLE
Upgrade to Akka 2.6.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ name := "cloudstate"
 
 val GrpcJavaVersion = "1.22.1"
 val GraalAkkaVersion = "0.4.1"
-val AkkaVersion = "2.5.29"
+val AkkaVersion = "2.6.4"
 val AkkaHttpVersion = "10.1.11"
 val AkkaManagementVersion = "1.0.5"
 val AkkaPersistenceCassandraVersion = "0.102"

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/crdt/LWWRegisterCrdtEntitySpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/crdt/LWWRegisterCrdtEntitySpec.scala
@@ -86,6 +86,7 @@ class LWWRegisterCrdtEntitySpec extends AbstractCrdtEntitySpec {
       expectDelta().value.value shouldBe element1
     }
 
+    // Walsh: failing test
     "handle change deltas with custom clock" in {
       val start = System.currentTimeMillis() + 1000000
       update(identity)
@@ -97,12 +98,16 @@ class LWWRegisterCrdtEntitySpec extends AbstractCrdtEntitySpec {
       expectNoMessage(200.millis)
 
       val cid2 = sendAndExpectCommand("cmd", command)
+
+      // Walsh: failing line
       sendAndExpectReply(cid2, updateRegister(element3, clock = CrdtClock.CUSTOM, customClockValue = start))
+
       Thread.sleep(200)
       get().value shouldBe element2
       expectDelta().value.value shouldBe element2
     }
 
+    // Walsh: failing test
     "handle change deltas with custom auto incrementing clock" in {
       val start = System.currentTimeMillis() + 1000000
       update(identity)


### PR DESCRIPTION
2 tests failing, marked with comments.

I tried removing implicit ActorMaterializer where I saw I could, no effect on failures.

I refactored away from deprecated Timers.startPeriodicTimer, also no effect.