### PR TITLE
Set up artifact publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,14 @@ env:
   - secure: "DCmB7Mq1Dl+/rDl46RVQplSoyC5nS1jkGf8OYoRG7lfc0fDj4ZPDSy6nEQX9BGUY0uJmmr77ojQWvnx0tHeXs6Ci4lHftJ7nmC1pttRmezbhjj5YRdYB7xfe1I2vT7qOhcv+qAHjAteXNxoLqqomp49ov2hzwsfesCbyKlJ3EtLyyWldUgOGad66VBgsVJjkXkarXngM1VEty/GINheSwNVaeF9aiX4eY/GksHKUNFn3N4vvubU9VlGHVjBAbPDXUp81L1rlkOHgSgKtehHy/FpcsHeStAoZMNNDCfnK0CKHCtKEJ8FhYKAwQR8WIEYU8cMjSYQVP0UQaC7mH//RwMECPEXZi8uB1mryIwfHu3l6AlIMh9tz9mgrZxSsX4Qba/v5IiM7hD4/IZCi83qCru1DPYBmd37LvUPWRB3m9tApxlDE+gspBFrqIc2u4524lLkWzu/gvsJam/VUDnrdmiJZblJi/XM+6FEo32o/aEiXi6l/cxDAu2kHJIO4MblSXvMu4hl69XTG/q9vc3rtkfVrzTtHJt2LWFNsHzN0odUH4FYmQz0bcqjBc6gI0elnM2gD+7EpxyAMNNBnAZ/oV7ktpfpmbc0/W7kw0t9f4kiYYR3ebO/efmuuIlFC1nJs2ouXVvuzP1GcMkq6lExpD4Fqulf1RXmDHcruj3Cr5a4="
   # DockerHub password for cloudstatebot
   - secure: "3YFGW7bUil+CFQSbgjCSMnFezWIGFdv6/eaNlKKhaxOueDoLmVrLqNhCXkS2Nz3f4tvPFzDN9VH3RyzEIG1u53nQvMw7vceV5szj4oyM4pGZ3TnugtEQFfRHJsUFAWFuRTr9etukBlxCo8HHT3FvcM5uKYQAmBt23wO/NuF8hFXDYQ6c6WHTvP6gzLP5lG70fVJ3ViA1QZEfOaEnOJNqknFtmGj8j0pQTE8oxXTSz61KDBzN3C9PtupDo2Xj0dtpurSZnGRt4BJYoBJkgBiQQJ0W/p5YWGHewdyV12/GgafhkyrPkSx02iOsq3yJrnX238xP/2QQCpMTtZ1lVMQsdXYmpX40hCoEXdxG1qlhH4ISNtXmck1J1VMRVg+sg8+PyFlRZObKcHtIWeGYOu8+T34zn0t+7VPswq0UY2xtPhetk9csNNtGQ7vTKKNFcFUdrROSEV/wmV/eudue473j5YZDDGEm43a04P81FsHVWxV9+uwuCiofMz3E1TcZJkySHYt3XnFhWGtdbJMHOkaYsrW++UA1wjWgn/EPcwNWpxiKJVoQmw3WYb0PH7ZXWaeQ/hqGpT+lhQzrNlP18us72c6kx7KW4aHgpWHEqsjceuSkoaAbCvxQxGbJqwDRyzOKdqTiVpapvd/wXAdatzcf1O+0n3C2lzLUbTpSkRx+s/8="
