### PR TITLE
Refactor proxy: don't convert to HttpResponse prematurely

### DIFF
--- a/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
@@ -499,12 +499,10 @@ object HttpApi {
           .getField(entityMessage.getDescriptorForType.findFieldByName("content_type")) match {
           case null | "" => ContentTypes.NoContentType
           case string: String =>
-            ContentType.parse(string) match {
-              case Left(list) =>
+            ContentType.parse(string).fold(list =>
                 throw new IllegalResponseException(
                   list.headOption.getOrElse(ErrorInfo.fromCompoundString("Unknown error"))
-                )
-              case Right(tpe) => tpe
+                ), identity)
             }
         }
 

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
@@ -499,11 +499,13 @@ object HttpApi {
           .getField(entityMessage.getDescriptorForType.findFieldByName("content_type")) match {
           case null | "" => ContentTypes.NoContentType
           case string: String =>
-            ContentType.parse(string).fold(list =>
-                throw new IllegalResponseException(
-                  list.headOption.getOrElse(ErrorInfo.fromCompoundString("Unknown error"))
-                ), identity)
-            }
+            ContentType
+              .parse(string)
+              .fold(list =>
+                      throw new IllegalResponseException(
+                        list.headOption.getOrElse(ErrorInfo.fromCompoundString("Unknown error"))
+                      ),
+                    identity)
         }
 
       def extractDataFromHttpBody(entityMessage: MessageOrBuilder): ByteString =


### PR DESCRIPTION
By keeping the data as `Source[ProtobufAny]` instead of converting it to a 
HttpResponse immediately after receiving it, we can save some
back-and-forth interpreting the data.