### PR TITLE
Fix link

### DIFF
--- a/node-support/README.md
+++ b/node-support/README.md
@@ -98,4 +98,4 @@ entity.start();
 ```
 
 
-For more information see https://cloudstate.io/docs/lang/javascript/.
+For more information see https://cloudstate.io/docs/user/lang/javascript/index.html.


### PR DESCRIPTION
The link to Javascript support is broken in the README.md. I think because of https to http
