### PR TITLE
Rework ProtobufGeneratedMessageRegisterFeature

### DIFF
--- a/graal-tools/src/main/scala/io/cloudstate/graaltools/AkkaActorRegisterFeature.scala
+++ b/graal-tools/src/main/scala/io/cloudstate/graaltools/AkkaActorRegisterFeature.scala
@@ -1,30 +1,25 @@
 package io.cloudstate.graaltools
 
 import com.oracle.svm.core.annotate.AutomaticFeature
-import org.graalvm.nativeimage.hosted.Feature.QueryReachabilityAccess
 import org.graalvm.nativeimage.hosted.{Feature, RuntimeReflection}
-
-import scala.collection.JavaConverters._
-import java.util.concurrent.ConcurrentHashMap
 
 @AutomaticFeature
 final class AkkaActorRegisterFeature extends Feature {
-  private[this] final val cache = {
-    val c = ConcurrentHashMap.newKeySet[String]
+  private[this] final val ignoreClass = Set(
     // FIXME the following are configured in akka-graal-config, remove this when migrating from it
-    c.add("akka.io.TcpConnection")
-    c.add("akka.io.TcpListener")
-    c.add("akka.stream.impl.fusing.ActorGraphInterpreter")
-    c
-  }
+    "akka.io.TcpConnection",
+    "akka.io.TcpListener",
+    "akka.stream.impl.fusing.ActorGraphInterpreter"
+  ).contains(_)
 
-  override final def duringAnalysis(access: Feature.DuringAnalysisAccess): Unit = {
+  override final def beforeAnalysis(access: Feature.BeforeAnalysisAccess): Unit = {
     val akkaActorClass =
       access.findClassByName(classOf[akka.actor.Actor].getName) // We do this to get compile-time safety of the classes, and allow graalvm to resolve their names
-    if (akkaActorClass != null && access.isReachable(akkaActorClass)) {
+
+    def register(subtype: Class[_]) =
       for {
-        subtype <- access.reachableSubtypes(akkaActorClass).iterator.asScala
-        if subtype != null && !subtype.isInterface && cache.add(subtype.getName)
+        subtype <- Option(subtype)
+        if !subtype.isInterface && ignoreClass(subtype.getName)
         _ = println("Automatically registering actor class for reflection purposes: " + subtype.getName)
         _ = RuntimeReflection.register(subtype)
         _ = RuntimeReflection.register(subtype.getDeclaredConstructors: _*)
@@ -34,7 +29,8 @@ final class AkkaActorRegisterFeature extends Feature {
       } {
         RuntimeReflection.register( /* finalIsWritable = */ true, context, self)
       }
-    }
+
+    access.registerSubtypeReachabilityHandler((_, subtype) => register(subtype), akkaActorClass)
   }
 
   private[this] final def getDeclaredField(cls: Class[_], name: String) =

--- a/graal-tools/src/main/scala/io/cloudstate/graaltools/AkkaActorRegisterFeature.scala
+++ b/graal-tools/src/main/scala/io/cloudstate/graaltools/AkkaActorRegisterFeature.scala
@@ -19,7 +19,7 @@ final class AkkaActorRegisterFeature extends Feature {
     def register(subtype: Class[_]) =
       for {
         subtype <- Option(subtype)
-        if !subtype.isInterface && ignoreClass(subtype.getName)
+        if !subtype.isInterface && !ignoreClass(subtype.getName)
         _ = println("Automatically registering actor class for reflection purposes: " + subtype.getName)
         _ = RuntimeReflection.register(subtype)
         _ = RuntimeReflection.register(subtype.getDeclaredConstructors: _*)

--- a/graal-tools/src/main/scala/io/cloudstate/graaltools/AkkaActorRegisterFeature.scala
+++ b/graal-tools/src/main/scala/io/cloudstate/graaltools/AkkaActorRegisterFeature.scala
@@ -10,7 +10,7 @@ final class AkkaActorRegisterFeature extends Feature {
     "akka.io.TcpConnection",
     "akka.io.TcpListener",
     "akka.stream.impl.fusing.ActorGraphInterpreter"
-  ).contains(_)
+  )
 
   override final def beforeAnalysis(access: Feature.BeforeAnalysisAccess): Unit = {
     val akkaActorClass =

--- a/proxy/core/src/graal/META-INF/native-image/com.google.protobuf/protobuf-java/reflect-config.json.conf
+++ b/proxy/core/src/graal/META-INF/native-image/com.google.protobuf/protobuf-java/reflect-config.json.conf
@@ -1,14 +1,2 @@
 [
-{
-  name: "com.google.protobuf.Extension"
-}
-{
-  name: "com.google.protobuf.ExtensionRegistry"
-  methods: [{name: "getEmptyRegistry", parameterTypes: []}]
-}
-{
-  name: "com.google.protobuf.DescriptorProtos"
-  allDeclaredFields: true
-  allDeclaredConstructors: true
-}
 ]

--- a/proxy/core/src/graal/META-INF/native-image/io.cloudstate/cloudstate-proxy-core/reflect-config.json.conf
+++ b/proxy/core/src/graal/META-INF/native-image/io.cloudstate/cloudstate-proxy-core/reflect-config.json.conf
@@ -67,13 +67,6 @@
   allDeclaredFields: true
 }
 {
-  name: "io.cloudstate.proxy.EntityDiscoveryManager"
-}
-{
-  name: "io.cloudstate.proxy.StatsCollector"
-  allDeclaredFields: true
-}
-{
   name: "io.cloudstate.proxy.Warmup"
 }
 {
@@ -104,10 +97,6 @@
 }
 {
   name: "io.cloudstate.proxy.entity.UserFunctionReply"
-  allPublicMethods: true
-}
-{
-  name: "io.cloudstate.proxy.autoscaler.AutoscalerMetrics"
   allPublicMethods: true
 }
 {


### PR DESCRIPTION
Rather than registering subclasses of various Protobuf message classes,
registering the nested classes within key Protobuf classes seems
sufficient.  Also, this can all happen once, before analyis, rather than
during analysis, which requires the cache.

Also, rework AkkaActorRegisterFeature to setup a
registerSubtypeReachabilityHandler in "beforeAnalysis", which also drops
the need for a cache.

Finally, drop a few more manual config points, which I was experimenting
with initialising on build (an abandoned approach) and seemingly turned
out not to be necessary anyways.

Fixes #295