### PR TITLE
Add antora extension for external code snippets

### DIFF
--- a/docs-asciidoc/.gitignore
+++ b/docs-asciidoc/.gitignore
@@ -1,0 +1,6 @@
+/.cache/
+/build/
+/node_modules/
+
+# we can't use package lock with the @djencks dependencies
+/package-lock.json

--- a/docs-asciidoc/Makefile
+++ b/docs-asciidoc/Makefile
@@ -1,0 +1,53 @@
+# Make Cloudstate documentation
+
+antora_version      := 2.3.3
+antora_docker_image := antora/antora
+
+docs_dir  := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+root_dir  := ${docs_dir}/..
+build_dir := ${docs_dir}/build
+site_dir  := ${build_dir}/site
+base_dir  := /antora/$(shell basename ${docs_dir})
+
+build: clean install html print-site
+
+clean:
+	rm -rf ${build_dir}
+
+# note: we can't currently use package lock with the @djencks dependencies
+install:
+	docker run \
+		-u $(shell id -u):$(shell id -g) \
+		-v ${root_dir}:/antora \
+		--rm \
+		--entrypoint /bin/sh \
+		-t ${antora_docker_image}:${antora_version} \
+		-c "cd ${base_dir} && rm -f package-lock.json && XDG_CONFIG_HOME=.cache/config npm install --cache=.cache/npm"
+
+html:
+	docker run \
+		-u $(shell id -u):$(shell id -g) \
+		-v ${root_dir}:/antora \
+		--rm \
+		--entrypoint /bin/sh \
+		-t ${antora_docker_image}:${antora_version} \
+		-c "cd ${base_dir} && XDG_CONFIG_HOME=.cache/config npm run build"
+
+html-author-mode:
+	docker run \
+		-u $(shell id -u):$(shell id -g) \
+		-v ${root_dir}:/antora \
+		--rm \
+		--entrypoint /bin/sh \
+		-t ${antora_docker_image}:${antora_version} \
+		-c "cd ${base_dir} && XDG_CONFIG_HOME=.cache/config npm run build-author-mode"
+
+print-site:
+	@echo
+	@echo "Cloudstate documentation: ${site_dir}"
+
+preview: html-author-mode
+	@echo
+	@echo "Cloudstate documentation: http://localhost:8000/docs/current/"
+	@echo
+	python3 -m http.server --directory ${site_dir}

--- a/docs-asciidoc/README.adoc
+++ b/docs-asciidoc/README.adoc
@@ -1,0 +1,21 @@
+= Cloudstate documentation
+
+Build the docs using the Makefile:
+
+....
+make build
+....
+
+Open the docs index page:
+
+....
+open build/site/docs/current/index.html
+....
+
+Or build in author mode, served locally:
+
+....
+make preview
+....
+
+Browse at http://localhost:8000/docs/current/

--- a/docs-asciidoc/author-mode-site.yml
+++ b/docs-asciidoc/author-mode-site.yml
@@ -1,34 +1,31 @@
 site:
   title: "Cloudstate Documentation"
   url: https://cloudstate.io/
-  
+
 content:
   sources:
-  - url: ./
+  - url: ..
     branches: [HEAD]
-    start-path: docs-asciidoc/src  
-  - url: ./
+    start-path: docs-asciidoc/src
+  - url: ..
     branches: [HEAD]
     start-path: docs-asciidoc/shared-content
-    
+
 ui:
   bundle:
     url: https://github.com/lightbend/antora-ui-lightbend-cloud-theme-cloudstate/raw/master/build/ui-bundle.zip
     snapshot: true
-  
-        
+
+extensions:
+  - path: "@djencks/antora-aggregate-collector"
+
 runtime:
   fetch: true
 
-asciidoc:
-
-  attributes:
-
-    
-    # the following two attributes cause review and todo notes to display
-    # review: ''
-    # todo: ''
-    
 output:
