### PR TITLE
Handle sun.nio.ch.SelectorImpl#selectedKeys

### DIFF
--- a/proxy/cassandra/src/graal/reflect-config.json
+++ b/proxy/cassandra/src/graal/reflect-config.json
@@ -1500,8 +1500,8 @@
 {
   "name":"sun.nio.ch.SelectorImpl",
   "fields":[
-    {"name":"publicSelectedKeys"}, 
-    {"name":"selectedKeys"}
+    {"name":"publicSelectedKeys", "allowUnsafeAccess": true},
+    {"name":"selectedKeys", "allowUnsafeAccess": true}
   ]
 },
 {

--- a/proxy/core/src/graal/reflect-config.json
+++ b/proxy/core/src/graal/reflect-config.json
@@ -1225,8 +1225,8 @@
 {
   "name":"sun.nio.ch.SelectorImpl",
   "fields":[
-    {"name":"publicSelectedKeys"}, 
-    {"name":"selectedKeys"}
+    {"name":"publicSelectedKeys", "allowUnsafeAccess": true},
+    {"name":"selectedKeys", "allowUnsafeAccess": true}
   ]
 },
 {

--- a/proxy/postgres/src/graal/reflect-config.json
+++ b/proxy/postgres/src/graal/reflect-config.json
@@ -1239,8 +1239,8 @@
 {
   "name":"sun.nio.ch.SelectorImpl",
   "fields":[
-    {"name":"publicSelectedKeys"}, 
-    {"name":"selectedKeys"}
+    {"name":"publicSelectedKeys", "allowUnsafeAccess": true},
+    {"name":"selectedKeys", "allowUnsafeAccess": true}
   ]
 },
 {


### PR DESCRIPTION
And publicSelectedKeys too.

    2020-04-07 12:11:06.882 ERROR akka.actor.OneForOneStrategy - Boxed Error
    java.util.concurrent.ExecutionException: Boxed Error
    	at scala.concurrent.impl.Promise$.resolver(Promise.scala:87)
    	at scala.concurrent.impl.Promise$.scala$concurrent$impl$Promise$$resolveTry(Promise.scala:79)
    	at scala.concurrent.impl.Promise$DefaultPromise.tryComplete(Promise.scala:284)
    	at scala.concurrent.Promise.complete(Promise.scala:53)
    	at scala.concurrent.Promise.complete$(Promise.scala:52)
    	at scala.concurrent.impl.Promise$DefaultPromise.complete(Promise.scala:187)
    	at scala.concurrent.Promise.failure(Promise.scala:104)
    	at scala.concurrent.Promise.failure$(Promise.scala:104)
    	at scala.concurrent.impl.Promise$DefaultPromise.failure(Promise.scala:187)
    	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:45)
    	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
    	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
    	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:92)
    	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
    	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
    	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:92)
    	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:41)
    	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:49)
    	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
    	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
    	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
    	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
    	at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:527)
    	at com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:193)
    Caused by: com.oracle.svm.core.jdk.UnsupportedFeatureError: The offset of private final java.util.Set sun.nio.ch.SelectorImpl.selectedKeys is accessed without the field being first registered as unsafe accessed. Please register the field as unsafe accessed. You can do so with a reflection configuration that contains an entry for the field with the attribute "allowUnsafeAccess": true. Such a configuration file can be generated for you. Read CONFIGURE.md and REFLECTION.md for details.
    	at com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:101)
    	at jdk.internal.misc.Unsafe.objectFieldOffset(Unsafe.java:50)
    	at sun.misc.Unsafe.objectFieldOffset(Unsafe.java:640)
    	at io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent0.objectFieldOffset(PlatformDependent0.java:504)
    	at io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent.objectFieldOffset(PlatformDependent.java:592)
    	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop$4.run(NioEventLoop.java:213)
    	at java.security.AccessController.doPrivileged(AccessController.java:81)
    	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.openSelector(NioEventLoop.java:203)
    	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoop.<init>(NioEventLoop.java:143)
    	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:127)
    	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:36)
    	at io.grpc.netty.shaded.io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
    	at io.grpc.netty.shaded.io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:58)
    	at io.grpc.netty.shaded.io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:47)
    	at io.grpc.netty.shaded.io.netty.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:59)
    	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:77)
    	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:72)
    	at io.grpc.netty.shaded.io.netty.channel.nio.NioEventLoopGroup.<init>(NioEventLoopGroup.java:59)
    	at io.grpc.netty.shaded.io.grpc.netty.Utils$DefaultEventLoopGroupResource.create(Utils.java:336)
    	at io.grpc.netty.shaded.io.grpc.netty.Utils$DefaultEventLoopGroupResource.create(Utils.java:318)
    	at io.grpc.internal.SharedResourceHolder.getInternal(SharedResourceHolder.java:104)
    	at io.grpc.internal.SharedResourceHolder.get(SharedResourceHolder.java:74)
    	at io.grpc.internal.SharedResourcePool.getObject(SharedResourcePool.java:35)
    	at io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder$NettyTransportFactory.<init>(NettyChannelBuilder.java:575)
    	at io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder.buildTransportFactory(NettyChannelBuilder.java:444)
    	at io.grpc.internal.AbstractManagedChannelImplBuilder.build(AbstractManagedChannelImplBuilder.java:507)
    	at akka.grpc.internal.NettyClientUtils$.$anonfun$createChannel$1(NettyClientUtils.scala:56)
    	at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)
    	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
    	... 14 more