### PR TITLE
Reformat HOCON

### DIFF
--- a/proxy/core/src/main/scala/io/cloudstate/proxy/HoconFormat.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/HoconFormat.scala
@@ -1,0 +1,121 @@
+package io.cloudstate.proxy
+
+import java.io.File
+import java.lang.System.{lineSeparator => EOL}
+import java.nio.file.Files
+
+import scala.collection.JavaConverters._
+import scala.reflect.ensureAccessible
+import com.typesafe.config._, impl.Parseable
+
+object HoconFormat {
+  def reformat(f: File) = Files.writeString(f.toPath, withEol(render(parseValue(parseable(f)))))
+
+  def render(configValue: ConfigValue): String = {
+    val sb = new StringBuilder()
+    var indent = -1
+
+    def loop(cv: ConfigValue): Unit = cv match {
+      case xs: ConfigList =>
+        appendRepeat('[', xs.asScala)(v => v)(loop)
+      case kvs: ConfigObject =>
+        val outer = if (sb.isEmpty && !kvs.isEmpty) (0: Char) else '{'
+        appendRepeat(outer, pairsSorted(kvs))(_._2) { kv =>
+          sb.append(renderString(kv._1)).append(": ")
+          loop(kv._2)
+        }
+      case x =>
+        x.unwrapped() match {
+          case s: String => sb.append(ConfigUtil.quoteString(s))
+          case v => sb.append(v)
+        }
+    }
+
+    def appendRepeat[A](outer: Char, xs: Seq[A])(toVal: A => ConfigValue)(each: A => Unit) = {
+      val formatted = xs.nonEmpty && (indent <= 0 || (indent == 1 && xs.size > 1))
+      def nl() = if (formatted) sb.append(EOL + "  " * indent)
+
+      if (outer != 0) {
+        sb.append(outer)
+        indent += 1
+        nl()
+      }
+
+      var first = true
+      for (x <- xs) {
+        if (first) first = false
+        else if (formatted) nl()
+        else sb.append(", ")
+
+        for (comment <- toVal(x).origin.comments.asScala) {
+          sb.append('#')
+          if (!(comment.startsWith(" "))) sb.append(' ')
+          sb.append(comment)
+          nl()
+        }
+
+        each(x)
+      }
+
+      if (outer != 0) {
+        indent -= 1
+        if (!first) nl()
+        sb.append((outer + 2).toChar)
+      }
+    }
+
+    loop(configValue)
+    sb.toString
+  }
+
+  private val keysOrder =
+    "name" ::
+    "allDeclaredFields" :: "allDeclaredMethods" :: "allDeclaredConstructors" :: "allDeclaredClasses" ::
+    "allPublicFields" :: "allPublicMethods" :: "allPublicConstructors" :: "allPublicClasses" ::
+    "fields" :: "methods" ::
+    Nil
+
+  private def pairsSorted(obj: ConfigObject) =
+    obj.keySet.asScala.toSeq
+      .sorted { (a: String, b: String) =>
+        val aDigits = a.nonEmpty && a.forall(Character.isDigit(_))
+        val bDigits = b.nonEmpty && b.forall(Character.isDigit(_))
+        val aKey = keysOrder.contains(a)
+        val bKey = keysOrder.contains(b)
+        if (aDigits && bDigits)
+          new java.math.BigInteger(a).compareTo(new java.math.BigInteger(b))
+        else if (aDigits) -1
+        else if (bDigits) 1
+        else if (aKey && bKey) keysOrder.indexOf(a) - keysOrder.indexOf(b)
+        else if (aKey) -1
+        else if (bKey) 1
+        else a.compareTo(b)
+      }
+      .map(key => key -> obj.get(key))
+
+  private def renderString(s: String): String = {
+    // this can quote unnecessarily as long as it never fails to quote when necessary
+    if (s.isEmpty)
+      return ConfigUtil.quoteString(s)
+
+    // if it starts with a hyphen or number, we have to quote
+    // to ensure we end up with a string and not a number
+    val first = s.codePointAt(0)
+    if (Character.isDigit(first) || first == '-')
+      return ConfigUtil.quoteString(s)
+
+    if (s.startsWith("include") || s.startsWith("true") || s.startsWith("false") ||
+        s.startsWith("null") || s.contains("//"))
+      return ConfigUtil.quoteString(s)
+
+    // only unquote if it's pure alphanumeric
+    if (s.forall(c => c == '-' || Character.isLetter(c) || Character.isDigit(c))) s
+    else ConfigUtil.quoteString(s)
+  }
+
+  private def parseable(f: File) = Parseable.newFile(f, ConfigParseOptions.defaults())
+  private val parseValueMeth = ensureAccessible(classOf[Parseable].getDeclaredMethod("parseValue"))
+  private def parseValue(p: Parseable) = parseValueMeth.invoke(p).asInstanceOf[ConfigValue]
+
+  private def withEol(s: String) = if (s.takeRight(EOL.length) == EOL) s else s"$s$EOL"
+}

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/HoconFormatMain.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/HoconFormatMain.scala
@@ -1,0 +1,51 @@
+package io.cloudstate.proxy
+
+import java.io.File
+
+object HoconFormatMain {
+  val all = List(
+    "src/main/resources/META-INF/native-image/io.grpc/grpc-core/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/io.grpc/grpc-netty-shaded/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe/config/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/net.java.openjdk/base/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/io.cloudstate/cloudstate-proxy-core/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-management-cluster-bootstrap/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.lightbend.akka.management/akka-management/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-cluster/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-slf4j/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-stream/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-http-core/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-remote/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-distributed-data/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-cluster-sharding/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-http2-support/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-persistence/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-actor/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.typesafe.akka/akka-cluster-tools/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.thesamet.scalapb/scalapb-runtime/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.google.protobuf/protobuf-java/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/org.agrona/agrona/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/com.lightbend.akka.discovery/akka-discovery-kubernetes-api/reflect-config.json.conf",
+    "src/main/resources/META-INF/native-image/org.scala-lang/scala-library/reflect-config.json.conf",
+    "../postgres/src/main/resources/META-INF/native-image/com.zaxxer/HikariCP/reflect-config.json.conf",
+    "../postgres/src/main/resources/META-INF/native-image/com.github.dnvriend/akka-persistence-jdbc/reflect-config.json.conf",
+    "../postgres/src/main/resources/META-INF/native-image/org.postgresql/postgresql/reflect-config.json.conf",
+    "../postgres/src/main/resources/META-INF/native-image/net.java.openjdk/base/reflect-config.json.conf",
+    "../postgres/src/main/resources/META-INF/native-image/com.typesafe.slick/slick/reflect-config.json.conf",
+    "../postgres/src/main/resources/META-INF/native-image/com.typesafe.slick/slick-hikaricp/reflect-config.json.conf",
+    "../cassandra/src/main/resources/META-INF/native-image/com.datastax.cassandra/cassandra-driver-core/reflect-config.json.conf",
+    "../cassandra/src/main/resources/META-INF/native-image/io.netty/netty-handler/reflect-config.json.conf",
+    "../cassandra/src/main/resources/META-INF/native-image/io.netty/netty-codec/reflect-config.json.conf",
+    "../cassandra/src/main/resources/META-INF/native-image/io.netty/netty-common/reflect-config.json.conf",
+    "../cassandra/src/main/resources/META-INF/native-image/io.netty/netty-transport/reflect-config.json.conf",
+    "../cassandra/src/main/resources/META-INF/native-image/io.netty/netty-buffer/reflect-config.json.conf",
+    "../cassandra/src/main/resources/META-INF/native-image/net.java.openjdk/base/reflect-config.json.conf",
+    "../cassandra/src/main/resources/META-INF/native-image/com.typesafe.akka/akka-persistence-cassandra/reflect-config.json.conf",
+    "../cassandra/src/main/resources/META-INF/native-image/com.google.guava/guava/reflect-config.json.conf"
+  )
+
+  def main(args: Array[String]): Unit = reformatAll(args)
+
+  def reformatAll(strings: Seq[String]): Unit =
+    (if (strings.isEmpty) all else strings).foreach(s => HoconFormat.reformat(new File(s)))
+}


### PR DESCRIPTION
I wrote this a little while ago, as the default rendering in Typesafe Config makes a meal out of our list ConfigValue's.

The thinking was that if in the future we needed to run the guided, "generate me the JSON files" mode of native-image, then we could split that mega-file into pieces (I'll PR that utility code in a second) and format it sanely with this.

And/or this could be just wired up to the build to assist reformatting the config file and/or to CI to fail build validations.

Anyways.  Not wanting to lose this effort, I'm PR'ing it in case there's an interest.