+  # Bintray username; encrypted with: travis encrypt --pro -r cloudstateio/cloudstate BINTRAY_USER=<bintray.username>
+  - secure: "1VJczIq2S9/gKMJNBcjUm8JNhvrgTeIrdceKcMKy3JU5aEYQbpGA7kjiCOQJ93Qnsko+N/NPzfqfh1zxTIHM62hm4nL/EBmQ/tJbjYw9w7yTzGhRyvz+c7dByE3h4PsMuqziDioyN1gV8L7MZ8Zrk0Xzze+EoBDdLxNhenVS/yKmJ8QiZ8FeqMjl/xmMZnMWNdlU+zhQGZ2we2/FexLciVYAq+FrL0aigNPe55eEqwdU/+ZSxAtBSlGP4CJ6XOcLgf7yi11n/xubT88wpxXN5u97MwlE7bxu+t2NyxyKgSXOseqO7dV3mrGqmGm2xWkRRrhOxcrjBEzo5/q0HVwuFhUTw2GnOqj/0hQ5XlzZto8H5qFsjK2di0lJnMmAeYWGslj83/tu8uxaGIEYNegpYJN+koEWeAf6O1OdweCxVYTPCAKggI4NQeu/3+gbY0H8+2RGaN3S1SEhV1b4DEHBIO5VGqFLbQ//yP/W6AqUpuspIxhWSoEuIBDZqVEKf0eku974mQ8OmpoMubr1vB/I85qiFZOEt9xeWQQ+ui1Due1f1xIxKKhOAStvDH3JQNfxd35Dq1tZmcsrDB11y1Q785T/E0UHNvjvP1kQ39NaKUHiAcbFQxBF4XfcQ15MVKiuiGZlF4kvWI9oCRRu9i50KbnSRBaq2WQrT0p0UZCuBso="
+  # Bintray API key; encrypted with: travis encrypt --pro -r cloudstateio/cloudstate BINTRAY_PASS=<bintray.apikey>
+  - secure: "chDdVAkjcTc1HjahcD2m00AgMseYXIDU7UVN5K0q/mPXGkXgOzpiFeu2vE5v0joGviD8hTZ7uLz2tfq91yaqzMeHnH32ZCdz4EGgwbKPriHfzy4Uk/wHWG9qMq+az2GhVryROxJrqqsKJkajcUauPaCmXfc1mljgq/rvTelyxNHYJFnza9B3t4KvB8Vg55e0Gsa/ysz60FEzZu3cReJGch7CcYBiBxh2zw8B5z5kaDTjeX0r681fi9rAKthJOm6An8YhZpfCmBUTa8CCpaoPAWiz5wXW5+C7ccrc769QQ4rrWu+C0pLzQYUyWxlxEUni8BGbfhMlTaHFkVhSV10yqVc+aS7vrWXirAJ1o9nG+yAiMBCHzGVEhgkRc8xJj2ONHEiGAjZU2653P+/oSApouuhLSIaPtE5Cw0ylBrUUiNx3K+E3Ej6UH6hpaRTURD6r8lJwmaXbMP85BlPSnqgqLYXaZX1kB+a6nTeiZgeQCY5k1YVLPLvJw9nBOSHc0t2Fea3lkLfuOb813GeIGmxoboPdtwhX8JCLCK4lX2si2qyNI4sJfeoxKt8jAcjuOl+LCC1PcU1ZU9C01FzUByVyZBG6nY2GFwGYXX6CrhRZtEpIm4tyRnlTeeTeMl4fK0E3RU9v3gRYj3pfJ40UZaT7th7hFHvV2fW+qQU4vuuXqW8="
+  # Sonatype user token username; encrypted with: travis encrypt --pro -r cloudstateio/cloudstate SONA_USER=<sonatype.token.username>
+  - secure: "uzrFSzBPe+TnkRZlCnJ8r46FEgrxXBp9E2K3HfMg6HW+yUcYkv0z1Zf+QZHjD/ZKMd/XAg457IvOwxx1dPlIVgYjxpgGSkdiTimii/c7xkH0f8tg8PdZKqTw1WAO70ut3dtcH96HjtL0bsdKGtcDm60LbyPUKoXOQyfilUIUERmbpMx5cEbKauZdl6E+3wEz5bPD+MdWDWElFONCSJHpoOgl6Z6jAc1Z3VbXT932/WKBGwEedjPTgwtHkVa0FK4a0ehWQ41ZfXbQgyiF9LOiuuL+wFmOh9QTFixhvkLLtiD73ywkFRePEWul8IAFNClZEIGvc1SdsHhKVKPkDfgvI6RRtxjly62Y8VmnXFDe7Pi2UZwFNTYZkmBz0R+7zCb52NlUwUGNl6YwthmxInB1bU1BDJSwxnpAkZ85OEbyl92VXXtgFTxOhylzg976SQPR9qzT6Dl0gUmsq9VxiQaRYZNXarAWUVJlseEmq+RMMjYK35K+RlkC+J19u54F8ob5mbUSTsPhnnsHqZG61o9uVsfKBkK+k9MVwZqk/SF9eHAPiv6vW8DN4KS6gPQQSPuBxI4Ruj6RyYz9IGh05fT0NrbP0xJaqox4lrCCtZ72VsxXTp8qfI8NHE8CUpHM072YMHR5BR1bPbptMcqIkfnmYqWTyqWdczcJaYF07WYwS2w="
+  # Sonatype user token password; encrypted with: travis encrypt --pro -r cloudstateio/cloudstate SONA_PASS=<sonatype.token.username>
+  - secure: "1+YZiGEGRfCcFqYqwJPwFk1TI15weQHbBxP9elnQa5gsc4a+YpdoyOA9y30BcoUPiB0xNpLwG449k5xUVKmpaNjU4iRlfvIGKF6tSEwuQ1BKyihNXgh9Iin+500BprRF7jXXaf96cJv45lEQRDv9Obsygtsv6VU0wbt/Ixc93PTf/Kk2DEetDxQuMN3abIC+tpFw5vtdIyE4UqC0FbmW/9MEO35Vdd9doxO5YCOvs3rDxw6GKs3x3Am88UD8FLhI6UnjGkSsii0rmXniNG18im5Gtyqr2vZXDrVaWYAf9dJd7j2TUJ0muVJZOhLlNc9RUP2dWs9zU0s0YAlxg6F8sdp4BEB1YpgWCWImRjgPjMTDS4FwcI5cjJ2FOOlU03VoeWxNhKKAK5kDTQ9+A+NA/a8sauBa5X4pituiXsuXb0aXC98EaL7UowtJu3UlKCIh7sbyFqItJbLGUxLB25TdOH146A5NMsc/ftXhutp4JV02ozy81oBI+o6Mv287vXqVdKWSATkwGdZmN01Lm+IITc3t6U7ZtiBXCL6iF3slPcAaI/Rj1Air4tAh252Nzi2uLpsj8Hyk9sPiDPPIhS3p6ccaPCYYI2+MuJ5acxd/gjqYQL18q54vJxjrfkJiLzQgFmaDAd84n1fNJ15rdb/Thh80l5pNt8WtMwrPuiTmKKM="
 services:
   - docker
 jobs:
