### PR TITLE
Added metadata support to the proxy

### DIFF
--- a/protocols/protocol/cloudstate/entity.proto
+++ b/protocols/protocol/cloudstate/entity.proto
@@ -27,7 +27,7 @@ import "google/protobuf/descriptor.proto";
 option java_package = "io.cloudstate.protocol";
 option go_package = "cloudstate/protocol";
 
-// Transport specific metadata associated with a message.
+// Transport-specific metadata associated with a message.
 //
 // The semantics of the metadata are not defined in this protocol, but rather, depend on the transport on which a
 // particular instance of the metadata maps to. What keys or values are allowed or disallowed, whether duplicate values

--- a/protocols/protocol/cloudstate/entity.proto
+++ b/protocols/protocol/cloudstate/entity.proto
@@ -153,7 +153,7 @@ message SideEffect {
     // sent, or not.
     bool synchronous = 4;
 
-    // The metadata to include with the forward
+    // The metadata to include with the side effect
     Metadata metadata = 5;
 }
 

--- a/protocols/protocol/cloudstate/entity.proto
+++ b/protocols/protocol/cloudstate/entity.proto
@@ -27,10 +27,87 @@ import "google/protobuf/descriptor.proto";
 option java_package = "io.cloudstate.protocol";
 option go_package = "cloudstate/protocol";
 
+// Transport specific metadata associated with a message.
+//
+// The semantics of the metadata are not defined in this protocol, but rather, depend on the transport on which a
+// particular instance of the metadata maps to. What keys or values are allowed or disallowed, whether duplicate values
+// for the same key are allowed and how they are handled, and whether key names are case sensitive or not, are all
+// undefined in the context of the Cloudstate protocol.
+//
+// If a metadata entry associated with a message can't be expressed in an underlying transport, for example, due to
+// invalid characters in a key or value, the behavior of the proxy is undefined. This is because metadata is transport
+// specific, so if the user function chooses to use metadata, it is choosing to be specific to a particular transport,
+// which is beyond the scope of the Cloudstate protocol, and it's therefore the user functions responsibility to adhere
+// to the semantics of that transport. The proxy MAY decide to drop metadata entries if it knows they are invalid or
+// unsupported. If a metadata entry is dropped, the proxy MAY inform the user function that the entry was dropped by
+// sending an error message to the EntityDiscovery.ReportError gRPC call.
+//
+// The metadata MAY also contain CloudEvent metadata. If a message comes from a Cloudstate event source, the Cloudstate
+// proxy MUST attach CloudEvent metadata to it if the event doesn't already have CloudEvent metadata attached to it.
+// This metadata SHALL be encoded according to the binary mode of the CloudEvent HTTP protocol binding, which can be
+// found here:
+//
+// https://github.com/cloudevents/spec/blob/master/http-protocol-binding.md
+//
+// The Cloudstate proxy MAY synthesize appropriate values for Cloudstate metadata if no equivalent metadata exists in
+// the event source, for example, if there is no type, the Cloudstate proxy MAY use the name of the gRPC message as the
+// CloudEvent type, and if there is no source, the Cloudstate proxy MAY use the name of the topic as the source.
+//
+// If an incoming message does have CloudEvent metadata attached to it, the Cloudstate proxy MUST transcode that
+// CloudEvent metadata to the HTTP protocol binding as described above.
+//
+// Messages sent from the user function to an event destination MAY include CloudEvent metadata. If they include any
+// CloudEvent metadata, they MUST include all required CloudEvent attributes, including id, source, specversion and
+// type. The behavior of the proxy is undefined if some of these attributes, but not others, are included - the proxy
+// MAY ignore them all, or MAY generate values itself, but SHOULD NOT fail sending the message. If the destination for
+// the message is an event destination, the Cloudstate proxy MUST transcode the supplied Cloudstate metadata to a
+// binding appropriate for the underlying transport for that event destination, it MUST NOT pass the CloudEvent
+// metadata as is unless the transport uses the same binding rules.
+message Metadata {
+    // The metadata entries.
+    repeated MetadataEntry entries = 1;
+}
+
+// A metadata entry.
+message MetadataEntry {
+
+    // Key for the entry. Valid keys depend on the transport from or to which this metadata is sent.
+    string key = 1;
+
+    // The value.
+    oneof value {
+
+        // A string value. Valid values depend on the transport from or which this metadata is sent.
+        //
+        // If the transport does not support string values, the behavior of the Cloudstate proxy is undefined from the
+        // point of view of this protocol. If there is a convention in the protocol for encoding string values as
+        // UTF-8 bytes, then the Cloudstate proxy MAY do that.
+        string string_value = 2;
+
+        // A bytes value. Valid values depend on the transport from or which this metadata is sent.
+        //
+        // If the transport does not support bytes values, the behavior of the Cloudstate proxy is undefined from the
+        // point of view of this protocol. If there is a convention in the protocol for encoding bytes values as
+        // Base64 encoded strings, then the Cloudstate proxy MAY do that.
+        bytes bytes_value = 3;
+    }
+}
+
 // A reply to the sender.
 message Reply {
     // The reply payload
     google.protobuf.Any payload = 1;
+
+    // Metadata for the reply
+    //
+    // Not all transports support per message metadata, for example, gRPC doesn't. The Cloudstate proxy MAY ignore the
+    // metadata in this case, or it MAY lift the metadata into another place, for example, in gRPC, a unary call MAY
+    // have its reply metadata placed in the headers of the HTTP response, or the first reply to a streamed call MAY
+    // if its metadata placed in the headers of the HTTP response.
+    //
+    // If the metadata is ignored, the Cloudstate proxy MAY notify the user function by sending an error message to the
+    // EntityDiscovery.ReportError gRPC call.
+    Metadata metadata = 2;
 }
 
 // Forwards handling of this request to another entity.
@@ -41,6 +118,8 @@ message Forward {
     string command_name = 2;
     // The payload.
     google.protobuf.Any payload = 3;
+    // The metadata to include with the forward
+    Metadata metadata = 4;
 }
 
 // An action for the client
@@ -73,6 +152,9 @@ message SideEffect {
     // Whether this side effect should be performed synchronously, ie, before the reply is eventually
     // sent, or not.
     bool synchronous = 4;
+
+    // The metadata to include with the forward
+    Metadata metadata = 5;
 }
 
 // A command. For each command received, a reply must be sent with a matching command id.