-#   dir: ./
-   clean: true
+  clean: true
+
+asciidoc:
+  attributes:
+    review: ''
+    todo: ''

--- a/docs-asciidoc/package.json
+++ b/docs-asciidoc/package.json
@@ -1,0 +1,13 @@
+{
+  "description": "Antora extensions for Cloudstate docs",
+  "scripts": {
+    "build": "antora --generator @djencks/site-generator-default site.yml --cache-dir=.cache/antora --stacktrace",
+    "build-author-mode": "antora --generator @djencks/site-generator-default author-mode-site.yml --cache-dir=.cache/antora --stacktrace"
+  },
+  "devDependencies": {
+    "@djencks/antora-aggregate-collector": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-antora-aggregate-collector-v0.0.1.tgz",
+    "@djencks/content-aggregator": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-content-aggregator-v2.3.1.tgz",
+    "@djencks/playbook-builder": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-playbook-builder-v2.3.1.tgz",
+    "@djencks/site-generator-default": "https://experimental-repo.s3-us-west-1.amazonaws.com/djencks-site-generator-default-v2.3.1.tgz"
+  }
+}

--- a/docs-asciidoc/shared-content/antora.yml
+++ b/docs-asciidoc/shared-content/antora.yml
@@ -3,4 +3,10 @@ version: dev
 title: ""
 nav:
 - modules/ROOT/nav.adoc
-
+source-map:
+  - source-paths: docs/src/test/java/docs/user
+    target:
+      path: modules/java/examples
+  - source-paths: docs/src/test/js/test
+    target:
+      path: modules/javascript/examples

--- a/docs-asciidoc/shared-content/modules/java/pages/eventsourced-entities.adoc
+++ b/docs-asciidoc/shared-content/modules/java/pages/eventsourced-entities.adoc
@@ -4,7 +4,10 @@ This page documents how to implement Cloudstate event sourced entities in Java. 
 
 An event sourced entity can be created by annotating it with the @javadoc[`@EventSourcedEntity`](io.cloudstate.javasupport.eventsourced.EventSourcedEntity) annotation.
 
