### PR TITLE
Avoid dead letter logs on event-sourced entity passivation

### DIFF
--- a/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentationSpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentationSpec.scala
@@ -16,7 +16,7 @@
 
 package io.cloudstate.proxy.telemetry
 
-import akka.actor.{ActorRef, Status}
+import akka.actor.ActorRef
 import akka.testkit.TestProbe
 import com.google.protobuf.ByteString
 import com.google.protobuf.any.{Any => ProtoAny}
@@ -239,8 +239,6 @@ class EventSourcedInstrumentationSpec extends AbstractTelemetrySpec {
       // passivate the entity
 
       entity ! EventSourcedEntity.Stop
-
-      userFunction.expectMsg(Status.Success(()))
 
       expectTerminated(entity)
 


### PR DESCRIPTION
Resolves #389.

When the entity passivates, it sends a Success message to the relay actor for the stream to shut down, it also stops the entity actor. The entity supervisor stops when it sees that the entity manager actor has terminated. But the stream also has an actorRef sink pointing to the supervisor, which sees the supervisor terminate (before the stream has completed) and so fails the stage, sending a Failure message to the already terminated supervisor.

First commit avoids the dead letter log by using a `StreamFailed` message with `DeadLetterSuppression`, like the `StreamClosed` message.

But since we may actually want the stream to drain and complete cleanly, second commit updates the entity stop to be more graceful around stream termination.

We'll still want some tests for entity passivation. Tracked in #359.