@@ -81,6 +89,7 @@ jobs:
     script:
     - echo "$DOCKER_PASSWORD" | docker login -u cloudstatebot --password-stdin
     - sbt "set concurrentRestrictions in Global += Tags.limitAll(1)" "dockerBuildAllNonNative publish" operator/docker:publish tck/docker:publish
+    - sbt proxy/publish proxy/bintrayRelease proxy/bintraySyncMavenCentral
   
   - stage: Deploy
     name: Publish latest builds
@@ -88,6 +97,11 @@ jobs:
     script:
     - echo "$DOCKER_PASSWORD" | docker login -u cloudstatebot --password-stdin
     - sbt -Duse.native.builds=false -Ddocker.tag=latest "set concurrentRestrictions in Global += Tags.limitAll(1)" "dockerBuildAllNonNative publish" operator/docker:publish tck/docker:publish
+
+  - stage: Deploy
+    name: Publish Java Support release
+    if: tag =~ ^java-support-
+    script: sbt java-support/publish java-support/bintrayRelease java-support/bintraySyncMavenCentral
 
 cache:
   directories:

--- a/project/PublishPlugin.scala
+++ b/project/PublishPlugin.scala
@@ -1,0 +1,32 @@
+import sbt._
+import sbt.Keys._
+import bintray.{BintrayKeys, BintrayPlugin}
+
+/**
+ * Publishing of JVM artifacts to Bintray.
+ */
+object PublishPlugin extends AutoPlugin {
+  import BintrayKeys._
+
+  override def requires = BintrayPlugin && VersionPlugin
+  override def trigger = allRequirements
+
+  override def buildSettings = Seq(
+    bintrayOrganization := Some("cloudstateio"),
+    bintrayRelease / aggregate := false, // called once in root projects
+    bintraySyncMavenCentral / aggregate := false
+  )
+
+  override def projectSettings = Seq(
+    bintrayRepository := { if (isSnapshot.value) "snapshots" else "releases" },
+    bintrayPackage := "cloudstate",
+    bintrayReleaseOnPublish := false, // release and sync packages in one go
+    pomIncludeRepository := (_ => false)
+  )
+}
+
+object NoPublish extends AutoPlugin {
+  override def projectSettings = Seq(
+    publish / skip := true
+  )
+}

--- a/project/VersionPlugin.scala
+++ b/project/VersionPlugin.scala
@@ -1,0 +1,27 @@
+import sbt._
+import sbt.Keys._
+import sbtdynver.DynVerPlugin
+
+/**
+ * Version settings — automatically added to all projects.
+ */
+object VersionPlugin extends AutoPlugin {
+  import DynVerPlugin.autoImport._
+
+  override def requires = DynVerPlugin
+  override def trigger = allRequirements
+
+  // we need the DynVer build settings as project settings, so we can have per-project tag prefix and versions
+  override def projectSettings = DynVerPlugin.buildSettings ++ Seq(
+    version := dynverGitDescribeOutput.value.mkVersion(versionFmt, "latest"),
+    dynver := version.value
+  )
+
+  // make sure the version doesn't change based on time
+  def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
+    val tagVersion = if (out.hasNoTags()) "0.0.0" else out.ref.dropPrefix
+    val dirtySuffix = if (out.isDirty()) "-dev" else ""
+    if (out.isCleanAfterTag) tagVersion
+    else tagVersion + out.commitSuffix.mkString("-", "-", "") + dirtySuffix
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.17")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.3.0")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "1.0.0") // When updating, also update GrpcJavaVersion in build.sbt to be in sync
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")
@@ -15,8 +15,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
-addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 
 addSbtPlugin("io.cloudstate" % "sbt-cloudstate-paradox" % "0.1.2")
 


### PR DESCRIPTION
Set up publishing to bintray for proxy jars. This is so we can depend on and extend these elsewhere.

Sync to maven central via bintray (which will do the signing). This will still need to be enabled by linking to jcenter, which needs something published first. I'll manually publish the first version. Should be automatically published to bintray, jcenter, and maven central on release tags from then on.

Update dynamic versions so that java-support can have its own versions based on `java-support-` tags, and be released automatically on tags.