### PR TITLE
Add basic instrumentation for event-sourced entities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -451,6 +451,8 @@ lazy val `proxy-core` = (project in file("proxy/core"))
 
       old.map(_.copy(outputPath = ct / "akka-grpc" / "main"))
     },
+    // add protobuf targets to managed source directories for IDEs
+    Compile / managedSourceDirectories ++= (Compile / PB.targets).value.map(_.outputPath).distinct,
     PB.protoSources in Compile ++= {
       val baseDir = (baseDirectory in ThisBuild).value / "protocols"
       Seq(baseDir / "frontend", baseDir / "protocol")

--- a/proxy/core/src/main/resources/reference.conf
+++ b/proxy/core/src/main/resources/reference.conf
@@ -8,8 +8,6 @@ cloudstate.proxy {
     user-function-host = ${?USER_FUNCTION_HOST}
     user-function-port = 8080
     user-function-port = ${?USER_FUNCTION_PORT}
-    metrics-port = 9090
-    metrics-port = ${?METRICS_PORT}
     relay-timeout = 1m
     max-inbound-message-size = 12M
     relay-buffer-size = 100
@@ -32,6 +30,24 @@ cloudstate.proxy {
 
     # If using a config that enables it, then set to true
     journal-enabled = false
+
+    telemetry {
+        # Whether telemetry (instrumentation and prometheus exporter) should be disabled
+        disabled = ${cloudstate.proxy.dev-mode-enabled}
+
+        prometheus {
+            # Prometheus exporter host
+            host = "0.0.0.0"
+            host = ${?METRICS_HOST}
+
+            # Prometheus exporter port
+            port = 9090
+            port = ${?METRICS_PORT}
+
+            # Whether to use the Prometheus default registry (or create a separate registry)
+            use-default-registry = true
+        }
+    }
 
     stats {
         report-period = 1s
@@ -88,7 +104,7 @@ cloudstate.proxy {
 
             # Set to "none" to disable TLS.
             # Valid options are, "none", and "GoogleInternetAuthorityG3.crt"
-            rootCa = "none" 
+            rootCa = "none"
 
             # Valid options are, "none", and "google-application-default".
             callCredentials = "none"

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/CloudStateProxyMain.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/CloudStateProxyMain.scala
@@ -28,12 +28,12 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.management.scaladsl.AkkaManagement
 import akka.pattern.{BackoffOpts, BackoffSupervisor}
 import akka.stream.SystemMaterializer
+import io.cloudstate.proxy.telemetry.CloudstateTelemetry
 import org.slf4j.LoggerFactory
 import sun.misc.Signal
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{Failure, Success}
 
 final class HealthCheckReady(system: ActorSystem) extends (() => Future[Boolean]) {
   private[this] final val log = LoggerFactory.getLogger(getClass)
@@ -76,8 +76,7 @@ object CloudStateProxyMain {
       devMode: Boolean,
       backoffMin: FiniteDuration,
       backoffMax: FiniteDuration,
-      backoffRandomFactor: Double,
-      metricsPort: Int
+      backoffRandomFactor: Double
   ) {
     validate()
     def this(config: Config) = {
@@ -85,8 +84,7 @@ object CloudStateProxyMain {
         devMode = config.getBoolean("dev-mode-enabled"),
         backoffMin = config.getDuration("backoff.min").toMillis.millis,
         backoffMax = config.getDuration("backoff.max").toMillis.millis,
-        backoffRandomFactor = config.getDouble("backoff.random-factor"),
-        metricsPort = config.getInt("metrics-port")
+        backoffRandomFactor = config.getDouble("backoff.random-factor")
       )
     }
 
@@ -171,16 +169,9 @@ object CloudStateProxyMain {
       // Start cluster bootstrap
       AkkaManagement(system).start()
       ClusterBootstrap(system).start()
-
-      // Start Prometheus exporter in prod mode
-      new AkkaHttpPrometheusExporter(appConfig.metricsPort).start().onComplete {
-        case Success(binding) =>
-          system.log.info("Prometheus exporter started on {}", binding.localAddress)
-        case Failure(error) =>
-          system.log.error(error, "Error starting Prometheus exporter!")
-          system.terminate()
-      }
     }
+
+    CloudstateTelemetry(system).start()
 
     system.actorOf(
       BackoffSupervisor.props(

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/eventsourced/EventSourcedEntity.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/eventsourced/EventSourcedEntity.scala
@@ -32,6 +32,7 @@ import io.cloudstate.protocol.event_sourced._
 import io.cloudstate.proxy.ConcurrencyEnforcer.{Action, ActionCompleted}
 import io.cloudstate.proxy.StatsCollector
 import io.cloudstate.proxy.entity.{EntityCommand, UserFunctionReply}
+import io.cloudstate.proxy.telemetry.CloudstateTelemetry
 
 import scala.collection.immutable.Queue
 
@@ -146,11 +147,14 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
                                statsCollector: ActorRef)
     extends PersistentActor
     with ActorLogging {
+
+  import io.cloudstate.proxy.telemetry.EventSourcedInstrumentation.StashContext
+
   override final def persistenceId: String = configuration.userFunctionName + entityId
 
   private val actorId = EventSourcedEntity.actorCounter.incrementAndGet()
 
-  private[this] final var stashedCommands = Queue.empty[(EntityCommand, ActorRef)] // PERFORMANCE: look at options for data structures
+  private[this] final var stashedCommands = Queue.empty[(EntityCommand, ActorRef, StashContext)] // PERFORMANCE: look at options for data structures
   private[this] final var currentCommand: EventSourcedEntity.OutstandingCommand = null
   private[this] final var stopped = false
   private[this] final var idCounter = 0L
@@ -158,6 +162,12 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
   private[this] final var reportedDatabaseOperationStarted = false
   private[this] final var databaseOperationStartTime = 0L
   private[this] final var commandStartTime = 0L
+
+  private[this] val instrumentation =
+    CloudstateTelemetry(context.system).eventSourcedEntityInstrumentation(configuration.userFunctionName)
+
+  instrumentation.entityActivated()
+  instrumentation.recoveryStarted()
 
   // Set up passivation timer
   context.setReceiveTimeout(configuration.passivationTimeout.duration)
@@ -175,13 +185,16 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
     }
     // This will shutdown the stream (if not already shut down)
     relay ! Status.Success(())
+    instrumentation.entityPassivated()
   }
 
   private[this] final def commandHandled(): Unit = {
     currentCommand = null
+    instrumentation.commandCompleted()
     if (stashedCommands.nonEmpty) {
-      val ((request, sender), newStashedCommands) = stashedCommands.dequeue
+      val ((request, sender, context), newStashedCommands) = stashedCommands.dequeue
       stashedCommands = newStashedCommands
+      instrumentation.commandUnstashed(context)
       handleCommand(request, sender)
     } else if (stopped) {
       context.stop(self)
@@ -189,13 +202,14 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
   }
 
   private[this] final def notifyOutstandingRequests(msg: String): Unit = {
+    instrumentation.entityFailed()
     currentCommand match {
       case null =>
       case req => req.replyTo ! createFailure(msg)
     }
     val errorNotification = createFailure("Entity terminated")
     stashedCommands.foreach {
-      case (_, replyTo) => replyTo ! errorNotification
+      case (_, replyTo, _) => replyTo ! errorNotification
     }
   }
 
@@ -208,6 +222,7 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
     concurrencyEnforcer ! ActionCompleted(currentCommand.actionId, System.nanoTime() - commandStartTime)
 
   private[this] final def handleCommand(entityCommand: EntityCommand, sender: ActorRef): Unit = {
+    instrumentation.commandStarted()
     idCounter += 1
     val command = Command(
       entityId = entityId,
@@ -237,9 +252,10 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
   override final def receiveCommand: PartialFunction[Any, Unit] = {
 
     case command: EntityCommand if currentCommand != null =>
-      stashedCommands = stashedCommands.enqueue((command, sender()))
+      stashedCommands = stashedCommands.enqueue((command, sender(), instrumentation.commandStashed()))
 
     case command: EntityCommand =>
+      instrumentation.commandReceived()
       handleCommand(command, sender())
 
     case EventSourcedStreamOut(m, _) =>
@@ -253,6 +269,7 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
           crash(s"Incorrect command id in reply, expecting ${currentCommand.commandId} but got ${r.commandId}")
 
         case ESOMsg.Reply(r) =>
+          instrumentation.commandProcessed()
           reportActionComplete()
           val commandId = currentCommand.commandId
           val events = r.events.toVector
@@ -260,13 +277,20 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
             currentCommand.replyTo ! esReplyToUfReply(r)
             commandHandled()
           } else {
+            instrumentation.persistStarted()
             reportDatabaseOperationStarted()
             var eventsLeft = events.size
-            persistAll(events) { _ =>
+            persistAll(events) { event =>
               eventsLeft -= 1
+              instrumentation.eventPersisted(event.serializedSize)
               if (eventsLeft <= 0) { // Remove this hack when switching to Akka Persistence Typed
+                instrumentation.persistCompleted() // note: this doesn't include saving snapshots
                 reportDatabaseOperationFinished()
-                r.snapshot.foreach(saveSnapshot)
+                r.snapshot.foreach { snapshot =>
+                  saveSnapshot(snapshot)
+                  // snapshot has not yet been successfully saved, but we need the size
+                  instrumentation.snapshotPersisted(snapshot.serializedSize)
+                }
                 // Make sure that the current request is still ours
                 if (currentCommand == null || currentCommand.commandId != commandId) {
                   crash("Internal error - currentRequest changed before all events were persisted")
@@ -287,6 +311,8 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
           crash(s"Incorrect command id in failure, expecting ${currentCommand.commandId} but got ${f.commandId}")
 
         case ESOMsg.Failure(f) =>
+          instrumentation.commandProcessed()
+          instrumentation.commandFailed()
           reportActionComplete()
           currentCommand.replyTo ! createFailure(f.description)
           commandHandled()
@@ -341,13 +367,19 @@ final class EventSourcedEntity(configuration: EventSourcedEntity.Configuration,
 
   override final def receiveRecover: PartialFunction[Any, Unit] = {
     case offer: SnapshotOffer =>
+      offer.snapshot match {
+        case snapshot: pbAny => instrumentation.snapshotLoaded(snapshot.serializedSize)
+        case _ =>
+      }
       maybeInit(Some(offer))
 
     case RecoveryCompleted =>
+      instrumentation.recoveryCompleted()
       reportDatabaseOperationFinished()
       maybeInit(None)
 
     case event: pbAny =>
+      instrumentation.eventLoaded(event.serializedSize)
       maybeInit(None)
       relay ! EventSourcedStreamIn(EventSourcedStreamIn.Message.Event(EventSourcedEvent(lastSequenceNr, Some(event))))
   }

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/telemetry/CloudstateTelemetry.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/telemetry/CloudstateTelemetry.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.proxy.telemetry
+
+import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId}
+import com.typesafe.config.Config
+import io.prometheus.client.CollectorRegistry
+
+object CloudstateTelemetry extends ExtensionId[CloudstateTelemetry] {
+
+  final case class Settings(
+      disabled: Boolean,
+      prometheusHost: String,
+      prometheusPort: Int,
+      prometheusUseDefaultRegistry: Boolean
+  ) {
+    def enabled: Boolean = !disabled
+  }
+
+  object Settings {
+    def apply(rootConfig: Config): Settings = {
+      val config = rootConfig.getConfig("cloudstate.proxy.telemetry")
+      Settings(
+        disabled = config.getBoolean("disabled"),
+        prometheusHost = config.getString("prometheus.host"),
+        prometheusPort = config.getInt("prometheus.port"),
+        prometheusUseDefaultRegistry = config.getBoolean("prometheus.use-default-registry")
+      )
+    }
+  }
+
+  def createExtension(system: ExtendedActorSystem): CloudstateTelemetry = new CloudstateTelemetry(system)
+}
+
+final class CloudstateTelemetry(system: ActorSystem) extends Extension {
+  val settings: CloudstateTelemetry.Settings = CloudstateTelemetry.Settings(system.settings.config)
+
+  val prometheusRegistry: CollectorRegistry =
+    if (settings.prometheusUseDefaultRegistry) CollectorRegistry.defaultRegistry else new CollectorRegistry
+
+  val eventSourcedInstrumentation: EventSourcedInstrumentation =
+    if (settings.enabled) new PrometheusEventSourcedInstrumentation(prometheusRegistry)
+    else NoEventSourcedInstrumentation
+
+  def eventSourcedEntityInstrumentation(entityName: String): EventSourcedEntityInstrumentation =
+    if (settings.enabled) new ActiveEventSourcedEntityInstrumentation(entityName, eventSourcedInstrumentation)
+    else NoEventSourcedEntityInstrumentation
+
+  def start(): Unit =
+    if (settings.enabled) {
+      new PrometheusExporter(prometheusRegistry, settings.prometheusHost, settings.prometheusPort)(system).start()
+    }
+}

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentation.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentation.scala
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.proxy.telemetry
+
+object EventSourcedInstrumentation {
+  final case class Context(startTime: Long)
+  final case class StashContext(stash: Context, restore: Context)
+}
+
+/**
+ * Instrumentation SPI for event-sourced entities.
+ */
+abstract class EventSourcedInstrumentation {
+  import EventSourcedInstrumentation._
+
+  /**
+   * Record entity activated.
+   *
+   * @param entityName the entity name
+   * @return the context that will be passed to [[entityPassivated]]
+   */
+  def entityActivated(entityName: String): Context
+
+  /**
+   * Record entity passivated (actor stopped).
+   *
+   * @param entityName the entity name
+   * @param context the context passed from [[entityActivated]]
+   */
+  def entityPassivated(entityName: String, context: Context): Unit
+
+  /**
+   * Record entity failed (unexpected termination or crash).
+   *
+   * @param entityName the entity name
+   */
+  def entityFailed(entityName: String): Unit
+
+  /**
+   * Record entity recovery started (loading snapshots and events).
+   *
+   * @param entityName the entity name
+   * @return the context that will be passed to [[recoveryCompleted]]
+   */
+  def recoveryStarted(entityName: String): Context
+
+  /**
+   * Record entity recovery completed (loading snapshots and events).
+   *
+   * @param entityName the entity name
+   * @param context the context passed from [[recoveryStarted]]
+   */
+  def recoveryCompleted(entityName: String, context: Context): Unit
+
+  /**
+   * Record command received.
+   *
+   * @param entityName the entity name
+   * @return the context that will be passed to [[commandCompleted]]
+   */
+  def commandReceived(entityName: String): Context
+
+  /**
+   * Record command stashed (currently processing).
+   *
+   * @param entityName the entity name
+   * @param context the context from [[commandReceived]]
+   * @return the context that will be passed to [[commandUnstashed]]
+   */
+  def commandStashed(entityName: String, context: Context): StashContext
+
+  /**
+   * Record command unstashed (ready to process).
+   *
+   * @param entityName the entity name
+   * @param context the context passed from [[commandStashed]]
+   */
+  def commandUnstashed(entityName: String, context: StashContext): Unit
+
+  /**
+   * Record command started processing (sending command to user function).
+   *
+   * @param entityName the entity name
+   * @return the context that will be passed to [[commandProcessed]]
+   */
+  def commandStarted(entityName: String): Context
+
+  /**
+   * Record command completed processing (reply received from user function).
+   *
+   * @param entityName the entity name
+   * @param context the context passed from [[commandStarted]]
+   */
+  def commandProcessed(entityName: String, context: Context): Unit
+
+  /**
+   * Record command failed.
+   *
+   * @param entityName the entity name
+   */
+  def commandFailed(entityName: String): Unit
+
+  /**
+   * Record command fully completed (including processing and persisting).
+   *
+   * @param entityName the entity name
+   * @param context the context passed from [[commandReceived]]
+   */
+  def commandCompleted(entityName: String, context: Context): Unit
+
+  /**
+   * Record entity persist events started.
+   *
+   * @param entityName the entity name
+   * @return the context that will be passed to [[persistCompleted]]
+   */
+  def persistStarted(entityName: String): Context
+
+  /**
+   * Record entity persist events completed.
+   *
+   * @param entityName the entity name
+   * @param context the context passed from [[persistStarted]]
+   */
+  def persistCompleted(entityName: String, context: Context): Unit
+
+  /**
+   * Record event persisted to storage.
+   *
+   * @param entityName the entity name
+   * @param size the serialized size of the event
+   */
+  def eventPersisted(entityName: String, size: Int): Unit
+
+  /**
+   * Record event loaded from storage.
+   *
+   * @param entityName the entity name
+   * @param size the serialized size of the event
+   */
+  def eventLoaded(entityName: String, size: Int): Unit
+
+  /**
+   * Record snapshot persisted to storage.
+   *
+   * @param entityName the entity name
+   * @param size the serialized size of the snapshot
+   */
+  def snapshotPersisted(entityName: String, size: Int): Unit
+
+  /**
+   * Record snapshot loaded from storage.
+   *
+   * @param entityName the entity name
+   * @param size the serialized size of the snapshot
+   */
+  def snapshotLoaded(entityName: String, size: Int): Unit
+}
+
+object NoEventSourcedInstrumentation extends EventSourcedInstrumentation {
+  import EventSourcedInstrumentation._
+
+  override def entityActivated(entityName: String): Context = null
+  override def entityPassivated(entityName: String, context: Context): Unit = ()
+  override def entityFailed(entityName: String): Unit = ()
+  override def recoveryStarted(entityName: String): Context = null
+  override def recoveryCompleted(entityName: String, context: Context): Unit = ()
+  override def commandReceived(entityName: String): Context = null
+  override def commandStashed(entityName: String, context: Context): StashContext = null
+  override def commandUnstashed(entityName: String, context: StashContext): Unit = ()
+  override def commandStarted(entityName: String): Context = null
+  override def commandProcessed(entityName: String, context: Context): Unit = ()
+  override def commandFailed(entityName: String): Unit = ()
+  override def commandCompleted(entityName: String, context: Context): Unit = ()
+  override def persistStarted(entityName: String): Context = null
+  override def persistCompleted(entityName: String, context: Context): Unit = ()
+  override def eventPersisted(entityName: String, size: Int): Unit = ()
+  override def eventLoaded(entityName: String, size: Int): Unit = ()
+  override def snapshotPersisted(entityName: String, size: Int): Unit = ()
+  override def snapshotLoaded(entityName: String, size: Int): Unit = ()
+}
+
+/**
+ * Instrumentation wrapper for an entity instance.
+ */
+abstract class EventSourcedEntityInstrumentation {
+  import EventSourcedInstrumentation._
+
+  def entityActivated(): Unit
+  def entityPassivated(): Unit
+  def entityFailed(): Unit
+  def recoveryStarted(): Unit
+  def recoveryCompleted(): Unit
+  def commandReceived(): Unit
+  def commandStashed(): StashContext
+  def commandUnstashed(context: StashContext): Unit
+  def commandStarted(): Unit
+  def commandProcessed(): Unit
+  def commandFailed(): Unit
+  def commandCompleted(): Unit
+  def persistStarted(): Unit
+  def persistCompleted(): Unit
+  def eventPersisted(size: Int): Unit
+  def eventLoaded(size: Int): Unit
+  def snapshotPersisted(size: Int): Unit
+  def snapshotLoaded(size: Int): Unit
+}
+
+/**
+ * Active instrumentation wrapper for an entity instance.
+ * Stores instrumentation contexts local to an entity.
+ */
+class ActiveEventSourcedEntityInstrumentation(entityName: String, eventSourced: EventSourcedInstrumentation)
+    extends EventSourcedEntityInstrumentation {
+  import EventSourcedInstrumentation._
+
+  // only one of these contexts is active at a time (stashed commands are stored in the stash queue)
+  private[this] var entityContext: Context = _
+  private[this] var recoveryContext: Context = _
+  private[this] var receiveContext: Context = _
+  private[this] var startContext: Context = _
+  private[this] var persistContext: Context = _
+
+  override def entityActivated(): Unit =
+    entityContext = eventSourced.entityActivated(entityName)
+
+  override def entityPassivated(): Unit = {
+    eventSourced.entityPassivated(entityName, entityContext)
+    entityContext = null
+  }
+
+  override def entityFailed(): Unit =
+    eventSourced.entityFailed(entityName)
+
+  override def recoveryStarted(): Unit =
+    recoveryContext = eventSourced.recoveryStarted(entityName)
+
+  override def recoveryCompleted(): Unit = {
+    eventSourced.recoveryCompleted(entityName, recoveryContext)
+    recoveryContext = null
+  }
+
+  override def commandReceived(): Unit =
+    receiveContext = eventSourced.commandReceived(entityName)
+
+  override def commandStashed(): StashContext =
+    eventSourced.commandStashed(entityName, eventSourced.commandReceived(entityName))
+
+  override def commandUnstashed(context: StashContext): Unit = {
+    eventSourced.commandUnstashed(entityName, context)
+    receiveContext = context.restore
+  }
+
+  override def commandStarted(): Unit =
+    startContext = eventSourced.commandStarted(entityName)
+
+  override def commandProcessed(): Unit = {
+    eventSourced.commandProcessed(entityName, startContext)
+    startContext = null
+  }
+
+  override def commandFailed(): Unit =
+    eventSourced.commandFailed(entityName)
+
+  override def commandCompleted(): Unit = {
+    eventSourced.commandCompleted(entityName, receiveContext)
+    receiveContext = null
+  }
+
+  override def persistStarted(): Unit =
+    persistContext = eventSourced.persistStarted(entityName)
+
+  override def persistCompleted(): Unit = {
+    eventSourced.persistCompleted(entityName, persistContext)
+    persistContext = null
+  }
+
+  override def eventPersisted(size: Int): Unit =
+    eventSourced.eventPersisted(entityName, size)
+
+  override def eventLoaded(size: Int): Unit =
+    eventSourced.eventLoaded(entityName, size)
+
+  override def snapshotPersisted(size: Int): Unit =
+    eventSourced.snapshotPersisted(entityName, size)
+
+  override def snapshotLoaded(size: Int): Unit =
+    eventSourced.snapshotLoaded(entityName, size)
+}
+
+object NoEventSourcedEntityInstrumentation extends EventSourcedEntityInstrumentation {
+  import EventSourcedInstrumentation._
+
+  override def entityActivated(): Unit = ()
+  override def entityPassivated(): Unit = ()
+  override def entityFailed(): Unit = ()
+  override def recoveryStarted(): Unit = ()
+  override def recoveryCompleted(): Unit = ()
+  override def commandReceived(): Unit = ()
+  override def commandStashed(): StashContext = null
+  override def commandUnstashed(context: StashContext): Unit = ()
+  override def commandStarted(): Unit = ()
+  override def commandProcessed(): Unit = ()
+  override def commandFailed(): Unit = ()
+  override def commandCompleted(): Unit = ()
+  override def persistStarted(): Unit = ()
+  override def persistCompleted(): Unit = ()
+  override def eventPersisted(size: Int): Unit = ()
+  override def eventLoaded(size: Int): Unit = ()
+  override def snapshotPersisted(size: Int): Unit = ()
+  override def snapshotLoaded(size: Int): Unit = ()
+}

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/telemetry/PrometheusEventSourcedInstrumentation.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/telemetry/PrometheusEventSourcedInstrumentation.scala
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.proxy.telemetry
+
+import io.prometheus.client.{CollectorRegistry, Counter, Histogram, Summary}
+
+object PrometheusEventSourcedInstrumentation {
+  object MetricName {
+    final val ActivatedEntitiesTotal = "cloudstate_eventsourced_activated_entities_total"
+    final val PassivatedEntitiesTotal = "cloudstate_eventsourced_passivated_entities_total"
+    final val EntityActiveTimeSeconds = "cloudstate_eventsourced_entity_active_time_seconds"
+    final val FailedEntitiesTotal = "cloudstate_eventsourced_failed_entities_total"
+    final val RecoveryTimeSeconds = "cloudstate_eventsourced_recovery_time_seconds"
+    final val ReceivedCommandsTotal = "cloudstate_eventsourced_received_commands_total"
+    final val StashedCommandsTotal = "cloudstate_eventsourced_stashed_commands_total"
+    final val UnstashedCommandsTotal = "cloudstate_eventsourced_unstashed_commands_total"
+    final val CommandStashTimeSeconds = "cloudstate_eventsourced_command_stash_time_seconds"
+    final val CommandProcessingTimeSeconds = "cloudstate_eventsourced_command_processing_time_seconds"
+    final val FailedCommandsTotal = "cloudstate_eventsourced_failed_commands_total"
+    final val CompletedCommandsTotal = "cloudstate_eventsourced_completed_commands_total"
+    final val CommandTotalTimeSeconds = "cloudstate_eventsourced_command_total_time_seconds"
+    final val PersistTimeSeconds = "cloudstate_eventsourced_persist_time_seconds"
+    final val PersistedEventsTotal = "cloudstate_eventsourced_persisted_events_total"
+    final val PersistedEventBytesTotal = "cloudstate_eventsourced_persisted_event_bytes_total"
+    final val LoadedEventsTotal = "cloudstate_eventsourced_loaded_events_total"
+    final val LoadedEventBytesTotal = "cloudstate_eventsourced_loaded_event_bytes_total"
+    final val PersistedSnapshotsTotal = "cloudstate_eventsourced_persisted_snapshots_total"
+    final val PersistedSnapshotBytesTotal = "cloudstate_eventsourced_persisted_snapshot_bytes_total"
+    final val LoadedSnapshotsTotal = "cloudstate_eventsourced_loaded_snapshots_total"
+    final val LoadedSnapshotBytesTotal = "cloudstate_eventsourced_loaded_snapshot_bytes_total"
+  }
+
+  object MetricLabel {
+    final val EntityName = "entity_name"
+  }
+
+  final val NanosecondsPerSecond = 1e9
+}
+
+class PrometheusEventSourcedInstrumentation(registry: CollectorRegistry) extends EventSourcedInstrumentation {
+  import EventSourcedInstrumentation._
+  import PrometheusEventSourcedInstrumentation._
+
+  // Notes:
+  // Using Histograms for command timing metrics, with the default buckets (from 5ms up to 10s).
+  // Timing metrics are in seconds, using the Prometheus convention of base units.
+  // Not using Summary for command timing metrics, as it currently has terrible performance.
+  // HDRHistogram-backed Summary still coming: https://github.com/prometheus/client_java/pull/484
+
+  private val activatedEntitiesTotal: Counter = Counter.build
+    .name(MetricName.ActivatedEntitiesTotal)
+    .help("Total entity instances that have activated.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val passivatedEntitiesTotal: Counter = Counter.build
+    .name(MetricName.PassivatedEntitiesTotal)
+    .help("Total entity instances that have passivated.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val entityActiveTimeSeconds: Summary = Summary.build
+    .name(MetricName.EntityActiveTimeSeconds)
+    .help("Duration that entities are active, in seconds.")
+    .labelNames(MetricLabel.EntityName)
+    .quantile(0.50, 0.050) // 50th percentile (median), 5% error
+    .quantile(0.95, 0.010) // 95th percentile, 1% error
+    .quantile(0.99, 0.001) // 99th percentile, 0.1% error
+    .quantile(1.00, 0.000) // 100th percentile (max), 0% error
+    .maxAgeSeconds(60)
+    .ageBuckets(6)
+    .register(registry)
+
+  private val failedEntitiesTotal: Counter = Counter.build
+    .name(MetricName.FailedEntitiesTotal)
+    .help("Total entity instances that have failed.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val recoveryTimeSeconds: Histogram = Histogram.build
+    .name(MetricName.RecoveryTimeSeconds)
+    .help("Duration for entity recovery, in seconds.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val receivedCommandsTotal: Counter = Counter.build
+    .name(MetricName.ReceivedCommandsTotal)
+    .help("Total commands received for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val stashedCommandsTotal: Counter = Counter.build
+    .name(MetricName.StashedCommandsTotal)
+    .help("Total commands stashed for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val unstashedCommandsTotal: Counter = Counter.build
+    .name(MetricName.UnstashedCommandsTotal)
+    .help("Total commands unstashed for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val commandStashTimeSeconds: Histogram = Histogram.build
+    .name(MetricName.CommandStashTimeSeconds)
+    .help("Duration that commands are stashed, in seconds.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val commandProcessingTimeSeconds: Histogram = Histogram.build
+    .name(MetricName.CommandProcessingTimeSeconds)
+    .help("Duration for command processing (until user function reply), in seconds.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val failedCommandsTotal: Counter = Counter.build
+    .name(MetricName.FailedCommandsTotal)
+    .help("Total commands that have failed.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val completedCommandsTotal: Counter = Counter.build
+    .name(MetricName.CompletedCommandsTotal)
+    .help("Total commands completed for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val commandTotalTimeSeconds: Histogram = Histogram.build
+    .name(MetricName.CommandTotalTimeSeconds)
+    .help("Total duration for command handling (including stash and persist), in seconds.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val persistTimeSeconds: Histogram = Histogram.build
+    .name(MetricName.PersistTimeSeconds)
+    .help("Duration for persisting events from a command, in seconds.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val persistedEventsTotal: Counter = Counter.build
+    .name(MetricName.PersistedEventsTotal)
+    .help("Total events persisted for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val persistedEventBytesTotal: Counter = Counter.build
+    .name(MetricName.PersistedEventBytesTotal)
+    .help("Total event sizes persisted for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val loadedEventsTotal: Counter = Counter.build
+    .name(MetricName.LoadedEventsTotal)
+    .help("Total events loaded for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val loadedEventBytesTotal: Counter = Counter.build
+    .name(MetricName.LoadedEventBytesTotal)
+    .help("Total event sizes loaded for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val persistedSnapshotsTotal: Counter = Counter.build
+    .name(MetricName.PersistedSnapshotsTotal)
+    .help("Total snapshots persisted for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val persistedSnapshotBytesTotal: Counter = Counter.build
+    .name(MetricName.PersistedSnapshotBytesTotal)
+    .help("Total snapshot sizes persisted for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val loadedSnapshotsTotal: Counter = Counter.build
+    .name(MetricName.LoadedSnapshotsTotal)
+    .help("Total snapshots loaded for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private val loadedSnapshotBytesTotal: Counter = Counter.build
+    .name(MetricName.LoadedSnapshotBytesTotal)
+    .help("Total snapshot sizes loaded for an entity.")
+    .labelNames(MetricLabel.EntityName)
+    .register(registry)
+
+  private def now: Long = System.nanoTime()
+
+  private def elapsedSeconds(context: Context): Double =
+    (now - context.startTime) / NanosecondsPerSecond
+
+  private def startSpan(): Context = Context(startTime = now)
+
+  private def startSpan(entityName: String, counter: Counter): Context = {
+    counter.labels(entityName).inc()
+    startSpan()
+  }
+
+  private def endSpan(entityName: String, timer: Histogram, context: Context): Unit =
+    timer.labels(entityName).observe(elapsedSeconds(context))
+
+  private def endSpan(entityName: String, counter: Counter, timer: Histogram, context: Context): Unit = {
+    counter.labels(entityName).inc()
+    endSpan(entityName, timer, context)
+  }
+
+  private def endSpan(entityName: String, timer: Summary, context: Context): Unit =
+    timer.labels(entityName).observe(elapsedSeconds(context))
+
+  private def endSpan(entityName: String, counter: Counter, timer: Summary, context: Context): Unit = {
+    counter.labels(entityName).inc()
+    endSpan(entityName, timer, context)
+  }
+
+  override def entityActivated(entityName: String): Context =
+    startSpan(entityName, activatedEntitiesTotal)
+
+  override def entityPassivated(entityName: String, context: Context): Unit =
+    endSpan(entityName, passivatedEntitiesTotal, entityActiveTimeSeconds, context)
+
+  override def entityFailed(entityName: String): Unit =
+    failedEntitiesTotal.labels(entityName).inc()
+
+  override def recoveryStarted(entityName: String): Context =
+    startSpan()
+
+  override def recoveryCompleted(entityName: String, context: Context): Unit =
+    endSpan(entityName, recoveryTimeSeconds, context)
+
+  override def commandReceived(entityName: String): Context =
+    startSpan(entityName, receivedCommandsTotal)
+
+  override def commandStashed(entityName: String, context: Context): StashContext =
+    StashContext(stash = startSpan(entityName, stashedCommandsTotal), restore = context)
+
+  override def commandUnstashed(entityName: String, context: StashContext): Unit =
+    endSpan(entityName, unstashedCommandsTotal, commandStashTimeSeconds, context.stash)
+
+  override def commandStarted(entityName: String): Context =
+    startSpan()
+
+  override def commandProcessed(entityName: String, context: Context): Unit =
+    endSpan(entityName, commandProcessingTimeSeconds, context)
+
+  override def commandFailed(entityName: String): Unit =
+    failedCommandsTotal.labels(entityName).inc()
+
+  override def commandCompleted(entityName: String, context: Context): Unit =
+    endSpan(entityName, completedCommandsTotal, commandTotalTimeSeconds, context)
+
+  override def persistStarted(entityName: String): Context =
+    startSpan()
+
+  override def persistCompleted(entityName: String, context: Context): Unit =
+    endSpan(entityName, persistTimeSeconds, context)
+
+  override def eventPersisted(entityName: String, size: Int): Unit = {
+    persistedEventsTotal.labels(entityName).inc()
+    persistedEventBytesTotal.labels(entityName).inc(size)
+  }
+
+  override def eventLoaded(entityName: String, size: Int): Unit = {
+    loadedEventsTotal.labels(entityName).inc()
+    loadedEventBytesTotal.labels(entityName).inc(size)
+  }
+
+  override def snapshotPersisted(entityName: String, size: Int): Unit = {
+    persistedSnapshotsTotal.labels(entityName).inc()
+    persistedSnapshotBytesTotal.labels(entityName).inc(size)
+  }
+
+  override def snapshotLoaded(entityName: String, size: Int): Unit = {
+    loadedSnapshotsTotal.labels(entityName).inc()
+    loadedSnapshotBytesTotal.labels(entityName).inc(size)
+  }
+}

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/AbstractTelemetrySpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/AbstractTelemetrySpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.proxy.telemetry
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import io.prometheus.client.CollectorRegistry
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{Matchers, WordSpecLike}
+import scala.io.Source
+
+abstract class AbstractTelemetrySpec extends WordSpecLike with Matchers with Eventually {
+
+  def withTestRegistry(conf: String = "")(run: TestKit => Any): Unit = {
+    // avoid multiple registrations on the global default registry in tests by creating a new registry
+    val testConf = conf + """
+      | cloudstate.proxy.telemetry.prometheus.use-default-registry = false
+      """
+    withTestKit(testConf)(run)
+  }
+
+  def withTestKit(conf: String)(run: TestKit => Any): Unit = {
+    val config = ConfigFactory.load(ConfigFactory.parseString(conf.stripMargin))
+    val testKit = new TestKit(ActorSystem(getClass.getSimpleName, config))
+    try run(testKit)
+    finally testKit.shutdown()
+  }
+
+  def scrape[T](url: String)(useSource: Source => T): T = {
+    val source = Source.fromURL(url)
+    try useSource(source)
+    finally source.close()
+  }
+
+  def metricValue(name: String, labels: (String, String)*)(implicit collectorRegistry: CollectorRegistry): Double =
+    collectorRegistry.getSampleValue(name, labels.map(_._1).toArray, labels.map(_._2).toArray)
+
+}

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/CloudstateTelemetrySpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/CloudstateTelemetrySpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.proxy.telemetry
+
+import akka.testkit.EventFilter
+import io.prometheus.client.CollectorRegistry
+
+class CloudstateTelemetrySpec extends AbstractTelemetrySpec {
+
+  "CloudstateTelemetry" should {
+
+    "be enabled in production mode by default" in withTestRegistry() { testKit =>
+      CloudstateTelemetry(testKit.system).settings.enabled shouldBe true
+    }
+
+    "be disabled in development mode by default" in withTestKit("""
+      | cloudstate.proxy.dev-mode-enabled = true
+      """) { testKit =>
+      CloudstateTelemetry(testKit.system).settings.disabled shouldBe true
+    }
+
+    "allow telemetry to be enabled in development mode" in withTestRegistry(
+      """
+      | cloudstate.proxy.dev-mode-enabled = true
+      | cloudstate.proxy.telemetry.disabled = false
+      """
+    ) { testKit =>
+      CloudstateTelemetry(testKit.system).settings.enabled shouldBe true
+    }
+
+    "use Prometheus default registry by default" in withTestKit(
+      """
+      | # disable telemetry so we don't register any metrics with the global default registry
+      | cloudstate.proxy.telemetry.disabled = true
+      """
+    ) { testKit =>
+      CloudstateTelemetry(testKit.system).prometheusRegistry should be theSameInstanceAs CollectorRegistry.defaultRegistry
+    }
+
+    "create separate Prometheus registry if configured" in withTestKit(
+      """
+      | cloudstate.proxy.telemetry.prometheus.use-default-registry = false
+      """
+    ) { testKit =>
+      CloudstateTelemetry(testKit.system).prometheusRegistry shouldNot be theSameInstanceAs CollectorRegistry.defaultRegistry
+    }
+
+    "start Prometheus exporter on default port (9090)" in withTestRegistry(
+      """
+      | akka.loggers = ["akka.testkit.TestEventListener"]
+      """
+    ) { testKit =>
+      import testKit.system
+      EventFilter.info(start = "Prometheus exporter started", occurrences = 1).intercept {
+        CloudstateTelemetry(system).start()
+      }
+      val metrics = scrape("http://localhost:9090")(_.mkString)
+      metrics should include("# TYPE cloudstate_eventsourced")
+    }
+
+    "allow Prometheus metrics port to be configured" in withTestRegistry(
+      """
+      | cloudstate.proxy.telemetry.prometheus.port = 9999
+      | akka.loggers = ["akka.testkit.TestEventListener"]
+      """
+    ) { testKit =>
+      import testKit.system
+      EventFilter.info(start = "Prometheus exporter started", occurrences = 1).intercept {
+        CloudstateTelemetry(system).start()
+      }
+      val metrics = scrape("http://localhost:9999")(_.mkString)
+      metrics should include("# TYPE cloudstate_eventsourced")
+    }
+
+    "bind event-sourced instrumentation to Prometheus by default" in withTestRegistry() { testKit =>
+      CloudstateTelemetry(testKit.system).eventSourcedInstrumentation shouldBe a[PrometheusEventSourcedInstrumentation]
+    }
+
+    "use noop event-sourced instrumentation when disabled" in withTestKit("""
+      | cloudstate.proxy.telemetry.disabled = true
+      """) { testKit =>
+      CloudstateTelemetry(testKit.system).eventSourcedInstrumentation should be theSameInstanceAs NoEventSourcedInstrumentation
+    }
+
+    "bind active event-sourced entity instrumentation by default" in withTestRegistry() { testKit =>
+      CloudstateTelemetry(testKit.system)
+        .eventSourcedEntityInstrumentation("name") shouldBe an[ActiveEventSourcedEntityInstrumentation]
+    }
+
+    "use noop event-sourced entity instrumentation when disabled" in withTestKit(
+      """
+      | cloudstate.proxy.telemetry.disabled = true
+      """
+    ) { testKit =>
+      CloudstateTelemetry(testKit.system)
+        .eventSourcedEntityInstrumentation("name") should be theSameInstanceAs NoEventSourcedEntityInstrumentation
+    }
+  }
+}

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentationSpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentationSpec.scala
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.proxy.telemetry
+
+import akka.actor.{ActorRef, Status}
+import akka.testkit.TestProbe
+import com.google.protobuf.ByteString
+import com.google.protobuf.any.{Any => ProtoAny}
+import io.cloudstate.protocol.entity.{ClientAction, Command, Failure, Reply}
+import io.cloudstate.protocol.event_sourced._
+import io.cloudstate.proxy.ConcurrencyEnforcer
+import io.cloudstate.proxy.entity.{EntityCommand, UserFunctionReply}
+import io.cloudstate.proxy.eventsourced.EventSourcedEntity
+import io.prometheus.client.CollectorRegistry
+import scala.concurrent.duration._
+
+class EventSourcedInstrumentationSpec extends AbstractTelemetrySpec {
+
+  "EventSourcedInstrumentation" should {
+
+    "record event-sourced entity metrics" in withTestRegistry(
+      """
+      | # use in-memory journal for testing
+      | cloudstate.proxy.journal-enabled = true
+      | akka.persistence {
+      |   journal.plugin = "akka.persistence.journal.inmem"
+      |   snapshot-store.plugin = inmem-snapshot-store
+      | }
+      | inmem-snapshot-store.class = "io.cloudstate.proxy.eventsourced.InMemSnapshotStore"
+      """
+    ) { testKit =>
+      import testKit._
+      import PrometheusEventSourcedInstrumentation.MetricName._
+      import PrometheusEventSourcedInstrumentation.MetricLabel._
+
+      // simulate user function interaction with event-sourced entity to validate instrumentation
+
+      implicit val registry: CollectorRegistry = CloudstateTelemetry(system).prometheusRegistry
+
+      implicit val replyTo: ActorRef = testActor
+
+      val userFunction = TestProbe()
+
+      val statsCollector = TestProbe() // ignored
+
+      val concurrencyEnforcer = system.actorOf(
+        ConcurrencyEnforcer.props(
+          ConcurrencyEnforcer.ConcurrencyEnforcerSettings(
+            concurrency = 1,
+            actionTimeout = 10.seconds,
+            cleanupPeriod = 5.seconds
+          ),
+          statsCollector.ref
+        ),
+        "concurrency-enforcer"
+      )
+
+      val entity = system.actorOf(
+        EventSourcedEntity.props(
+          EventSourcedEntity.Configuration(
+            serviceName = "service",
+            userFunctionName = "test",
+            passivationTimeout = 30.seconds,
+            sendQueueSize = 100
+          ),
+          entityId = "entity",
+          userFunction.ref,
+          concurrencyEnforcer,
+          statsCollector.ref
+        ),
+        "test-entity"
+      )
+
+      watch(entity)
+
+      // init with empty snapshot
+
+      userFunction.expectMsg(
+        EventSourcedStreamIn(
+          EventSourcedStreamIn.Message.Init(
+            EventSourcedInit(
+              serviceName = "service",
+              entityId = "entity",
+              snapshot = None
+            )
+          )
+        )
+      )
+
+      metricValue(ActivatedEntitiesTotal, EntityName -> "test") shouldBe 1
+      metricValue(RecoveryTimeSeconds + "_count", EntityName -> "test") shouldBe 1
+      metricValue(RecoveryTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+
+      // first command
+
+      entity ! EntityCommand(entityId = "test", name = "command")
+
+      userFunction.expectMsg(
+        EventSourcedStreamIn(
+          EventSourcedStreamIn.Message.Command(
+            Command(
+              entityId = "entity",
+              id = 1,
+              name = "command",
+              payload = None
+            )
+          )
+        )
+      )
+
+      metricValue(ReceivedCommandsTotal, EntityName -> "test") shouldBe 1
+
+      // second command (will be stashed)
+
+      entity ! EntityCommand(entityId = "test", name = "command")
+
+      eventually(timeout(5.seconds), interval(100.millis)) {
+        metricValue(ReceivedCommandsTotal, EntityName -> "test") shouldBe 2
+        metricValue(StashedCommandsTotal, EntityName -> "test") shouldBe 1
+      }
+
+      // send first reply
+
+      val replyPayload1 = ProtoAny("reply", ByteString.copyFromUtf8("reply1"))
+      val reply1 = ClientAction(ClientAction.Action.Reply(Reply(payload = Some(replyPayload1))))
+
+      val event1 = ProtoAny("event", ByteString.copyFromUtf8("event1"))
+      val event2 = ProtoAny("event", ByteString.copyFromUtf8("event2"))
+      val event3 = ProtoAny("event", ByteString.copyFromUtf8("event3"))
+      val snapshot1 = ProtoAny("snapshot", ByteString.copyFromUtf8("snapshot1"))
+
+      entity ! EventSourcedStreamOut(
+        EventSourcedStreamOut.Message.Reply(
+          EventSourcedReply(
+            commandId = 1,
+            clientAction = Some(reply1),
+            events = Seq(event1, event2, event3),
+            snapshot = Some(snapshot1)
+          )
+        )
+      )
+
+      expectMsg(UserFunctionReply(Some(reply1)))
+
+      metricValue(CommandProcessingTimeSeconds + "_count", EntityName -> "test") shouldBe 1
+      metricValue(CommandProcessingTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+
+      val expectedPersistedBytes1 = Seq(event1, event2, event3).map(_.serializedSize).sum
+
+      metricValue(PersistedEventsTotal, EntityName -> "test") shouldBe 3
+      metricValue(PersistedEventBytesTotal, EntityName -> "test") shouldBe expectedPersistedBytes1
+      metricValue(PersistTimeSeconds + "_count", EntityName -> "test") shouldBe 1
+      metricValue(PersistTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+
+      metricValue(PersistedSnapshotsTotal, EntityName -> "test") shouldBe 1
+      metricValue(PersistedSnapshotBytesTotal, EntityName -> "test") shouldBe snapshot1.serializedSize
+
+      eventually(timeout(5.seconds), interval(100.millis)) {
+        metricValue(CompletedCommandsTotal, EntityName -> "test") shouldBe 1
+        metricValue(CommandTotalTimeSeconds + "_count", EntityName -> "test") shouldBe 1
+        metricValue(CommandTotalTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+      }
+
+      // second command is unstashed
+
+      eventually(timeout(5.seconds), interval(100.millis)) {
+        metricValue(UnstashedCommandsTotal, EntityName -> "test") shouldBe 1
+        metricValue(CommandStashTimeSeconds + "_count", EntityName -> "test") shouldBe 1
+        metricValue(CommandStashTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+      }
+
+      userFunction.expectMsg(
+        EventSourcedStreamIn(
+          EventSourcedStreamIn.Message.Command(
+            Command(
+              entityId = "entity",
+              id = 2,
+              name = "command",
+              payload = None
+            )
+          )
+        )
+      )
+
+      // send second reply
+
+      val replyPayload2 = ProtoAny("reply", ByteString.copyFromUtf8("reply2"))
+      val reply2 = ClientAction(ClientAction.Action.Reply(Reply(payload = Some(replyPayload2))))
+
+      val event4 = ProtoAny("event", ByteString.copyFromUtf8("event4"))
+      val event5 = ProtoAny("event", ByteString.copyFromUtf8("event5"))
+
+      entity ! EventSourcedStreamOut(
+        EventSourcedStreamOut.Message.Reply(
+          EventSourcedReply(
+            commandId = 2,
+            clientAction = Some(reply2),
+            events = Seq(event4, event5),
+            snapshot = None
+          )
+        )
+      )
+
+      expectMsg(UserFunctionReply(Some(reply2)))
+
+      metricValue(CommandProcessingTimeSeconds + "_count", EntityName -> "test") shouldBe 2
+      metricValue(CommandProcessingTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+
+      val expectedPersistedBytes2 = expectedPersistedBytes1 + Seq(event4, event5).map(_.serializedSize).sum
+
+      metricValue(PersistedEventsTotal, EntityName -> "test") shouldBe 5
+      metricValue(PersistedEventBytesTotal, EntityName -> "test") shouldBe expectedPersistedBytes2
+      metricValue(PersistTimeSeconds + "_count", EntityName -> "test") shouldBe 2
+      metricValue(PersistTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+
+      metricValue(PersistedSnapshotsTotal, EntityName -> "test") shouldBe 1
+      metricValue(PersistedSnapshotBytesTotal, EntityName -> "test") shouldBe snapshot1.serializedSize
+
+      eventually(timeout(5.seconds), interval(100.millis)) {
+        metricValue(CompletedCommandsTotal, EntityName -> "test") shouldBe 2
+        metricValue(CommandTotalTimeSeconds + "_count", EntityName -> "test") shouldBe 2
+        metricValue(CommandTotalTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+      }
+
+      // passivate the entity
+
+      entity ! EventSourcedEntity.Stop
+
+      userFunction.expectMsg(Status.Success(()))
+
+      expectTerminated(entity)
+
+      metricValue(PassivatedEntitiesTotal, EntityName -> "test") shouldBe 1
+      metricValue(EntityActiveTimeSeconds + "_count", EntityName -> "test") shouldBe 1
+      metricValue(EntityActiveTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+
+      // reactivate the entity
+
+      val reactivatedEntity = system.actorOf(
+        EventSourcedEntity.props(
+          EventSourcedEntity.Configuration(
+            serviceName = "service",
+            userFunctionName = "test",
+            passivationTimeout = 30.seconds,
+            sendQueueSize = 100
+          ),
+          entityId = "entity",
+          userFunction.ref,
+          concurrencyEnforcer,
+          statsCollector.ref
+        ),
+        "test-entity-reactivated"
+      )
+
+      watch(reactivatedEntity)
+
+      // init with snapshot and events
+
+      userFunction.expectMsg(
+        EventSourcedStreamIn(
+          EventSourcedStreamIn.Message.Init(
+            EventSourcedInit(
+              serviceName = "service",
+              entityId = "entity",
+              snapshot = Some(EventSourcedSnapshot(snapshotSequence = 3, snapshot = Some(snapshot1)))
+            )
+          )
+        )
+      )
+
+      metricValue(LoadedSnapshotsTotal, EntityName -> "test") shouldBe 1
+      metricValue(LoadedSnapshotBytesTotal, EntityName -> "test") shouldBe snapshot1.serializedSize
+
+      userFunction.expectMsg(
+        EventSourcedStreamIn(
+          EventSourcedStreamIn.Message.Event(
+            EventSourcedEvent(
+              sequence = 4,
+              payload = Some(event4)
+            )
+          )
+        )
+      )
+
+      userFunction.expectMsg(
+        EventSourcedStreamIn(
+          EventSourcedStreamIn.Message.Event(
+            EventSourcedEvent(
+              sequence = 5,
+              payload = Some(event5)
+            )
+          )
+        )
+      )
+
+      val expectedLoadedBytes = Seq(event4, event5).map(_.serializedSize).sum
+
+      metricValue(LoadedEventsTotal, EntityName -> "test") shouldBe 2
+      metricValue(LoadedEventBytesTotal, EntityName -> "test") shouldBe expectedLoadedBytes
+
+      eventually(timeout(5.seconds), interval(100.millis)) {
+        metricValue(ActivatedEntitiesTotal, EntityName -> "test") shouldBe 2
+        metricValue(RecoveryTimeSeconds + "_count", EntityName -> "test") shouldBe 2
+        metricValue(RecoveryTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+      }
+
+      // send a command that fails
+
+      reactivatedEntity ! EntityCommand(entityId = "test", name = "command")
+
+      userFunction.expectMsg(
+        EventSourcedStreamIn(
+          EventSourcedStreamIn.Message.Command(
+            Command(
+              entityId = "entity",
+              id = 1,
+              name = "command",
+              payload = None
+            )
+          )
+        )
+      )
+
+      metricValue(ReceivedCommandsTotal, EntityName -> "test") shouldBe 3
+
+      reactivatedEntity ! EventSourcedStreamOut(
+        EventSourcedStreamOut.Message.Failure(Failure(commandId = 1, description = "failure"))
+      )
+
+      expectMsg(UserFunctionReply(Some(ClientAction(ClientAction.Action.Failure(Failure(description = "failure"))))))
+
+      metricValue(FailedCommandsTotal, EntityName -> "test") shouldBe 1
+
+      metricValue(CommandProcessingTimeSeconds + "_count", EntityName -> "test") shouldBe 3
+      metricValue(CommandProcessingTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+
+      eventually(timeout(5.seconds), interval(100.millis)) {
+        metricValue(CompletedCommandsTotal, EntityName -> "test") shouldBe 3
+        metricValue(CommandTotalTimeSeconds + "_count", EntityName -> "test") shouldBe 3
+        metricValue(CommandTotalTimeSeconds + "_sum", EntityName -> "test") should be > 0.0
+      }
+
+      // create unexpected termination for entity failure
+
+      reactivatedEntity ! EventSourcedEntity.StreamClosed
+
+      expectTerminated(reactivatedEntity)
+
+      metricValue(FailedEntitiesTotal, EntityName -> "test") shouldBe 1
+    }
+
+  }
+}


### PR DESCRIPTION
Add some simple metrics for event-sourced entities. Just counts currently, no timing metrics. Uses the prometheus client, since that's already available and exported. Counts can be converted to rates in prometheus queries.

Metrics are only tagged by the user function entity name (such as `"shopping-cart"`) so they're aggregated counts for an entity type on a node. Per-instance metrics are expected to be too high cardinality. Metrics include:

* gauge: entity instances currently active
* count: entity instances that have activated
* count: entity instances that have passivated
* count: commands received for an entity
* count: commands stashed for an entity
* count: commands processed for an entity
* count: events persisted for an entity
* count: event sizes (bytes) persisted for an entity
* count: events loaded for an entity
* count: event sizes (bytes) loaded for an entity
* count: snapshots persisted for an entity
* count: snapshot sizes (bytes) persisted for an entity
* count: snapshots loaded for an entity
* count: snapshot sizes (bytes) loaded for an entity

Only tested manually at the moment, can look at automated testing for the instrumentation later.