### PR TITLE
Allow java-support service info to be overridden in config

### DIFF
--- a/java-support/src/main/resources/reference.conf
+++ b/java-support/src/main/resources/reference.conf
@@ -1,10 +1,4 @@
 cloudstate {
-
-  library {
-    name = "cloudstate-java-support"
-    version = "0.4.3"
-  }
-
   user-function-interface = "127.0.0.1"
   user-function-interface = ${?HOST}
 

--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/EntityDiscoveryImpl.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/EntityDiscoveryImpl.scala
@@ -25,13 +25,14 @@ import io.cloudstate.javasupport.{BuildInfo, StatefulService}
 
 class EntityDiscoveryImpl(system: ActorSystem, services: Map[String, StatefulService]) extends EntityDiscovery {
 
-  private val config = system.settings.config.getConfig("cloudstate")
+  private def configuredOrElse(key: String, default: String): String =
+    if (system.settings.config.hasPath(key)) system.settings.config.getString(key) else default
 
   private val serviceInfo = ServiceInfo(
-    serviceRuntime = sys.props.getOrElse("java.runtime.name", "") + " " + sys.props.getOrElse("java.runtime.version",
-                                                                                              ""),
-    supportLibraryName = config.getString("library.name"),
-    supportLibraryVersion = config.getString("library.version")
+    serviceRuntime = sys.props.getOrElse("java.runtime.name", "")
+      + " " + sys.props.getOrElse("java.runtime.version", ""),
+    supportLibraryName = configuredOrElse("cloudstate.library.name", BuildInfo.name),
+    supportLibraryVersion = configuredOrElse("cloudstate.library.version", BuildInfo.version)
   )
 
   /**


### PR DESCRIPTION
Follow-up to #192. We want the service name and version to be overridable in config, but still default to the automatically generated build info.