@@ -92,6 +174,14 @@ message Command {
 
     // Whether the command is streamed or not
     bool streamed = 5;
+
+    // The command metadata.
+    //
+    // Not all transports support per message metadata, for example, gRPC doesn't. The Cloudstate proxy MAY include
+    // metadata from other locations in this case, for example, in gRPC, a unary call MAY have the HTTP request headers
+    // attached to the command, while a streamed call MAY have the HTTP request headers attached as the metadata for
+    // either the first command, or every command. This specification leaves this behavior undefined.
+    Metadata metadata = 6;
 }
 
 message StreamCancelled {

--- a/protocols/protocol/cloudstate/entity.proto
+++ b/protocols/protocol/cloudstate/entity.proto
@@ -103,7 +103,7 @@ message Reply {
     // Not all transports support per message metadata, for example, gRPC doesn't. The Cloudstate proxy MAY ignore the
     // metadata in this case, or it MAY lift the metadata into another place, for example, in gRPC, a unary call MAY
     // have its reply metadata placed in the headers of the HTTP response, or the first reply to a streamed call MAY
-    // if its metadata placed in the headers of the HTTP response.
+    // have its metadata placed in the headers of the HTTP response.
     //
     // If the metadata is ignored, the Cloudstate proxy MAY notify the user function by sending an error message to the
     // EntityDiscovery.ReportError gRPC call.

--- a/protocols/protocol/cloudstate/entity.proto
+++ b/protocols/protocol/cloudstate/entity.proto
@@ -37,7 +37,7 @@ option go_package = "cloudstate/protocol";
 // If a metadata entry associated with a message can't be expressed in an underlying transport, for example, due to
 // invalid characters in a key or value, the behavior of the proxy is undefined. This is because metadata is transport
 // specific, so if the user function chooses to use metadata, it is choosing to be specific to a particular transport,
-// which is beyond the scope of the Cloudstate protocol, and it's therefore the user functions responsibility to adhere
+// which is beyond the scope of the Cloudstate protocol, and it's therefore the user function's responsibility to adhere
 // to the semantics of that transport. The proxy MAY decide to drop metadata entries if it knows they are invalid or
 // unsupported. If a metadata entry is dropped, the proxy MAY inform the user function that the entry was dropped by
 // sending an error message to the EntityDiscovery.ReportError gRPC call.

--- a/protocols/protocol/cloudstate/function.proto
+++ b/protocols/protocol/cloudstate/function.proto
@@ -108,7 +108,7 @@ service StatelessFunction {
     //
     // The semantics of stream closure in this protocol map 1:1 with the semantics of gRPC stream closure,
     // that is, when the client closes the stream, the stream is considered half closed, and the server
-    // should eventually, but not necessarily immediately, close the streamage with a status code and
+    // should eventually, but not necessarily immediately, close the stream with a status code and
     // trailers.
     //
     // If however the server closes the stream with a status code and trailers, the stream is immediately

--- a/protocols/protocol/cloudstate/function.proto
+++ b/protocols/protocol/cloudstate/function.proto
@@ -26,6 +26,14 @@ import "cloudstate/entity.proto";
 option java_package = "io.cloudstate.protocol";
 option go_package = "cloudstate/protocol";
 
+// A function command.
+//
+// For unary and streamed out calls, the service name, command name and payload will always be set.
+//
+// For streamed in and duplex streamed calls, the first command sent will just contain the service
+// name and command name, but no payload. This will indicate that the function has been invoked.
+// Subsequent commands on the stream will only have the payload set, the service name and command
+// name will not be set.
 message FunctionCommand {
     // The name of the service this function is on.
     string service_name = 2;
@@ -35,6 +43,9 @@ message FunctionCommand {
 
     // The command payload.
     google.protobuf.Any payload = 4;
+
+    // Metadata
+    Metadata metadata = 5;
 }
 
 message FunctionReply {
@@ -45,17 +56,67 @@ message FunctionReply {
         Forward forward = 3;
     }
 
-    repeated SideEffect side_effects = 4;
+    repeated SideEffect side_effects = 5;
 }
 
 service StatelessFunction {
 
+    // Handle a unary command.
+    //
+    // The input command will contain the service name, command name, request metadata and the command
+    // payload. The reply may contain a direct reply, a forward or a failure, and it may contain many
+    // side effects.
     rpc handleUnary(FunctionCommand) returns (FunctionReply) {}
 
+    // Handle a streamed in command.
+    //
+    // The first message in will contain the request metadata, including the service name and command
+    // name. It will not have an associated payload set. This will be followed by zero to many messages
+    // in with a payload, but no service name or command name set.
+    //
+    // The semantics of stream closure in this protocol map 1:1 with the semantics of gRPC stream closure,
+    // that is, when the client closes the stream, the stream is considered half closed, and the server
+    // should eventually, but not necessarily immediately, send a response message with a status code and
+    // trailers.
+    //
+    // If however the server sends a response message before the client closes the stream, the stream is
+    // completely closed, and the client should handle this and stop sending more messages.
+    //
+    // Either the client or the server may cancel the stream at any time, cancellation is indicated
+    // through an HTTP2 stream RST message.
     rpc handleStreamedIn(stream FunctionCommand) returns (FunctionReply) {}
 
+    // Handle a streamed out command.
+    //
+    // The input command will contain the service name, command name, request metadata and the command
+    // payload. Zero or more replies may be sent, each containing either a direct reply, a forward or a
+    // failure, and each may contain many side effects. The stream to the client will be closed when the
+    // this stream is closed, with the same status as this stream is closed with.
+    //
+    // Either the client or the server may cancel the stream at any time, cancellation is indicated
+    // through an HTTP2 stream RST message.
     rpc handleStreamedOut(FunctionCommand) returns (stream FunctionReply) {}
 
+    // Handle a full duplex streamed command.
+    //
+    // The first message in will contain the request metadata, including the service name and command
+    // name. It will not have an associated payload set. This will be followed by zero to many messages
+    // in with a payload, but no service name or command name set.
+    //
+    // Zero or more replies may be sent, each containing either a direct reply, a forward or a failure,
+    // and each may contain many side effects.
+    //
+    // The semantics of stream closure in this protocol map 1:1 with the semantics of gRPC stream closure,
+    // that is, when the client closes the stream, the stream is considered half closed, and the server
+    // should eventually, but not necessarily immediately, close the streamage with a status code and
+    // trailers.
+    //
+    // If however the server closes the stream with a status code and trailers, the stream is immediately
+    // considered completely closed, and no further messages sent by the client will be handled by the
+    // server.
+    //
+    // Either the client or the server may cancel the stream at any time, cancellation is indicated
+    // through an HTTP2 stream RST message.
     rpc handleStreamed(stream FunctionCommand) returns (stream FunctionReply) {}
 
 }

--- a/protocols/protocol/cloudstate/function.proto
+++ b/protocols/protocol/cloudstate/function.proto
@@ -56,7 +56,7 @@ message FunctionReply {
         Forward forward = 3;
     }
 
-    repeated SideEffect side_effects = 5;
+    repeated SideEffect side_effects = 4;
 }
 
 service StatelessFunction {
@@ -73,6 +73,11 @@ service StatelessFunction {
     // The first message in will contain the request metadata, including the service name and command
     // name. It will not have an associated payload set. This will be followed by zero to many messages
     // in with a payload, but no service name or command name set.
+    //
+    // If the underlying transport supports per stream metadata, rather than per message metadata, then
+    // that metadata will only be included in the metadata of the first message. In contrast, if the
+    // underlying transport supports per message metadata, there will be no metadata on the first message,
+    // the metadata will instead be found on each subsequent message.
     //
     // The semantics of stream closure in this protocol map 1:1 with the semantics of gRPC stream closure,
     // that is, when the client closes the stream, the stream is considered half closed, and the server
@@ -105,6 +110,11 @@ service StatelessFunction {
     //
     // Zero or more replies may be sent, each containing either a direct reply, a forward or a failure,
     // and each may contain many side effects.
+    //
+    // If the underlying transport supports per stream metadata, rather than per message metadata, then
+    // that metadata will only be included in the metadata of the first message. In contrast, if the
+    // underlying transport supports per message metadata, there will be no metadata on the first message,
+    // the metadata will instead be found on each subsequent message.
     //
     // The semantics of stream closure in this protocol map 1:1 with the semantics of gRPC stream closure,
     // that is, when the client closes the stream, the stream is considered half closed, and the server

--- a/proxy/core/src/main/proto/cloudstate/proxy/statemanager.proto
+++ b/proxy/core/src/main/proto/cloudstate/proxy/statemanager.proto
@@ -32,6 +32,7 @@ option (scalapb.options) = {
 message UserFunctionCommand {
     string name = 1;
     google.protobuf.Any payload = 2;
+    cloudstate.Metadata metadata = 3;
 }
 
 message EntityCommand {
@@ -39,6 +40,7 @@ message EntityCommand {
     string name = 2;
     google.protobuf.Any payload = 3;
     bool streamed = 4;
+    cloudstate.Metadata metadata = 5;
 }
 
 message UserFunctionReply {

--- a/proxy/core/src/main/proto/cloudstate/proxy/statemanager.proto
+++ b/proxy/core/src/main/proto/cloudstate/proxy/statemanager.proto
@@ -29,12 +29,6 @@ option (scalapb.options) = {
     flat_package: true
 };
 
-message UserFunctionCommand {
-    string name = 1;
-    google.protobuf.Any payload = 2;
-    cloudstate.Metadata metadata = 3;
-}
-
 message EntityCommand {
     string entity_id = 1;
     string name = 2;

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
@@ -22,7 +22,7 @@ import akka.cluster.Cluster
 import akka.util.Timeout
 import akka.pattern.pipe
 import akka.stream.scaladsl.RunnableGraph
-import akka.http.scaladsl.{Http, HttpConnectionContext, UseHttp2}
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.cluster.singleton.{
   ClusterSingletonManager,
@@ -52,15 +52,10 @@ import io.cloudstate.proxy.autoscaler.{
 }
 import io.cloudstate.proxy.crdt.CrdtSupportFactory
 import io.cloudstate.proxy.eventsourced.EventSourcedSupportFactory
-import io.cloudstate.proxy.eventing.EventingManager
 import io.cloudstate.proxy.function.StatelessFunctionSupportFactory
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
-//import io.cloudstate.protocol.entity.{ClientAction, EntityDiscovery, Failure, Reply, UserFunctionError}
-import io.cloudstate.protocol.entity.EntityDiscovery
-import io.cloudstate.proxy.EntityDiscoveryManager.ServableEntity
 
 object EntityDiscoveryManager {
   final case class Configuration(

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
@@ -245,10 +245,10 @@ class EntityDiscoveryManager(config: EntityDiscoveryManager.Configuration)(
 
         val router = new UserFunctionRouter(entities, entityDiscoveryClient)
 
+        /*
         val eventSupport = EventingManager.createSupport(config.getConfig("eventing"))
-
-        val (route, eventingGraph) =
-          Serve.createRoute(entities, router, statsCollector, entityDiscoveryClient, descriptors, eventSupport)
+         */
+        val route = Serve.createRoute(entities, router, statsCollector, entityDiscoveryClient, descriptors, Map.empty)
 
         log.debug("Starting gRPC proxy")
 
@@ -264,7 +264,7 @@ class EntityDiscoveryManager(config: EntityDiscoveryManager.Configuration)(
         // Start warmup
         system.actorOf(Warmup.props(spec.entities.exists(_.entityType == EventSourced.name)), "state-manager-warm-up")
 
-        context.become(binding(eventingGraph))
+        context.become(binding(None))
 
       } catch {
         case e @ EntityDiscoveryException(message) =>

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
@@ -498,7 +498,8 @@ object HttpApi {
       result.build()
     }
 
-    private[this] final def transformResponse(grpcRequest: HttpRequest,
+    private[this] final def transformResponse(
+        grpcRequest: HttpRequest,
         futureResponse: Future[(List[HttpHeader], Source[ProtobufAny, NotUsed])]
     ): Future[HttpResponse] = {
       def extractContentTypeFromHttpBody(entityMessage: MessageOrBuilder): ContentType =
@@ -535,7 +536,6 @@ object HttpApi {
         } yield {
           firstMessage match {
             case (Seq(protobuf: ProtobufAny), rest) =>
-
               if (isHttpBodyResponse) {
                 val entityMessage = parseResponseBody(protobuf) // We need to peek-ahead to check the content-type of the response we're sending out
                 Future.successful(

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
@@ -266,7 +266,7 @@ object Serve {
                   (Metadata.defaultInstance, Source(other).concat(rest))
               }
 
-              val headers = metadata.entries.collect {
+              val headers = metadata.entries.iterator.collect {
                 case MetadataEntry(key, MetadataEntry.Value.StringValue(value), _) => RawHeader(key, value)
               }.toList
 

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
@@ -17,35 +17,31 @@
 package io.cloudstate.proxy
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.Success
+import scala.concurrent.{ExecutionContext, Future}
 import scala.annotation.tailrec
-import akka.grpc.scaladsl.{GrpcExceptionHandler, GrpcMarshalling}
-import GrpcMarshalling.{marshalStream, unmarshalStream}
 import akka.grpc.internal.{
   CancellationBarrierGraphStage,
   Codecs,
   GrpcProtocolNative,
   GrpcResponseHelpers,
-  Identity,
   ServerReflectionImpl
 }
 import akka.grpc.scaladsl.headers.`Message-Encoding`
-import akka.{Done, NotUsed}
+import akka.NotUsed
 import akka.grpc.{ProtobufSerializer, Trailers}
-import akka.grpc.javadsl.ServerReflection
-import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.{HttpEntity, HttpHeader, HttpRequest, HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.Uri.Path
 import akka.actor.{ActorRef, ActorSystem}
+import akka.http.scaladsl.model.headers.RawHeader
 import akka.util.ByteString
 import akka.stream.Materializer
-import akka.stream.scaladsl.{Flow, Keep, RunnableGraph, Source}
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.google.protobuf.{ByteString => ProtobufByteString}
 import com.google.protobuf.any.{Any => ProtobufAny}
 import com.google.protobuf.Descriptors.{Descriptor, FileDescriptor, MethodDescriptor}
 import grpc.reflection.v1alpha.reflection.ServerReflectionHandler
 import io.cloudstate.protocol.entity._
-import io.cloudstate.proxy.eventing.{Emitter, Emitters, EventingManager, EventingSupport}
+import io.cloudstate.proxy.eventing.Emitter
 import io.cloudstate.proxy.EntityDiscoveryManager.ServableEntity
 import io.cloudstate.proxy.entity.{UserFunctionCommand, UserFunctionReply}
 import io.cloudstate.proxy.protobuf.Types
@@ -56,6 +52,7 @@ object Serve {
   private final val log = LoggerFactory.getLogger(getClass)
 
   private[this] final val fallback: Any => Any = _ => fallback
+
   private final def checkFallback[B] = fallback.asInstanceOf[Any => B]
 
   private final val Http404Response: Future[HttpResponse] =
@@ -77,7 +74,7 @@ object Serve {
       throw new UnsupportedOperationException("operation not supported")
   }
 
-  final class CommandSerializer(val commandName: String, desc: Descriptor)
+  final class CommandSerializer(val commandName: String, desc: Descriptor, metadata: Metadata)
       extends ProtobufSerializer[UserFunctionCommand] {
     final val commandTypeUrl = Types.AnyTypeUrlHostName + desc.getFullName
 
@@ -87,68 +84,77 @@ object Serve {
     }
 
     override final def deserialize(bytes: ByteString): UserFunctionCommand =
-      parse(ProtobufAny(typeUrl = commandTypeUrl, value = ProtobufByteString.copyFrom(bytes.asByteBuffer)))
+      parse(ProtobufAny(typeUrl = commandTypeUrl, value = ProtobufByteString.copyFrom(bytes.asByteBuffer)), metadata)
 
-    final def parse(any: ProtobufAny): UserFunctionCommand =
-      UserFunctionCommand(name = commandName, payload = Some(any))
+    final def parse(any: ProtobufAny, metadata: Metadata): UserFunctionCommand =
+      UserFunctionCommand(name = commandName, payload = Some(any), metadata = Some(metadata))
   }
 
   final class CommandHandler(final val entity: ServableEntity,
                              final val method: MethodDescriptor,
                              final val router: UserFunctionRouter,
-                             final val emitter: Future[Emitter],
+                             final val emitter: Option[Emitter],
                              final val entityDiscoveryClient: EntityDiscoveryClient,
-                             final val log: Logger) {
+                             final val log: Logger)(implicit ec: ExecutionContext) {
 
     final val fullCommandName: String = entity.serviceName + "." + method.getName
-    final val serializer: CommandSerializer = new CommandSerializer(method.getName, method.getInputType)
     final val unary: Boolean = !method.toProto.getClientStreaming && !method.toProto.getServerStreaming
     final val expectedReplyTypeUrl: String = Types.AnyTypeUrlHostName + method.getOutputType.getFullName
+    final val commandTypeUrl = Types.AnyTypeUrlHostName + method.getInputType.getFullName
 
-    final val flow: Flow[UserFunctionCommand, ProtobufAny, NotUsed] = {
-      val handler = router.handle(entity.serviceName)
+    final def deserialize(metadata: Metadata)(bytes: ByteString): UserFunctionCommand = {
+      val payload = ProtobufAny(typeUrl = commandTypeUrl, value = ProtobufByteString.copyFrom(bytes.asByteBuffer))
+      UserFunctionCommand(name = method.getName, payload = Some(payload), metadata = Some(metadata))
+    }
 
-      val zipWithEmitter = emitter.value match {
-        case Some(Success(e)) => handler.map(v => (e, v)) // Cheaper than mapAsync if already completed
-        case _ => handler.mapAsync(1)(reply => emitter.zip(Future.successful(reply)))
-      }
+    final val handler: Flow[UserFunctionCommand, UserFunctionReply, NotUsed] =
+      router.handle(entity.serviceName)
 
-      zipWithEmitter
+    final val processReplies: Flow[UserFunctionReply, ProtobufAny, NotUsed] = {
+      val handler = Flow[UserFunctionReply]
         .map({
-          case (
-              emitter,
-              UserFunctionReply(Some(ClientAction(ClientAction.Action.Reply(Reply(some @ Some(payload), _)), _)), _, _)
-              ) =>
+          case UserFunctionReply(Some(ClientAction(ClientAction.Action.Reply(reply @ Reply(Some(payload), _, _)), _)),
+                                 _,
+                                 _) =>
             if (payload.typeUrl != expectedReplyTypeUrl) {
               val msg =
-                s"${fullCommandName}: Expected reply type_url to be [${expectedReplyTypeUrl}] but was [${payload.typeUrl}]."
+                s"$fullCommandName: Expected reply type_url to be [$expectedReplyTypeUrl] but was [${payload.typeUrl}]."
               log.warn(msg)
               entityDiscoveryClient.reportError(UserFunctionError(s"Warning: $msg"))
-            } else {
-              val _ = emitter.emit(payload, method) // TODO: check returned boolean?
             }
-            some
-          case (_, UserFunctionReply(Some(ClientAction(ClientAction.Action.Forward(_), _)), _, _)) =>
+            Some(reply)
+          case UserFunctionReply(Some(ClientAction(ClientAction.Action.Forward(_), _)), _, _) =>
             log.error("Cannot serialize forward reply, this should have been handled by the UserFunctionRouter")
             None
-          case (_,
-                UserFunctionReply(Some(ClientAction(ClientAction.Action.Failure(Failure(_, message, _)), _)), _, _)) =>
+          case UserFunctionReply(Some(ClientAction(ClientAction.Action.Failure(Failure(_, message, _)), _)), _, _) =>
             log.error("User Function responded with a failure: {}", message)
             None
           case _ =>
             None
         })
         .collect(Function.unlift(identity))
+
+      emitter match {
+        /*
+        case Some(e) =>
+          handler.mapAsync(4) {
+            case Reply(Some(payload), metadata, _) =>
+              e.emit(payload, method, metadata).map(_ => payload)
+          }
+         */
+        case _ => handler.map(_.payload.get)
+      }
+
     }
   }
 
-  private[proxy] def createResponse(request: HttpRequest, protobufs: Source[ProtobufAny, NotUsed])(
+  private def createResponse(request: HttpRequest, headers: List[HttpHeader], protobufs: Source[ProtobufAny, NotUsed])(
       implicit system: ActorSystem
-  ): Future[HttpResponse] = {
+  ): HttpResponse = {
     val responseWriter = GrpcProtocolNative.newWriter(Codecs.negotiate(request))
-    Future.successful(
+    val response =
       GrpcResponseHelpers(protobufs, Serve.mapRequestFailureExceptions)(Serve.ReplySerializer, responseWriter, system)
-    )
+    response.withHeaders(response.headers ++ headers)
   }
 
   def createRoute(entities: Seq[ServableEntity],
@@ -156,15 +162,23 @@ object Serve {
                   statsCollector: ActorRef,
                   entityDiscoveryClient: EntityDiscoveryClient,
                   fileDescriptors: Seq[FileDescriptor],
-                  eventingSupport: Option[EventingSupport])(
+                  emitters: Map[String, Emitter])(
       implicit sys: ActorSystem,
       mat: Materializer,
       ec: ExecutionContext
-  ): (PartialFunction[HttpRequest, Future[HttpResponse]], Option[RunnableGraph[Future[Done]]]) = {
-    val (grpcProxy, eventingGraph) =
-      createGrpcApi(entities, router, statsCollector, entityDiscoveryClient, eventingSupport)
+  ): PartialFunction[HttpRequest, Future[HttpResponse]] = {
+    val grpcProxy = createGrpcApi(entities, router, statsCollector, entityDiscoveryClient, emitters)
+    val grpcHandler = Function.unlift { request: HttpRequest =>
+      val asResponse = grpcProxy.andThen { futureResult =>
+        Some(futureResult.map {
+          case (headers, messages) =>
+            createResponse(request, headers, messages)
+        })
+      }
+      asResponse.applyOrElse(request, (_: HttpRequest) => None)
+    }
     val routes = Array(
-      GrpcWebSupport.wrapGrpcHandler(grpcProxy),
+      GrpcWebSupport.wrapGrpcHandler(grpcHandler),
       HttpApi.serve(entities.map(_.serviceDescriptor -> grpcProxy).toList),
       handleNetworkProbe(),
       ServerReflectionHandler.partial(
@@ -172,7 +186,7 @@ object Serve {
       )
     )
 
-    ({ // Creates a fast implementation of multi-PartialFunction composition
+    { // Creates a fast implementation of multi-PartialFunction composition
       case req =>
         @tailrec def matchRoutes(req: HttpRequest, idx: Int): Future[HttpResponse] =
           if (idx < routes.length) {
@@ -183,8 +197,9 @@ object Serve {
             log.debug("Not found request: " + req.getUri())
             Http404Response
           }
+
         matchRoutes(req, 0)
-    }, eventingGraph)
+    }
   }
 
   /**
@@ -206,64 +221,62 @@ object Serve {
                                         router: UserFunctionRouter,
                                         statsCollector: ActorRef,
                                         entityDiscoveryClient: EntityDiscoveryClient,
-                                        eventingSupport: Option[EventingSupport])(
+                                        emitters: Map[String, Emitter])(
       implicit sys: ActorSystem,
       mat: Materializer,
       ec: ExecutionContext
-  ): (PartialFunction[HttpRequest, Source[ProtobufAny, NotUsed]], Option[RunnableGraph[Future[Done]]]) = {
-    val p = Promise[Emitter]
-    val eventingGraph =
-      eventingSupport.flatMap(
-        support =>
-          EventingManager
-            .createStreams(router, entityDiscoveryClient, entities, support)
-            .map(_.mapMaterializedValue({ case (emitter, done) => p.success(emitter); done }))
-      ) match {
-        case None =>
-          p.success(Emitters.ignore)
-          None
-        case some =>
-          some
-      }
+  ): PartialFunction[HttpRequest, Future[(List[HttpHeader], Source[ProtobufAny, NotUsed])]] = {
 
     val rpcMethodSerializers = (for {
       entity <- entities.iterator
       method <- entity.serviceDescriptor.getMethods.iterator.asScala
     } yield {
-      val handler = new CommandHandler(entity, method, router, p.future, entityDiscoveryClient, log)
+      val handler =
+        new CommandHandler(entity, method, router, emitters.get(method.getFullName), entityDiscoveryClient, log)
       (Path / entity.serviceName / method.getName, handler)
     }).toMap
 
-    val routes: PartialFunction[HttpRequest, Source[ProtobufAny, NotUsed]] = {
+    val routes: PartialFunction[HttpRequest, Future[(List[HttpHeader], Source[ProtobufAny, NotUsed])]] = {
       case req: HttpRequest if rpcMethodSerializers.contains(req.uri.path) =>
-        val startTime = System.nanoTime()
         val handler = rpcMethodSerializers(req.uri.path)
 
-        // Only report request stats for unary commands, doesn't make sense for streamed
-        val processRequest =
-          if (handler.unary) {
-            statsCollector ! StatsCollector.RequestReceived
-            handler.flow.watchTermination() { (_, complete) =>
-              complete.onComplete { _ =>
-                statsCollector ! StatsCollector.ResponseSent(System.nanoTime() - startTime)
-              }
-              NotUsed
-            }
-          } else {
-            handler.flow
-          }
+        val metadata = Metadata(req.headers.map { header =>
+          MetadataEntry(header.name(), MetadataEntry.Value.StringValue(header.value))
+        })
 
         val reader = GrpcProtocolNative.newReader(Codecs.detect(req).get)
 
         req.entity.dataBytes
           .viaMat(reader.dataFrameDecoder)(Keep.none)
-          .map(handler.serializer.deserialize)
+          .map(handler.deserialize(metadata))
           .via(new CancellationBarrierGraphStage) // In gRPC we signal failure by returning an error code, so we don't want the cancellation bubbled out
-          .via(processRequest)
+          .via(handler.handler)
+          .prefixAndTail(1)
+          .runWith(Sink.head)
+          .map {
+            case (maybeFirstReply, rest) =>
+              val (metadata, replies) = maybeFirstReply match {
+                case Seq(
+                    reply @ UserFunctionReply(Some(ClientAction(ClientAction.Action.Reply(Reply(_, metadata, _)), _)),
+                                              _,
+                                              _)
+                    ) =>
+                  (metadata.getOrElse(Metadata.defaultInstance), Source.single(reply).concat(rest))
+                case other =>
+                  (Metadata.defaultInstance, Source(other).concat(rest))
+              }
+
+              val headers = metadata.entries.collect {
+                case MetadataEntry(key, MetadataEntry.Value.StringValue(value), _) => RawHeader(key, value)
+              }.toList
+
+              (headers, replies.via(handler.processReplies))
+          }
     }
 
-    (routes, eventingGraph)
+    routes
   }
 
   private case class CommandException(msg: String) extends RuntimeException(msg, null, false, false)
+
 }

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/UserFunctionRouter.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/UserFunctionRouter.scala
@@ -19,7 +19,7 @@ package io.cloudstate.proxy
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Sink, Source}
-import io.cloudstate.protocol.entity.{ClientAction, EntityDiscovery, Forward, SideEffect, UserFunctionError}
+import io.cloudstate.protocol.entity.{ClientAction, EntityDiscovery, Forward, Metadata, SideEffect, UserFunctionError}
 import io.cloudstate.proxy.EntityDiscoveryManager.ServableEntity
 import io.cloudstate.proxy.entity.{UserFunctionCommand, UserFunctionReply}
 
@@ -40,11 +40,17 @@ class UserFunctionRouter(val entities: Seq[ServableEntity], entityDiscovery: Ent
 
   final def handle(serviceName: String): Flow[UserFunctionCommand, UserFunctionReply, NotUsed] =
     Flow[UserFunctionCommand].flatMapConcat { command =>
-      routeMessage(Nil, RouteReason.Initial, serviceName, command.name, command.payload, synchronous = true)
+      routeMessage(Nil,
+                   RouteReason.Initial,
+                   serviceName,
+                   command.name,
+                   command.payload,
+                   synchronous = true,
+                   command.metadata)
     }
 
   final def handleUnary(serviceName: String, command: UserFunctionCommand): Future[UserFunctionReply] =
-    routeMessageUnary(Nil, RouteReason.Initial, serviceName, command.name, command.payload)
+    routeMessageUnary(Nil, RouteReason.Initial, serviceName, command.name, command.payload, command.metadata)
 
   private final def route(
       trace: List[(RouteReason, String, String)]
@@ -52,13 +58,15 @@ class UserFunctionRouter(val entities: Seq[ServableEntity], entityDiscovery: Ent
     Flow[UserFunctionReply].flatMapConcat { response =>
       val sideEffects = Source(response.sideEffects.toList)
         .flatMapConcat {
-          case SideEffect(serviceName, commandName, payload, synchronous, _) =>
-            routeMessage(trace, RouteReason.SideEffect, serviceName, commandName, payload, synchronous)
+          case SideEffect(serviceName, commandName, payload, synchronous, metadata, _) =>
+            routeMessage(trace, RouteReason.SideEffect, serviceName, commandName, payload, synchronous, metadata)
         }
 
       val nextAction = response.clientAction match {
-        case Some(ClientAction(ClientAction.Action.Forward(Forward(serviceName, commandName, payload, _)), _)) =>
-          routeMessage(trace, RouteReason.Forwarded, serviceName, commandName, payload, synchronous = true)
+        case Some(
+            ClientAction(ClientAction.Action.Forward(Forward(serviceName, commandName, payload, metadata, _)), _)
+            ) =>
+          routeMessage(trace, RouteReason.Forwarded, serviceName, commandName, payload, synchronous = true, metadata)
         case None | Some(ClientAction(ClientAction.Action.Empty, _)) =>
           Source.empty
         case _ =>
@@ -79,7 +87,8 @@ class UserFunctionRouter(val entities: Seq[ServableEntity], entityDiscovery: Ent
                                                  RouteReason.SideEffect,
                                                  sideEffect.serviceName,
                                                  sideEffect.commandName,
-                                                 sideEffect.payload)
+                                                 sideEffect.payload,
+                                                 sideEffect.metadata)
         if (sideEffect.synchronous) {
           sideEffectFuture
         } else {
@@ -88,8 +97,10 @@ class UserFunctionRouter(val entities: Seq[ServableEntity], entityDiscovery: Ent
       }
     } flatMap { _ =>
       response.clientAction match {
-        case Some(ClientAction(ClientAction.Action.Forward(Forward(serviceName, commandName, payload, _)), _)) =>
-          routeMessageUnary(trace, RouteReason.Forwarded, serviceName, commandName, payload)
+        case Some(
+            ClientAction(ClientAction.Action.Forward(Forward(serviceName, commandName, payload, metadata, _)), _)
+            ) =>
+          routeMessageUnary(trace, RouteReason.Forwarded, serviceName, commandName, payload, metadata)
         case _ =>
           Future.successful(response)
       }
@@ -100,13 +111,14 @@ class UserFunctionRouter(val entities: Seq[ServableEntity], entityDiscovery: Ent
                                  serviceName: String,
                                  commandName: String,
                                  payload: Option[com.google.protobuf.any.Any],
-                                 synchronous: Boolean): Source[UserFunctionReply, NotUsed] = {
+                                 synchronous: Boolean,
+                                 metadata: Option[Metadata]): Source[UserFunctionReply, NotUsed] = {
 
     val source = entityCommands.get(serviceName) match {
       case Some(EntityCommands(_, entitySupport, commands)) =>
         if (commands(commandName)) {
           Source
-            .single(UserFunctionCommand(commandName, payload))
+            .single(UserFunctionCommand(commandName, payload, metadata))
             .via(entitySupport.handler(commandName))
             .via(route((routeReason, serviceName, commandName) :: trace))
         } else {
@@ -131,11 +143,12 @@ class UserFunctionRouter(val entities: Seq[ServableEntity], entityDiscovery: Ent
                                       routeReason: RouteReason,
                                       serviceName: String,
                                       commandName: String,
-                                      payload: Option[com.google.protobuf.any.Any]): Future[UserFunctionReply] =
+                                      payload: Option[com.google.protobuf.any.Any],
+                                      metadata: Option[Metadata]): Future[UserFunctionReply] =
     entityCommands.get(serviceName) match {
       case Some(EntityCommands(_, entitySupport, commands)) =>
         if (commands(commandName)) {
-          entitySupport.handleUnary(UserFunctionCommand(commandName, payload)).flatMap { result =>
+          entitySupport.handleUnary(UserFunctionCommand(commandName, payload, metadata)).flatMap { result =>
             routeUnary((routeReason, serviceName, commandName) :: trace, result)
           }
         } else {

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/UserFunctionTypeSupport.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/UserFunctionTypeSupport.scala
@@ -18,7 +18,7 @@ package io.cloudstate.proxy
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
-import com.google.protobuf.Descriptors.{FieldDescriptor, MethodDescriptor, ServiceDescriptor}
+import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
 import com.google.protobuf.{ByteString, DynamicMessage}
 import io.cloudstate.protocol.entity.Entity
 import io.cloudstate.entity_key.EntityKeyProto
@@ -26,7 +26,7 @@ import io.cloudstate.proxy.entity.{EntityCommand, UserFunctionCommand, UserFunct
 import io.cloudstate.proxy.protobuf.Options
 
 import scala.collection.JavaConverters._
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait UserFunctionTypeSupport {
 
@@ -43,7 +43,7 @@ trait UserFunctionTypeSupportFactory {
 /**
  * Abstract support for any user function type that is entity based (ie, has entity id keys).
  */
-abstract class EntityTypeSupportFactory extends UserFunctionTypeSupportFactory {
+abstract class EntityTypeSupportFactory(implicit ec: ExecutionContext) extends UserFunctionTypeSupportFactory {
   override final def build(entity: Entity, serviceDescriptor: ServiceDescriptor): UserFunctionTypeSupport = {
     require(serviceDescriptor != null,
             "ServiceDescriptor not found, please verify the spelling and package name provided when looking it up")
@@ -69,7 +69,9 @@ private object EntityMethodDescriptor {
 
 final class EntityMethodDescriptor(val method: MethodDescriptor) {
   private[this] val keyFields = method.getInputType.getFields.iterator.asScala
-    .filter(field => EntityKeyProto.entityKey.get(Options.convertFieldOptions(field)))
+    .filter(
+      field => EntityKeyProto.entityKey.get(Options.convertFieldOptions(field))
+    )
     .toArray
     .sortBy(_.getIndex)
 
@@ -91,7 +93,7 @@ final class EntityMethodDescriptor(val method: MethodDescriptor) {
 
 private final class EntityUserFunctionTypeSupport(serviceDescriptor: ServiceDescriptor,
                                                   methodDescriptors: Map[String, EntityMethodDescriptor],
-                                                  entityTypeSupport: EntityTypeSupport)
+                                                  entityTypeSupport: EntityTypeSupport)(implicit ec: ExecutionContext)
     extends UserFunctionTypeSupport {
 
   override def handler(name: String): Flow[UserFunctionCommand, UserFunctionReply, NotUsed] = {
@@ -107,7 +109,8 @@ private final class EntityUserFunctionTypeSupport(serviceDescriptor: ServiceDesc
     EntityCommand(entityId = entityId,
                   name = command.name,
                   payload = command.payload,
-                  streamed = method.method.isServerStreaming)
+                  streamed = method.method.isServerStreaming,
+                  metadata = command.metadata)
   }
 
   private def methodDescriptor(name: String): EntityMethodDescriptor =

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/UserFunctionTypeSupport.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/UserFunctionTypeSupport.scala
@@ -20,9 +20,9 @@ import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
 import com.google.protobuf.{ByteString, DynamicMessage}
-import io.cloudstate.protocol.entity.Entity
+import io.cloudstate.protocol.entity.{Entity, Metadata}
 import io.cloudstate.entity_key.EntityKeyProto
-import io.cloudstate.proxy.entity.{EntityCommand, UserFunctionCommand, UserFunctionReply}
+import io.cloudstate.proxy.entity.{EntityCommand, UserFunctionReply}
 import io.cloudstate.proxy.protobuf.Options
 
 import scala.collection.JavaConverters._
@@ -30,10 +30,40 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait UserFunctionTypeSupport {
 
-  def handler(command: String): Flow[UserFunctionCommand, UserFunctionReply, NotUsed]
+  /**
+   * Get a handler as a Flow.
+   *
+   * This may be used for both unary and streamed calls. If unary, then it would be expected that only one message
+   * is passed to the flow, but if more than one message is passed to the flow, then the implementation should treat
+   * that as multiple unary calls, with replies returned in order.
+   *
+   * There are two types of metadata, stream level metadata, message level metadata. Depending on transport, these
+   * may or may not exist. And depending on the entity type, how these are handled may be different. Stream level
+   * metadata is passed as an argument to this handler, while message level metadata is attached to the
+   * UserFunctionCommand.
+   *
+   * For example, gRPC has metadata associated with the call, not individual messages, so this will be stream level
+   * metadata, passed in the metadata parameter, while the UserFunctionCommand would have empty metadata. Meanwhile,
+   * event sources don't have stream level metadata, but they do have per message metadata, so their metadata will be
+   * attached to the command.
+   *
+   * How implementations handle the metadata depends on the implementation. Entity implementations, where different
+   * messages are sent to different entities, might not have a concept of a stream, and so they should merge the
+   * stream level metadata with the metadata attached to each command before passing it on.
+   */
+  def handler(command: String, metadata: Metadata): Flow[UserFunctionRouter.Message, UserFunctionReply, NotUsed]
 
-  def handleUnary(command: UserFunctionCommand): Future[UserFunctionReply]
+  def handleUnary(command: String, message: UserFunctionRouter.Message): Future[UserFunctionReply]
 
+}
+
+object UserFunctionTypeSupport {
+  def mergeStreamLevelMetadata(metadata: Metadata, command: UserFunctionRouter.Message) =
+    if (metadata.entries.nonEmpty) {
+      command.copy(
+        metadata = Metadata(metadata.entries ++ command.metadata.entries)
+      )
+    } else command
 }
 
 trait UserFunctionTypeSupportFactory {
@@ -96,21 +126,23 @@ private final class EntityUserFunctionTypeSupport(serviceDescriptor: ServiceDesc
                                                   entityTypeSupport: EntityTypeSupport)(implicit ec: ExecutionContext)
     extends UserFunctionTypeSupport {
 
-  override def handler(name: String): Flow[UserFunctionCommand, UserFunctionReply, NotUsed] = {
+  override def handler(name: String,
+                       metadata: Metadata): Flow[UserFunctionRouter.Message, UserFunctionReply, NotUsed] = {
     val method = methodDescriptor(name)
-    Flow[UserFunctionCommand].map(ufToEntityCommand(method)).via(entityTypeSupport.handler(method))
+    Flow[UserFunctionRouter.Message].map(ufToEntityCommand(method)).via(entityTypeSupport.handler(method, metadata))
   }
 
-  override def handleUnary(command: UserFunctionCommand): Future[UserFunctionReply] =
-    entityTypeSupport.handleUnary(ufToEntityCommand(methodDescriptor(command.name))(command))
+  override def handleUnary(commandName: String, message: UserFunctionRouter.Message): Future[UserFunctionReply] =
+    entityTypeSupport.handleUnary(ufToEntityCommand(methodDescriptor(commandName))(message))
 
-  private def ufToEntityCommand(method: EntityMethodDescriptor): UserFunctionCommand => EntityCommand = { command =>
-    val entityId = method.extractId(command.payload.fold(ByteString.EMPTY)(_.value))
-    EntityCommand(entityId = entityId,
-                  name = command.name,
-                  payload = command.payload,
-                  streamed = method.method.isServerStreaming,
-                  metadata = command.metadata)
+  private def ufToEntityCommand(method: EntityMethodDescriptor): UserFunctionRouter.Message => EntityCommand = {
+    command =>
+      val entityId = method.extractId(command.payload.value)
+      EntityCommand(entityId = entityId,
+                    name = method.method.getName,
+                    payload = Some(command.payload),
+                    streamed = method.method.isServerStreaming,
+                    metadata = Some(command.metadata))
   }
 
   private def methodDescriptor(name: String): EntityMethodDescriptor =
@@ -121,8 +153,18 @@ private final class EntityUserFunctionTypeSupport(serviceDescriptor: ServiceDesc
 
 trait EntityTypeSupport {
 
-  def handler(methodDescriptor: EntityMethodDescriptor): Flow[EntityCommand, UserFunctionReply, NotUsed]
+  def handler(methodDescriptor: EntityMethodDescriptor,
+              metadata: Metadata): Flow[EntityCommand, UserFunctionReply, NotUsed]
 
   def handleUnary(command: EntityCommand): Future[UserFunctionReply]
 
+}
+
+object EntityTypeSupport {
+  def mergeStreamLevelMetadata(metadata: Metadata, command: EntityCommand) =
+    if (metadata.entries.nonEmpty) {
+      command.copy(
+        metadata = Some(Metadata(command.metadata.fold(metadata.entries)(m => metadata.entries ++ m.entries)))
+      )
+    } else command
 }

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/crdt/CrdtEntity.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/crdt/CrdtEntity.scala
@@ -590,7 +590,7 @@ final class CrdtEntity(client: Crdt, configuration: CrdtEntity.Configuration, en
     case Deleted(_) =>
     // Ignore, we know.
 
-    case EntityCommand(_, _, _, streamed, _) =>
+    case EntityCommand(_, _, _, streamed, _, _) =>
       val reply = UserFunctionReply(
         Some(ClientAction(ClientAction.Action.Failure(Failure(description = "Entity deleted"))))
       )

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/eventing/EventingManager.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/eventing/EventingManager.scala
@@ -52,6 +52,7 @@ trait EventingSupport {
 
 object EventingManager {
 
+  /* Commented out temporarily while projection support is developed
   final val log = LoggerFactory.getLogger("EventingManager")
 
   final case class EventMapping private (entity: ServableEntity, routes: Map[MethodDescriptor, Eventing])
@@ -215,4 +216,6 @@ object EventingManager {
             })
         )
     }
+
+ */
 }

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/eventing/EventingManager.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/eventing/EventingManager.scala
@@ -24,7 +24,7 @@ import io.cloudstate.protocol.entity.{ClientAction, EntityDiscoveryClient, Failu
 import io.cloudstate.proxy.{Serve, UserFunctionRouter}
 import io.cloudstate.proxy.EntityDiscoveryManager.ServableEntity
 import io.cloudstate.proxy.protobuf.{Options, Types}
-import io.cloudstate.proxy.entity.{UserFunctionCommand, UserFunctionReply}
+import io.cloudstate.proxy.entity.UserFunctionReply
 import io.cloudstate.eventing.{Eventing, EventingProto}
 import com.google.protobuf.any.{Any => ProtobufAny}
 import com.google.protobuf.Descriptors.MethodDescriptor
@@ -45,177 +45,178 @@ object Emitters {
   }
 }
 
+/* Commented out temporarily while projection support is developed
+
 trait EventingSupport {
-  def createSource(sourceName: String, handler: CommandHandler): Source[UserFunctionCommand, Future[Cancellable]]
-  def createDestination(destinationName: String, handler: CommandHandler): Flow[ProtobufAny, AnyRef, NotUsed]
+def createSource(sourceName: String, handler: CommandHandler): Source[UserFunctionCommand, Future[Cancellable]]
+def createDestination(destinationName: String, handler: CommandHandler): Flow[ProtobufAny, AnyRef, NotUsed]
 }
 
 object EventingManager {
 
-  /* Commented out temporarily while projection support is developed
-  final val log = LoggerFactory.getLogger("EventingManager")
+final val log = LoggerFactory.getLogger("EventingManager")
 
-  final case class EventMapping private (entity: ServableEntity, routes: Map[MethodDescriptor, Eventing])
+final case class EventMapping private (entity: ServableEntity, routes: Map[MethodDescriptor, Eventing])
 
-  private val noEmitter = Future.successful(Emitters.ignore)
+private val noEmitter = Future.successful(Emitters.ignore)
 
-  // Contains all entities which has at least one endpoint which accepts events
-  def createEventMappings(entities: Seq[ServableEntity]): Seq[EventMapping] =
-    entities.flatMap { entity =>
-      val endpoints =
-        entity.serviceDescriptor.getMethods.iterator.asScala.foldLeft(Map.empty[MethodDescriptor, Eventing]) {
-          case (map, method) =>
-            EventingProto.eventing.get(Options.convertMethodOptions(method)) match {
-              case None => map
-              case Some(e) =>
-                (e.in, e.out) match {
-                  case (null, null) | ("", "") => map
-                  case (in, out) if in == out =>
-                    throw new IllegalStateException(
-                      s"Endpoint '${method.getFullName}' has the same input topic as output topic ('${in}'), this is not allowed."
-                    )
-                  case (in, out) =>
-                    log.debug("EventingProto.events for {}: {} -> {}",
-                              method.getFullName: AnyRef,
-                              in: AnyRef,
-                              out: AnyRef)
-                    map.updated(method, e)
-                }
-            }
-        }
-
-      if (endpoints.isEmpty) Nil
-      else List(EventMapping(entity, endpoints))
-    }
-
-  def createSupport(eventConfig: Config)(implicit materializer: Materializer): Option[EventingSupport] =
-    eventConfig.getString("support") match {
-      case "none" =>
-        log.info("Eventing support turned off in configuration")
-        None
-      case s @ "google-pubsub" =>
-        log.info("Creating google-pubsub eventing support")
-        Some(new GCPubsubEventingSupport(eventConfig.getConfig(s), materializer))
-      case other =>
-        throw new IllegalStateException(s"Check your configuration. There is no eventing support named: $other")
-    }
-
-  def createStreams(router: UserFunctionRouter,
-                    entityDiscoveryClient: EntityDiscoveryClient,
-                    entities: Seq[ServableEntity],
-                    support: EventingSupport): Option[RunnableGraph[(Emitter, Future[Done])]] =
-    createEventMappings(entities) match {
-      case Nil => None
-      case eventMappings =>
-        val allEligibleOutputsByMethodDescriptor =
-          eventMappings
-            .flatMap(_.routes.collect {
-              case (m, e) if e.out != "" => (m.getFullName, e.out)
-            })
-            .toMap
-
-        type TopicName = String
-        type Record = (TopicName, ProtobufAny)
-
-        val inNOutBurger: Seq[
-          (Option[(TopicName, Source[Record, Future[Cancellable]])], Option[(TopicName, Flow[Record, AnyRef, NotUsed])])
-        ] =
-          for {
-            EventMapping(entity, routes) <- eventMappings
-            (mdesc, eventing) <- routes.toSeq // Important since we do not want dedupe that we get from the map otherwise
-          } yield {
-            log.info("Creating route for {}", eventing)
-            val commandHandler = new CommandHandler(entity, mdesc, router, noEmitter, entityDiscoveryClient, log) // Could we reuse these from Serve?
-
-            val in = Option(eventing.in).collect({
-              case topic if topic != "" =>
-                val source =
-                  support
-                    .createSource(topic, commandHandler)
-                    .via(commandHandler.flow)
-                    .collect({ case any if eventing.out != "" => (eventing.out, any) }) //Without an out there is nothing to persist
-                (topic, source)
-            })
-
-            val out = Option(eventing.out).collect({
-              case topic if topic != "" =>
-                val dest = Flow[Record]
-                  .map(_._2)
-                  .via(support.createDestination(topic, commandHandler))
-                  .dropWhile(_ => true)
-                (topic, dest)
-            })
-
-            (in, out)
+// Contains all entities which has at least one endpoint which accepts events
+def createEventMappings(entities: Seq[ServableEntity]): Seq[EventMapping] =
+  entities.flatMap { entity =>
+    val endpoints =
+      entity.serviceDescriptor.getMethods.iterator.asScala.foldLeft(Map.empty[MethodDescriptor, Eventing]) {
+        case (map, method) =>
+          EventingProto.eventing.get(Options.convertMethodOptions(method)) match {
+            case None => map
+            case Some(e) =>
+              (e.in, e.out) match {
+                case (null, null) | ("", "") => map
+                case (in, out) if in == out =>
+                  throw new IllegalStateException(
+                    s"Endpoint '${method.getFullName}' has the same input topic as output topic ('${in}'), this is not allowed."
+                  )
+                case (in, out) =>
+                  log.debug("EventingProto.events for {}: {} -> {}",
+                            method.getFullName: AnyRef,
+                            in: AnyRef,
+                            out: AnyRef)
+                  map.updated(method, e)
+              }
           }
+      }
 
-        val sources = inNOutBurger.collect({ case (Some(in), _) => in })
+    if (endpoints.isEmpty) Nil
+    else List(EventMapping(entity, endpoints))
+  }
 
-        val deadLetters =
-          Flow[Record]
-            .map({
-              case (topic, msg) =>
-                log.warn(
-                  s"Message destined for eventing topic '${topic}' discarded since no such topic is found in the configuration."
-                )
-                msg
-            })
-            .dropWhile(_ => true)
+def createSupport(eventConfig: Config)(implicit materializer: Materializer): Option[EventingSupport] =
+  eventConfig.getString("support") match {
+    case "none" =>
+      log.info("Eventing support turned off in configuration")
+      None
+    case s @ "google-pubsub" =>
+      log.info("Creating google-pubsub eventing support")
+      Some(new GCPubsubEventingSupport(eventConfig.getConfig(s), materializer))
+    case other =>
+      throw new IllegalStateException(s"Check your configuration. There is no eventing support named: $other")
+  }
 
-        val destinations =
-          ("", deadLetters) +: inNOutBurger.collect({ case (_, Some(out)) => out })
+def createStreams(router: UserFunctionRouter,
+                  entityDiscoveryClient: EntityDiscoveryClient,
+                  entities: Seq[ServableEntity],
+                  support: EventingSupport): Option[RunnableGraph[(Emitter, Future[Done])]] =
+  createEventMappings(entities) match {
+    case Nil => None
+    case eventMappings =>
+      val allEligibleOutputsByMethodDescriptor =
+        eventMappings
+          .flatMap(_.routes.collect {
+            case (m, e) if e.out != "" => (m.getFullName, e.out)
+          })
+          .toMap
 
-        val emitter =
-          Source.queue[Record](destinations.size * 128, OverflowStrategy.backpressure)
+      type TopicName = String
+      type Record = (TopicName, ProtobufAny)
 
-        val destinationMap = destinations.map(_._1).sorted.zipWithIndex.toMap
-        val destinationSelector =
-          (r: Record) => destinationMap.get(r._1).getOrElse(destinationMap("")) // Send to deadLetters if no match
+      val inNOutBurger: Seq[
+        (Option[(TopicName, Source[Record, Future[Cancellable]])], Option[(TopicName, Flow[Record, AnyRef, NotUsed])])
+      ] =
+        for {
+          EventMapping(entity, routes) <- eventMappings
+          (mdesc, eventing) <- routes.toSeq // Important since we do not want dedupe that we get from the map otherwise
+        } yield {
+          log.info("Creating route for {}", eventing)
+          val commandHandler = new CommandHandler(entity, mdesc, router, noEmitter, entityDiscoveryClient, log) // Could we reuse these from Serve?
 
-        val eventingFlow = Flow
-          .fromGraph(GraphDSL.create() { implicit b =>
-            import GraphDSL.Implicits._
-
-            val mergeForPublish = b.add(Merge[Record](sources.size + 1)) // 1 + for emitter
-
-            val routeToDestination =
-              b.add(Partition[Record](destinations.size, destinationSelector))
-
-            val mergeForExit = b.add(Merge[AnyRef](destinations.size))
-
-            sources.zipWithIndex foreach {
-              case ((topicName, source), idx) =>
-                b.add(source).out ~> mergeForPublish.in(idx + 1) // 0 we keep for emitter
-            }
-
-            mergeForPublish.out ~> routeToDestination.in
-
-            destinations foreach {
-              case (topicName, flow) =>
-                routeToDestination.out(destinationMap(topicName)) ~> b.add(flow) ~> mergeForExit
-            }
-
-            FlowShape(mergeForPublish.in(0), mergeForExit.out)
+          val in = Option(eventing.in).collect({
+            case topic if topic != "" =>
+              val source =
+                support
+                  .createSource(topic, commandHandler)
+                  .via(commandHandler.flow)
+                  .collect({ case any if eventing.out != "" => (eventing.out, any) }) //Without an out there is nothing to persist
+              (topic, source)
           })
 
-        Some(
-          emitter
-            .via(eventingFlow)
-            .toMat(Sink.ignore)((queue, future) => {
-              val emitter = new Emitter {
-                override def emit(event: ProtobufAny, method: MethodDescriptor): Boolean =
-                  if (event.value.isEmpty) false
-                  else {
-                    allEligibleOutputsByMethodDescriptor
-                      .get(method.getFullName) // FIXME Check expected type of event compared to method.getOutputType
-                      .map(out => queue.offer((out, event))) // FIXME handle this Future
-                      .isDefined
-                  }
-              }
-              (emitter, future)
-            })
-        )
-    }
+          val out = Option(eventing.out).collect({
+            case topic if topic != "" =>
+              val dest = Flow[Record]
+                .map(_._2)
+                .via(support.createDestination(topic, commandHandler))
+                .dropWhile(_ => true)
+              (topic, dest)
+          })
+
+          (in, out)
+        }
+
+      val sources = inNOutBurger.collect({ case (Some(in), _) => in })
+
+      val deadLetters =
+        Flow[Record]
+          .map({
+            case (topic, msg) =>
+              log.warn(
+                s"Message destined for eventing topic '${topic}' discarded since no such topic is found in the configuration."
+              )
+              msg
+          })
+          .dropWhile(_ => true)
+
+      val destinations =
+        ("", deadLetters) +: inNOutBurger.collect({ case (_, Some(out)) => out })
+
+      val emitter =
+        Source.queue[Record](destinations.size * 128, OverflowStrategy.backpressure)
+
+      val destinationMap = destinations.map(_._1).sorted.zipWithIndex.toMap
+      val destinationSelector =
+        (r: Record) => destinationMap.get(r._1).getOrElse(destinationMap("")) // Send to deadLetters if no match
+
+      val eventingFlow = Flow
+        .fromGraph(GraphDSL.create() { implicit b =>
+          import GraphDSL.Implicits._
+
+          val mergeForPublish = b.add(Merge[Record](sources.size + 1)) // 1 + for emitter
+
+          val routeToDestination =
+            b.add(Partition[Record](destinations.size, destinationSelector))
+
+          val mergeForExit = b.add(Merge[AnyRef](destinations.size))
+
+          sources.zipWithIndex foreach {
+            case ((topicName, source), idx) =>
+              b.add(source).out ~> mergeForPublish.in(idx + 1) // 0 we keep for emitter
+          }
+
+          mergeForPublish.out ~> routeToDestination.in
+
+          destinations foreach {
+            case (topicName, flow) =>
+              routeToDestination.out(destinationMap(topicName)) ~> b.add(flow) ~> mergeForExit
+          }
+
+          FlowShape(mergeForPublish.in(0), mergeForExit.out)
+        })
+
+      Some(
+        emitter
+          .via(eventingFlow)
+          .toMat(Sink.ignore)((queue, future) => {
+            val emitter = new Emitter {
+              override def emit(event: ProtobufAny, method: MethodDescriptor): Boolean =
+                if (event.value.isEmpty) false
+                else {
+                  allEligibleOutputsByMethodDescriptor
+                    .get(method.getFullName) // FIXME Check expected type of event compared to method.getOutputType
+                    .map(out => queue.offer((out, event))) // FIXME handle this Future
+                    .isDefined
+                }
+            }
+            (emitter, future)
+          })
+      )
+  }
+}
 
  */
-}

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/eventing/GooglePubsubEventing.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/eventing/GooglePubsubEventing.scala
@@ -16,6 +16,7 @@
 
 package io.cloudstate.proxy.eventing
 
+/*
 import com.typesafe.config.{Config, ConfigFactory}
 import akka.NotUsed
 import akka.actor.{ActorSystem, Cancellable}
@@ -85,24 +86,24 @@ final class PubSubSettings private (
   }
 
   /**
-   * Endpoint hostname where the gRPC connection is made.
-   */
+ * Endpoint hostname where the gRPC connection is made.
+ */
   def withHost(host: String): PubSubSettings = copy(host = host)
 
   /**
-   * Endpoint port where the gRPC connection is made.
-   */
+ * Endpoint port where the gRPC connection is made.
+ */
   def withPort(port: Int): PubSubSettings = copy(port = port)
 
   /**
-   * A filename on the classpath which contains the root certificate authority
-   * that is going to be used to verify certificate presented by the gRPC endpoint.
-   */
+ * A filename on the classpath which contains the root certificate authority
+ * that is going to be used to verify certificate presented by the gRPC endpoint.
+ */
   def withRootCa(rootCa: String): PubSubSettings = copy(rootCa = Some(rootCa))
 
   /**
-   * Credentials that are going to be used for gRPC call authorization.
-   */
+ * Credentials that are going to be used for gRPC call authorization.
+ */
   def withCallCredentials(callCredentials: gRPCCallCredentials): PubSubSettings =
     copy(callCredentials = Some(callCredentials))
 
@@ -113,8 +114,8 @@ final class PubSubSettings private (
     new PubSubSettings(host, port, rootCa, callCredentials)
 
   /**
-   * Creates a GrpcClientSettings from this PubSubSettings
-   */
+ * Creates a GrpcClientSettings from this PubSubSettings
+ */
   def createClientSettings()(implicit sys: ActorSystem): GrpcClientSettings = {
     val sslConfig = rootCa.fold("") { rootCa =>
       s"""
@@ -350,3 +351,4 @@ class GCPubsubEventingSupport(config: Config, materializer: Materializer) extend
       }
     }
 }
+ */

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/function/StatelessFunctionSupportFactory.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/function/StatelessFunctionSupportFactory.scala
@@ -21,13 +21,13 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.event.Logging
 import akka.grpc.GrpcClientSettings
 import akka.stream.Materializer
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{Flow, Source}
 import akka.util.Timeout
-import com.google.protobuf.Descriptors.ServiceDescriptor
-import io.cloudstate.protocol.entity.{ClientAction, Entity}
+import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
+import io.cloudstate.protocol.entity.{ClientAction, Entity, Metadata}
 import io.cloudstate.proxy._
 import io.cloudstate.protocol.function._
-import io.cloudstate.proxy.entity.{EntityCommand, UserFunctionReply}
+import io.cloudstate.proxy.entity.UserFunctionReply
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConverters._
@@ -37,87 +37,96 @@ class StatelessFunctionSupportFactory(system: ActorSystem,
                                       grpcClientSettings: GrpcClientSettings,
                                       concurrencyEnforcer: ActorRef,
                                       statsCollector: ActorRef)(implicit ec: ExecutionContext, mat: Materializer)
-    extends EntityTypeSupportFactory {
+    extends UserFunctionTypeSupportFactory {
 
   private final val log = Logging.getLogger(system, this.getClass)
 
   private final val statelessFunctionClient = StatelessFunctionClient(grpcClientSettings)(system)
 
-  override def buildEntityTypeSupport(entity: Entity,
-                                      serviceDescriptor: ServiceDescriptor,
-                                      methodDescriptors: Map[String, EntityMethodDescriptor]): EntityTypeSupport = {
+  override def build(entity: Entity, serviceDescriptor: ServiceDescriptor): UserFunctionTypeSupport = {
     log.debug("Starting StatelessFunction entity for {}", entity.persistenceId)
 
-    validate(serviceDescriptor, methodDescriptors)
+    val methodDescriptors = serviceDescriptor.getMethods.asScala.map { method =>
+      method.getName -> method
+    }.toMap
 
     new StatelessFunctionSupport(entity.serviceName,
+                                 methodDescriptors,
                                  statelessFunctionClient,
                                  config.proxyParallelism,
                                  config.relayTimeout,
                                  ec)
   }
-
-  private[this] final def validate(serviceDescriptor: ServiceDescriptor,
-                                   methodDescriptors: Map[String, EntityMethodDescriptor]): Unit = ()
 }
 
 private final class StatelessFunctionSupport(serviceName: String,
+                                             methodDescriptors: Map[String, MethodDescriptor],
                                              statelessFunctionClient: StatelessFunctionClient,
                                              parallelism: Int,
                                              private implicit val relayTimeout: Timeout,
                                              private implicit val ec: ExecutionContext)
-    extends EntityTypeSupport {
-  import akka.pattern.ask
+    extends UserFunctionTypeSupport {
 
-  private final val unaryFlow =
-    Flow[EntityCommand].mapAsync(1)(handleUnary)
+  private def methodDescriptor(name: String): MethodDescriptor =
+    methodDescriptors.getOrElse(name, throw EntityDiscoveryException(s"Unknown command $name on service $serviceName"))
 
-  private final val streamOutFlow =
-    Flow[EntityCommand]
+  private def unaryFlow(commandName: String, metadata: Metadata) =
+    Flow[UserFunctionRouter.Message]
+      .mapAsync(1)(
+        message => handleUnary(commandName, UserFunctionTypeSupport.mergeStreamLevelMetadata(metadata, message))
+      )
+
+  private def streamOutFlow(commandName: String, metadata: Metadata) =
+    Flow[UserFunctionRouter.Message]
       .flatMapConcat(
-        ec =>
+        message =>
           statelessFunctionClient
-            .handleStreamedOut(entityCommandToFunctionCommand(ec))
+            .handleStreamedOut(
+              convertUnaryIn(commandName, UserFunctionTypeSupport.mergeStreamLevelMetadata(metadata, message))
+            )
             .map(functionReplyToUserFunctionReply)
       )
 
-  private final val streamInFlow =
-    Flow
-      .setup[EntityCommand, UserFunctionReply, NotUsed] { (mat, attr) =>
-        implicit val materializer = mat
+  private def streamInFlow(commandName: String, metadata: Metadata) =
+    sourceToSourceToFlow((in: Source[UserFunctionRouter.Message, NotUsed]) => {
+      Source.future(statelessFunctionClient.handleStreamedIn(convertStreamIn(commandName, metadata, in)))
+    }).map(functionReplyToUserFunctionReply)
 
-        val (outSubscriber, outSource) = Source.asSubscriber[FunctionCommand].preMaterialize()
-        val outSink = Flow[EntityCommand].map(entityCommandToFunctionCommand).to(Sink.fromSubscriber(outSubscriber))
+  private def streamedFlow(commandName: String, metadata: Metadata) =
+    sourceToSourceToFlow(
+      (in: Source[UserFunctionRouter.Message, NotUsed]) =>
+        statelessFunctionClient.handleStreamed(convertStreamIn(commandName, metadata, in))
+    ).map(functionReplyToUserFunctionReply)
 
-        val inSource =
-          Source.fromFuture(statelessFunctionClient.handleStreamedIn(outSource)).map(functionReplyToUserFunctionReply)
+  private def convertStreamIn(commandName: String,
+                              metadata: Metadata,
+                              in: Source[UserFunctionRouter.Message, NotUsed]): Source[FunctionCommand, NotUsed] =
+    Source
+      .single(
+        FunctionCommand(
+          serviceName = serviceName,
+          name = commandName,
+          metadata = Some(metadata)
+        )
+      )
+      .concat(
+        in.map { message =>
+          FunctionCommand(
+            payload = Some(message.payload),
+            metadata = Some(message.metadata)
+          )
+        }
+      )
 
-        Flow.fromSinkAndSource(outSink, inSource)
-      }
-      .mapMaterializedValue(_ => NotUsed)
-
-  private final val streamedFlow = Flow
-    .setup[EntityCommand, UserFunctionReply, NotUsed] { (mat, attr) =>
-      implicit val materializer = mat
-
-      val (outSubscriber, outSource) = Source.asSubscriber[FunctionCommand].preMaterialize()
-      val outSink = Flow[EntityCommand].map(entityCommandToFunctionCommand).to(Sink.fromSubscriber(outSubscriber))
-
-      val (publisher, inSink) = Sink.asPublisher[FunctionReply](false).preMaterialize()
-      val inSource = Source.fromPublisher(publisher).map(functionReplyToUserFunctionReply)
-
-      statelessFunctionClient.handleStreamed(outSource).runWith(inSink)
-      Flow.fromSinkAndSource(outSink, inSource)
-    }
-    .mapMaterializedValue(_ => NotUsed)
-
-  override final def handler(method: EntityMethodDescriptor): Flow[EntityCommand, UserFunctionReply, NotUsed] = {
-    val streamIn = method.method.isClientStreaming
-    val streamOut = method.method.isServerStreaming
-    if (streamIn && streamOut) streamedFlow
-    else if (streamIn) streamInFlow
-    else if (streamOut) streamOutFlow
-    else unaryFlow
+  override def handler(commandName: String,
+                       metadata: Metadata): Flow[UserFunctionRouter.Message, UserFunctionReply, NotUsed] = {
+    val method = methodDescriptor(commandName)
+    val streamIn = method.isClientStreaming
+    val streamOut = method.isServerStreaming
+    if (streamIn && streamOut) streamedFlow(commandName, metadata)
+    else if (streamIn) streamInFlow(commandName, metadata)
+    else if (streamOut) streamOutFlow(commandName, metadata)
+    else unaryFlow(commandName, metadata)
   }
 
   private def functionReplyToUserFunctionReply(reply: FunctionReply): UserFunctionReply = {
@@ -134,19 +143,20 @@ private final class StatelessFunctionSupport(serviceName: String,
     )
   }
 
-  private def entityCommandToFunctionCommand(command: EntityCommand): FunctionCommand =
+  private def convertUnaryIn(commandName: String, message: UserFunctionRouter.Message): FunctionCommand =
     FunctionCommand(
       serviceName = serviceName,
-      name = command.name,
-      payload = command.payload
+      name = commandName,
+      payload = Some(message.payload),
+      metadata = Some(message.metadata)
     )
 
-  override final def handleUnary(entityCommand: EntityCommand): Future[UserFunctionReply] =
-    if (entityCommand.streamed) {
-      throw new IllegalStateException("Request streaming is not yet supported for StatelessFunctions")
-    } else {
-      statelessFunctionClient
-        .handleUnary(entityCommandToFunctionCommand(entityCommand))
-        .map(functionReplyToUserFunctionReply)
-    }
+  override def handleUnary(commandName: String, message: UserFunctionRouter.Message): Future[UserFunctionReply] =
+    statelessFunctionClient
+      .handleUnary(convertUnaryIn(commandName, message))
+      .map(functionReplyToUserFunctionReply)
+
+  private def sourceToSourceToFlow[In, Out, MOut](f: Source[In, NotUsed] => Source[Out, MOut]): Flow[In, Out, NotUsed] =
+    Flow[In].prefixAndTail(0).flatMapConcat { case (Nil, in) => f(in) }
+
 }

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/HttpApiSpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/HttpApiSpec.scala
@@ -16,24 +16,12 @@
 
 package io.cloudstate.proxy
 
-import akka.actor.ActorRef
-
-import scala.concurrent.duration._
-import akka.{ConfigurationException, Done, NotUsed}
-import akka.util.Timeout
+import akka.ConfigurationException
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.stream.scaladsl.Flow
 import org.scalatest._
-import akka.testkit.TestProbe
 import io.cloudstate.proxy.test._
-import com.google.protobuf.Descriptors.{FileDescriptor, ServiceDescriptor}
-import com.google.protobuf.empty.Empty
-import io.cloudstate.protocol.entity.{EntityDiscovery, EntityDiscoveryClient, EntitySpec, ProxyInfo, UserFunctionError}
-import io.cloudstate.proxy.EntityDiscoveryManager.ServableEntity
+import com.google.protobuf.Descriptors.FileDescriptor
 import io.cloudstate.proxy.PathTemplateParser.PathTemplateParseException
-import io.cloudstate.proxy.entity.{UserFunctionCommand, UserFunctionReply}
-
-import scala.concurrent.Future
 
 class HttpApiSpec extends WordSpec with MustMatchers with ScalatestRouteTest {
 

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/crdt/AbstractCrdtEntitySpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/crdt/AbstractCrdtEntitySpec.scala
@@ -200,7 +200,7 @@ abstract class AbstractCrdtEntitySpec
 
   protected def expectCommand(name: String, payload: ProtoAny, streamed: Boolean = false): Long =
     inside(toUserFunction.expectMsgType[CrdtStreamIn].message) {
-      case CrdtStreamIn.Message.Command(Command(eid, cid, n, p, s, _)) =>
+      case CrdtStreamIn.Message.Command(Command(eid, cid, n, p, s, _, _)) =>
         eid should ===(entityId)
         n should ===(name)
         p shouldBe Some(payload)

--- a/proxy/proxy-tests/src/test/scala/io/cloudstate/proxy/eventing/GooglePubsubSpec.scala
+++ b/proxy/proxy-tests/src/test/scala/io/cloudstate/proxy/eventing/GooglePubsubSpec.scala
@@ -42,7 +42,7 @@ import io.cloudstate.javasupport.{CloudState, CloudStateRunner}
  `docker run --rm --expose=8085 --volume=/data --name=googlepubsub -d -p 8085:8085 google/cloud-sdk:latest /bin/sh -c "gcloud beta emulators pubsub start --project=test --host-port=0.0.0.0:8085 --data-dir=/data"`
  */
 class GooglePubsubSpec extends WordSpec with BeforeAndAfterAll with Eventually with Matchers with ScalaFutures {
-
+  /*
   lazy val projectId = System.getenv("PUBSUB_PROJECT_ID")
 
   final def runTheseTests: Boolean = projectId != null
@@ -135,4 +135,6 @@ class GooglePubsubSpec extends WordSpec with BeforeAndAfterAll with Eventually w
     try socket.getLocalPort
     finally socket.close()
   }
+
+ */
 }


### PR DESCRIPTION
This adds metadata support to the proxy, and also modifies the contract in the protocol for stateless functions.

This PR has been pulled out of the projections PR, in an effort to try and simplify that PR. Eventing support has been completely disabled in this PR (large parts of code are commented out), when the projections PR is merged, that will include all the necessary changes to eventing to make it work with the changes to everything else in this PR.  

What has been done:

* Metadata support added to protocols and proxy
* No user function support libraries have been modified. The metadata has been added to the protocol in a backwards compatible way, so they shouldn't need to be updated.
* The one exception to this is streaming support for stateless functions in JavaScript, but that needs rewriting anyway, and I have those changes ready for a future PR, so I'm not too concerned about that.