### PR TITLE
Use a slimmer docker base image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ val PrometheusClientVersion = "0.6.0"
 val ScalaTestVersion = "3.0.5"
 val ProtobufVersion = "3.9.0" // We use this version because it is the latest which works with native-image 20.0.0
 val GraalVersion = "20.1.0"
-val DockerBaseImageVersion = "adoptopenjdk/openjdk11:debian"
+val DockerBaseImageVersion = "adoptopenjdk/openjdk11:debianslim-jre"
 val DockerBaseImageJavaLibraryPath = "${JAVA_HOME}/lib"
 
 val excludeTheseDependencies: Seq[ExclusionRule] = Seq(


### PR DESCRIPTION
Switch to the debian slim with just JRE docker image. Not sure if there was a reason for using a full JDK image, but shouldn't be needed at runtime. This takes around 250MB off the images. There are probably possibilities to go smaller again, especially for native images, but this is an easy first step.