-@@snip [ShoppingCartEntity.java](/docs/src/test/java/docs/user/eventsourced/ShoppingCartEntity.java) { #entity-class }
+[source,java]
+----
+include::example$eventsourced/ShoppingCartEntity.java[tag=entity-class]
+----
 
 The `persistenceId` is used to namespace events in the journal. This is useful when you share the same database between multiple entities. It defaults to the simple name for the entity class (in this case, `ShoppingCartEntity`). It is good practice to explicitly define a `persistenceId`. This helps to decouple the journal data from the classnames in your code—the event naming in the journal remains coherent, even if the underlying entity classname may have changed.
 
@@ -78,7 +81,7 @@ Here's an example event handler for the `ItemAdded` event. A utility method, `co
 
 == Producing and handling snapshots
 
-Snapshots are an important optimisation for event sourced entities that may contain many events, to ensure that they can be loaded quickly even when they have very long journals. To produce a snapshot, a method annotated with @javadoc[`@Snapshot`](io.cloudstate.javasupport.eventsourced.Snapshot) must be declared. It takes a context class of type @javadoc[`SnapshotContext`](io.cloudstate.javasupport.eventsourced.SnapshotContext), and must return a snapshot of the current state in serializable form. 
+Snapshots are an important optimisation for event sourced entities that may contain many events, to ensure that they can be loaded quickly even when they have very long journals. To produce a snapshot, a method annotated with @javadoc[`@Snapshot`](io.cloudstate.javasupport.eventsourced.Snapshot) must be declared. It takes a context class of type @javadoc[`SnapshotContext`](io.cloudstate.javasupport.eventsourced.SnapshotContext), and must return a snapshot of the current state in serializable form.
 
 @@snip [ShoppingCartEntity.java](/docs/src/test/java/docs/user/eventsourced/ShoppingCartEntity.java) { #snapshot }
 

--- a/docs-asciidoc/shared-content/modules/javascript/pages/eventsourced.adoc
+++ b/docs-asciidoc/shared-content/modules/javascript/pages/eventsourced.adoc
@@ -18,7 +18,10 @@ In this file, the `Cart` message is the state, while `ItemAdded` and `ItemRemove
 
 An event sourced entity can be created using the @extref:[EventSourced](jsdoc:EventSourced.html) class.
 
-@@snip [shoppingcart.js](/docs/src/test/js/test/eventsourced/shoppingcart.js) { #entity-class }
+[source,js]
+----
+include::example$eventsourced/shoppingcart.js[tag=entity-class]
+----
 
 Here we pass in the protobuf files that contain our service and our domain protocol, `shoppingcart.proto` and `domain.proto`. Cloudstate needs the protobuf file that your service lives in so that it can load it and read it. It also needs the protobuf file that your domain events and snapshots are in so that when it receives these events and snapshots from the proxy, and can know how to deserialize them.
 

--- a/docs-asciidoc/site.yml
+++ b/docs-asciidoc/site.yml
@@ -1,34 +1,26 @@
 site:
   title: "Cloudstate Documentation"
   url: https://cloudstate.io/
-  
+
 content:
   sources:
-  - url: ./
+  - url: ..
     branches: [HEAD]
-    start-path: docs-asciidoc/src  
-  - url: ./
+    start-path: docs-asciidoc/src
+  - url: ..
     branches: [HEAD]
     start-path: docs-asciidoc/shared-content
-    
+
 ui:
   bundle:
     url: https://github.com/lightbend/antora-ui-lightbend-cloud-theme-cloudstate/raw/master/build/ui-bundle.zip
     snapshot: true
-  
-        
+
+extensions:
+  - path: "@djencks/antora-aggregate-collector"
+
 runtime:
   fetch: true
 
-asciidoc:
-
-  attributes:
-
-    
-    # the following two attributes cause review and todo notes to display
-    review: ''
-    todo: ''
-    
 output:
-#   dir: ./
-   clean: true
+  clean: true

--- a/docs/src/test/java/docs/user/eventsourced/ShoppingCartEntity.java
+++ b/docs/src/test/java/docs/user/eventsourced/ShoppingCartEntity.java
@@ -27,10 +27,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-// #entity-class
+// #entity-class tag::entity-class[]
 @EventSourcedEntity(persistenceId = "shopping-cart", snapshotEvery = 20)
 public class ShoppingCartEntity {
-  // #entity-class
+  // #entity-class end::entity-class[]
 
   // #entity-state
   private final Map<String, Shoppingcart.LineItem> cart = new LinkedHashMap<>();

--- a/docs/src/test/js/test/eventsourced/shoppingcart.js
+++ b/docs/src/test/js/test/eventsourced/shoppingcart.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// #entity-class
+// #entity-class tag::entity-class[]
 const EventSourced = require("cloudstate").EventSourced;
 
 const entity = new EventSourced(
@@ -25,7 +25,7 @@ const entity = new EventSourced(
         snapshotEvery: 100
     }
 );
-// #entity-class
+// #entity-class end::entity-class[]
 
 // #lookup-type
 const pkg = "example.shoppingcart.domain.";


### PR DESCRIPTION
This adds the `djencks/antora-aggregate-collector` extension, so we can have code snippets from examples that are outside the antora source tree.

Also add a Makefile which uses the antora docker images for building, along the lines of the Cloudflow docs.

@rstento, as discussed, a way to use those extensions for code snippets. I've just converted one example each for java and javascript docs. These extensions are unofficial and experimental currently — would be better if antora had some built-in support for something like this. It could be better to just have the code examples in the antora source tree, and add language-specific builds that compile and test. Or use the symlink approach, but it can only be a link in one direction: the original sources still need to be in antora. But this lets us include the examples from their current locations at least.