### PR TITLE
Handle failures in user functions

### DIFF
--- a/java-support/src/main/scala/io/cloudstate/javasupport/CloudStateRunner.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/CloudStateRunner.scala
@@ -62,7 +62,7 @@ object CloudStateRunner {
  * CloudStateRunner can be seen as a low-level API for cases where [[io.cloudstate.javasupport.CloudState.start()]] isn't enough.
  */
 final class CloudStateRunner private[this] (_system: ActorSystem, services: Map[String, StatefulService]) {
-  private[this] implicit final val system = _system
+  private[javasupport] implicit final val system = _system
   private[this] implicit final val materializer: Materializer = ActorMaterializer()
 
   private[this] final val configuration =

--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/Contexts.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/Contexts.scala
@@ -61,6 +61,7 @@ private[impl] trait AbstractClientActionContext extends ClientActionContext {
     checkActive()
     if (error.isEmpty) {
       error = Some(errorMessage)
+      logError(errorMessage)
       throw FailInvoked
     } else throw new IllegalStateException("fail(…) already previously invoked!")
   }
@@ -80,6 +81,8 @@ private[impl] trait AbstractClientActionContext extends ClientActionContext {
   }
 
   final def hasError: Boolean = error.isDefined
+
+  protected def logError(message: String): Unit = ()
 
   final def createClientAction(reply: Optional[JavaPbAny], allowNoReply: Boolean): Option[ClientAction] =
     error match {

--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/eventsourced/AnnotationBasedEventSourcedSupport.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/eventsourced/AnnotationBasedEventSourcedSupport.scala
@@ -25,6 +25,7 @@ import io.cloudstate.javasupport.impl.{AnySupport, ReflectionHelper, ResolvedEnt
 
 import scala.collection.concurrent.TrieMap
 import com.google.protobuf.{Descriptors, Any => JavaPbAny}
+import io.cloudstate.javasupport.impl.eventsourced.EventSourcedImpl.EntityException
 import io.cloudstate.javasupport.{EntityFactory, ServiceCallFactory}
 
 /**
@@ -78,7 +79,7 @@ private[impl] class AnnotationBasedEventSourcedSupport(
           }
           handler.invoke(entity, event, ctx)
         case None =>
-          throw new RuntimeException(
+          throw EntityException(
             s"No event handler found for event ${event.getClass} on $behaviorsString"
           )
       }
@@ -88,7 +89,8 @@ private[impl] class AnnotationBasedEventSourcedSupport(
       behavior.commandHandlers.get(context.commandName()).map { handler =>
         handler.invoke(entity, command, context)
       } getOrElse {
-        throw new RuntimeException(
+        throw EntityException(
+          context,
           s"No command handler found for command [${context.commandName()}] on $behaviorsString"
         )
       }
@@ -104,7 +106,7 @@ private[impl] class AnnotationBasedEventSourcedSupport(
           }
           handler.invoke(entity, snapshot, ctx)
         case None =>
-          throw new RuntimeException(
+          throw EntityException(
             s"No snapshot handler found for snapshot ${snapshot.getClass} on $behaviorsString"
           )
       }

--- a/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/EventSourcedImplSpec.scala
+++ b/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/EventSourcedImplSpec.scala
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.javasupport.impl.eventsourced
+
+import com.google.protobuf.Empty
+import io.cloudstate.javasupport.EntityId
+import io.cloudstate.javasupport.eventsourced._
+import io.cloudstate.testkit.eventsourced.{EventSourcedMessages, TestEventSourcedClient}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+  import EventSourcedImplSpec._
+  import EventSourcedMessages._
+  import ShoppingCart.Item
+  import ShoppingCart.Protocol._
+
+  val service: TestEventSourcedService = ShoppingCart.testService
+  val client: TestEventSourcedClient = TestEventSourcedClient(service.port)
+
+  override def afterAll(): Unit = {
+    client.terminate()
+    service.terminate()
+  }
+
+  "EventSourcedImpl" should {
+
+    "manage entities with expected commands and events" in {
+      val entity = client.connect
+      entity.send(init(ShoppingCart.Name, "cart"))
+      entity.send(command(1, "cart", "GetCart"))
+      entity.expect(reply(1, EmptyCart))
+      entity.send(command(2, "cart", "AddItem", addItem("abc", "apple", 1)))
+      entity.expect(reply(2, EmptyPayload, itemAdded("abc", "apple", 1)))
+      entity.send(command(3, "cart", "AddItem", addItem("abc", "apple", 2)))
+      entity.expect(reply(3, EmptyPayload, Seq(itemAdded("abc", "apple", 2)), cartSnapshot(Item("abc", "apple", 3))))
+      entity.send(command(4, "cart", "GetCart"))
+      entity.expect(reply(4, cart(Item("abc", "apple", 3))))
+      entity.send(command(5, "cart", "AddItem", addItem("123", "banana", 4)))
+      entity.expect(reply(5, EmptyPayload, itemAdded("123", "banana", 4)))
+      entity.passivate()
+      val reactivated = client.connect
+      reactivated.send(init(ShoppingCart.Name, "cart", snapshot(3, cartSnapshot(Item("abc", "apple", 3)))))
+      reactivated.send(event(4, itemAdded("123", "banana", 4)))
+      reactivated.send(command(1, "cart", "GetCart"))
+      reactivated.expect(reply(1, cart(Item("abc", "apple", 3), Item("123", "banana", 4))))
+      reactivated.passivate()
+    }
+
+    "fail when first message is not init" in {
+      service.expectLogError("Terminating entity due to unexpected failure") {
+        val entity = client.connect
+        entity.send(command(1, "cart", "command"))
+        entity.expect(failure("Protocol error: Expected Init message"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail when service doesn't exist" in {
+      service.expectLogError("Terminating entity [foo] due to unexpected failure") {
+        val entity = client.connect
+        entity.send(init(serviceName = "DoesNotExist", entityId = "foo"))
+        entity.expect(failure("Protocol error: Service not found: DoesNotExist"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail when command payload is missing" in {
+      service.expectLogError("Terminating entity [cart] due to unexpected failure for command [foo]") {
+        val entity = client.connect
+        entity.send(init(ShoppingCart.Name, "cart"))
+        entity.send(command(1, "cart", "foo", payload = None))
+        entity.expect(failure(1, "Protocol error: No command payload"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail when command entity id is incorrect" in {
+      service.expectLogError("Terminating entity [cart2] due to unexpected failure for command [foo]") {
+        val entity = client.connect
+        entity.send(init(ShoppingCart.Name, "cart1"))
+        entity.send(command(1, "cart2", "foo"))
+        entity.expect(failure(1, "Protocol error: Receiving entity is not the intended recipient of command"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail when entity is sent multiple init" in {
+      service.expectLogError("Terminating entity [cart] due to unexpected failure") {
+        val entity = client.connect
+        entity.send(init(ShoppingCart.Name, "cart"))
+        entity.send(init(ShoppingCart.Name, "cart"))
+        entity.expect(failure("Protocol error: Entity already inited"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail when entity is sent empty message" in {
+      service.expectLogError("Terminating entity [cart] due to unexpected failure") {
+        val entity = client.connect
+        entity.send(init(ShoppingCart.Name, "cart"))
+        entity.send(EmptyMessage)
+        entity.expect(failure("Protocol error: Received empty/unknown message"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail when snapshot handler does not exist" in {
+      service.expectLogError("Terminating entity due to unexpected failure") {
+        val entity = client.connect
+        val notSnapshot = domainLineItem("?", "not a cart snapshot", 1)
+        val snapshotClass = notSnapshot.getClass
+        entity.send(init(ShoppingCart.Name, "cart", snapshot(42, notSnapshot)))
+        entity.expect(
+          failure(s"No snapshot handler found for snapshot $snapshotClass on ${ShoppingCart.TestCartClass}")
+        )
+        entity.expectClosed()
+      }
+    }
+
+    "fail when snapshot handler throws exception" in {
+      service.expectLogError("Terminating entity due to unexpected failure") {
+        val entity = client.connect
+        entity.send(init(ShoppingCart.Name, "cart", snapshot(42, cartSnapshot())))
+        entity.expect(failure("Unexpected failure: Boom: no items"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail when event handler does not exist" in {
+      service.expectLogError("Terminating entity due to unexpected failure") {
+        val entity = client.connect
+        val notEvent = domainLineItem("?", "not an event", 1)
+        val eventClass = notEvent.getClass
+        entity.send(init(ShoppingCart.Name, "cart"))
+        entity.send(event(1, notEvent))
+        entity.expect(failure(s"No event handler found for event $eventClass on ${ShoppingCart.TestCartClass}"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail when event handler throws exception" in {
+      service.expectLogError("Terminating entity due to unexpected failure") {
+        val entity = client.connect
+        entity.send(init(ShoppingCart.Name, "cart"))
+        entity.send(event(1, itemAdded("123", "FAIL", 42)))
+        entity.expect(failure("Unexpected failure: Boom: name is FAIL"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail when command handler does not exist" in {
+      service.expectLogError("Terminating entity [cart] due to unexpected failure for command [foo]") {
+        val entity = client.connect
+        entity.send(init(ShoppingCart.Name, "cart"))
+        entity.send(command(1, "cart", "foo"))
+        entity.expect(failure(1, s"No command handler found for command [foo] on ${ShoppingCart.TestCartClass}"))
+        entity.expectClosed()
+      }
+    }
+
+    "fail action when command handler uses context fail" in {
+      service.expectLogError(
+        "Fail invoked for command [AddItem] for entity [cart]: Cannot add negative quantity of item [foo]"
+      ) {
+        val entity = client.connect
+        entity.send(init(ShoppingCart.Name, "cart"))
+        entity.send(command(1, "cart", "AddItem", addItem("foo", "bar", -1)))
+        entity.expect(actionFailure(1, "Cannot add negative quantity of item [foo]"))
+        entity.send(command(2, "cart", "GetCart"))
+        entity.expect(reply(2, EmptyCart)) // check emit-then-fail doesn't change entity state
+        entity.passivate()
+        val reactivated = client.connect
+        reactivated.send(init(ShoppingCart.Name, "cart"))
+        reactivated.send(command(1, "cart", "GetCart"))
+        reactivated.expect(reply(1, EmptyCart))
+        reactivated.passivate()
+      }
+    }
+
+    "fail when command handler throws exception" in {
+      service.expectLogError("Terminating entity [cart] due to unexpected failure for command [RemoveItem]") {
+        val entity = client.connect
+        entity.send(init(ShoppingCart.Name, "cart"))
+        entity.send(command(1, "cart", "RemoveItem", removeItem("foo")))
+        entity.expect(failure(1, "Unexpected failure: Boom: foo"))
+        entity.expectClosed()
+      }
+    }
+  }
+}
+
+object EventSourcedImplSpec {
+  object ShoppingCart {
+    import com.example.shoppingcart.Shoppingcart
+    import com.example.shoppingcart.persistence.Domain
+
+    val Name: String = Shoppingcart.getDescriptor.findServiceByName("ShoppingCart").getFullName
+
+    def testService: TestEventSourcedService = service[TestCart]
+
+    def service[T: ClassTag]: TestEventSourcedService =
+      TestEventSourced.service[T](
+        Shoppingcart.getDescriptor.findServiceByName("ShoppingCart"),
+        Domain.getDescriptor
+      )
+
+    case class Item(id: String, name: String, quantity: Int)
+
+    object Protocol {
+      import scala.jdk.CollectionConverters._
+
+      val EmptyCart: Shoppingcart.Cart = Shoppingcart.Cart.newBuilder.build
+
+      def cart(items: Item*): Shoppingcart.Cart =
+        Shoppingcart.Cart.newBuilder.addAllItems(lineItems(items)).build
+
+      def lineItems(items: Seq[Item]): java.lang.Iterable[Shoppingcart.LineItem] =
+        items.sortBy(_.id).map(item => lineItem(item.id, item.name, item.quantity)).asJava
+
+      def lineItem(id: String, name: String, quantity: Int): Shoppingcart.LineItem =
+        Shoppingcart.LineItem.newBuilder.setProductId(id).setName(name).setQuantity(quantity).build
+
+      def addItem(id: String, name: String, quantity: Int): Shoppingcart.AddLineItem =
+        Shoppingcart.AddLineItem.newBuilder.setProductId(id).setName(name).setQuantity(quantity).build
+
+      def removeItem(id: String): Shoppingcart.RemoveLineItem =
+        Shoppingcart.RemoveLineItem.newBuilder.setProductId(id).build
+
+      def itemAdded(id: String, name: String, quantity: Int): Domain.ItemAdded =
+        Domain.ItemAdded.newBuilder.setItem(domainLineItem(id, name, quantity)).build
+
+      def domainLineItems(items: Seq[Item]): java.lang.Iterable[Domain.LineItem] =
+        items.sortBy(_.id).map(item => domainLineItem(item.id, item.name, item.quantity)).asJava
+
+      def domainLineItem(id: String, name: String, quantity: Int): Domain.LineItem =
+        Domain.LineItem.newBuilder.setProductId(id).setName(name).setQuantity(quantity).build
+
+      def cartSnapshot(items: Item*): Domain.Cart =
+        Domain.Cart.newBuilder.addAllItems(domainLineItems(items)).build
+    }
+
+    val TestCartClass: Class[_] = classOf[TestCart]
+
+    @EventSourcedEntity(persistenceId = "shopping-cart", snapshotEvery = 2)
+    class TestCart(@EntityId val entityId: String) {
+      val cart = mutable.Map.empty[String, Item]
+
+      @CommandHandler
+      def getCart: Shoppingcart.Cart = Protocol.cart(cart.values.toSeq: _*)
+
+      @CommandHandler
+      def addItem(item: Shoppingcart.AddLineItem, ctx: CommandContext): Empty = {
+        // emit and then fail on negative quantities, for testing atomicity
+        ctx.emit(Protocol.itemAdded(item.getProductId, item.getName, item.getQuantity))
+        if (item.getQuantity <= 0) ctx.fail(s"Cannot add negative quantity of item [${item.getProductId}]")
+        Empty.getDefaultInstance
+      }
+
+      @EventHandler
+      def itemAdded(itemAdded: Domain.ItemAdded): Unit = {
+        if (itemAdded.getItem.getName == "FAIL") throw new RuntimeException("Boom: name is FAIL") // fail for testing
+        val currentQuantity = cart.get(itemAdded.getItem.getProductId).map(_.quantity).getOrElse(0)
+        cart.update(itemAdded.getItem.getProductId,
+                    Item(itemAdded.getItem.getProductId,
+                         itemAdded.getItem.getName,
+                         currentQuantity + itemAdded.getItem.getQuantity))
+      }
+
+      @CommandHandler
+      def removeItem(item: Shoppingcart.RemoveLineItem): Empty = {
+        if (true) throw new RuntimeException("Boom: " + item.getProductId) // always fail for testing
+        Empty.getDefaultInstance
+      }
+
+      @Snapshot
+      def snapshot: Domain.Cart = Protocol.cartSnapshot(cart.values.toSeq: _*)
+
+      @SnapshotHandler
+      def handleSnapshot(cartSnapshot: Domain.Cart): Unit = {
+        import scala.jdk.CollectionConverters._
+        if (cartSnapshot.getItemsList.isEmpty) throw new RuntimeException("Boom: no items") // fail for testing
+        cart.clear()
+        cartSnapshot.getItemsList.asScala.foreach { item =>
+          cart.update(item.getProductId, Item(item.getProductId, item.getName, item.getQuantity))
+        }
+      }
+    }
+  }
+}

--- a/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/TestEventSourced.scala
+++ b/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/TestEventSourced.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.javasupport.impl.eventsourced
+
+import akka.actor.ActorSystem
+import akka.testkit.{EventFilter, SocketUtil}
+import com.google.protobuf.Descriptors.{FileDescriptor, ServiceDescriptor}
+import com.typesafe.config.{Config, ConfigFactory}
+import io.cloudstate.javasupport.{CloudState, CloudStateRunner}
+import scala.reflect.ClassTag
+
+object TestEventSourced {
+  def service[T: ClassTag](descriptor: ServiceDescriptor, fileDescriptors: FileDescriptor*): TestEventSourcedService =
+    new TestEventSourcedService(implicitly[ClassTag[T]].runtimeClass, descriptor, fileDescriptors)
+}
+
+class TestEventSourcedService(entityClass: Class[_],
+                              descriptor: ServiceDescriptor,
+                              fileDescriptors: Seq[FileDescriptor]) {
+  val port: Int = SocketUtil.temporaryLocalPort()
+
+  val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
+    cloudstate.user-function-port = $port
+    akka {
+      loglevel = ERROR
+      loggers = ["akka.testkit.TestEventListener"]
+      http.server {
+        preview.enable-http2 = on
+        idle-timeout = infinite
+      }
+    }
+  """))
+
+  val runner: CloudStateRunner = new CloudState()
+    .registerEventSourcedEntity(entityClass, descriptor, fileDescriptors: _*)
+    .createRunner(config)
+
+  runner.run()
+
+  def expectLogError[T](message: String)(block: => T): T =
+    EventFilter.error(message, occurrences = 1).intercept(block)(runner.system)
+
+  def terminate(): Unit = runner.terminate()
+}

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
@@ -101,6 +101,7 @@ import io.grpc.Status
 import io.cloudstate.proxy.protobuf.Options
 import com.google.api.httpbody.HttpBody
 import scalapb.UnknownFieldSet
+import scala.util.control.NonFatal
 
 // References:
 // https://cloud.google.com/endpoints/docs/grpc-service-config/reference/rpc/google.api#httprule
@@ -430,6 +431,7 @@ object HttpApi {
         }
         .recover {
           case ire: IllegalRequestException => HttpResponse(ire.status.intValue, entity = ire.status.reason)
+          case NonFatal(error) => HttpResponse(StatusCodes.InternalServerError, entity = error.getMessage)
         }
 
     override final def applyOrElse[A1 <: HttpRequest, B1 >: Future[HttpResponse]](req: A1, default: A1 => B1): B1 =

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
@@ -31,6 +31,7 @@ import akka.grpc.{ProtobufSerializer, Trailers}
 import akka.http.scaladsl.model.{HttpEntity, HttpHeader, HttpRequest, HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.Uri.Path
 import akka.actor.{ActorRef, ActorSystem}
+import akka.event.{Logging, LoggingAdapter}
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.util.ByteString
 import akka.stream.Materializer
@@ -48,8 +49,6 @@ import io.grpc.{Status, StatusRuntimeException}
 import org.slf4j.{Logger, LoggerFactory}
 
 object Serve {
-  private final val log = LoggerFactory.getLogger(getClass)
-
   private[this] final val fallback: Any => Any = _ => fallback
 
   private final def checkFallback[B] = fallback.asInstanceOf[Any => B]
@@ -78,7 +77,7 @@ object Serve {
                              final val router: UserFunctionRouter,
                              final val emitter: Option[Emitter],
                              final val entityDiscoveryClient: EntityDiscoveryClient,
-                             final val log: Logger)(implicit ec: ExecutionContext) {
+                             final val log: LoggingAdapter)(implicit ec: ExecutionContext) {
 
     final val fullCommandName: String = entity.serviceName + "." + method.getName
     final val unary: Boolean = !method.toProto.getClientStreaming && !method.toProto.getServerStreaming
@@ -102,7 +101,7 @@ object Serve {
             if (payload.typeUrl != expectedReplyTypeUrl) {
               val msg =
                 s"$fullCommandName: Expected reply type_url to be [$expectedReplyTypeUrl] but was [${payload.typeUrl}]."
-              log.warn(msg)
+              log.warning(msg)
               entityDiscoveryClient.reportError(UserFunctionError(s"Warning: $msg"))
             }
             Some(reply)
@@ -111,7 +110,7 @@ object Serve {
             None
           case UserFunctionReply(Some(ClientAction(ClientAction.Action.Failure(Failure(_, message, _)), _)), _, _) =>
             log.error("User Function responded with a failure: {}", message)
-            None
+            throw CommandException(message)
           case _ =>
             None
         })
@@ -150,6 +149,7 @@ object Serve {
       mat: Materializer,
       ec: ExecutionContext
   ): PartialFunction[HttpRequest, Future[HttpResponse]] = {
+    val log = Logging(sys.eventStream, Serve.getClass)
     val grpcProxy = createGrpcApi(entities, router, statsCollector, entityDiscoveryClient, emitters)
     val grpcHandler = Function.unlift { request: HttpRequest =>
       val asResponse = grpcProxy.andThen { futureResult =>
@@ -209,7 +209,7 @@ object Serve {
       mat: Materializer,
       ec: ExecutionContext
   ): PartialFunction[HttpRequest, Future[(List[HttpHeader], Source[ProtobufAny, NotUsed])]] = {
-
+    val log = Logging(sys.eventStream, Serve.getClass)
     val rpcMethodSerializers = (for {
       entity <- entities.iterator
       method <- entity.serviceDescriptor.getMethods.iterator.asScala

--- a/proxy/core/src/test/proto/cloudstate/proxy/test/thing.proto
+++ b/proxy/core/src/test/proto/cloudstate/proxy/test/thing.proto
@@ -1,0 +1,48 @@
+// Copyright 2019 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package cloudstate.proxy.test;
+
+import "cloudstate/entity_key.proto";
+import "google/api/annotations.proto";
+import "google/api/http.proto";
+import "google/protobuf/empty.proto";
+
+option java_package = "io.cloudstate.proxy.test";
+
+message Key {
+  string key = 1 [(.cloudstate.entity_key) = true];
+}
+
+message Value {
+  string key = 1 [(.cloudstate.entity_key) = true];
+  string value = 2;
+}
+
+service Thing {
+  rpc Get(Key) returns (Value) {
+    option (google.api.http) = {
+      get: "/thing/{key}",
+    };
+  }
+
+  rpc Set(Value) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      post: "/thing/{key}",
+      body: "*",
+    };
+  }
+}

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/TestProxy.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/TestProxy.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.proxy
+
+import akka.actor.ActorSystem
+import akka.testkit.TestEvent.Mute
+import akka.testkit.{EventFilter, SocketUtil, TestKit}
+import com.typesafe.config.{Config, ConfigFactory}
+import io.cloudstate.protocol.crdt.Crdt
+import io.cloudstate.protocol.entity.ProxyInfo
+import io.cloudstate.protocol.event_sourced.EventSourced
+import io.cloudstate.protocol.function.StatelessFunction
+import java.net.{ConnectException, Socket}
+import scala.concurrent.duration._
+
+object TestProxy {
+  def apply(servicePort: Int): TestProxy = new TestProxy(servicePort)
+}
+
+class TestProxy(servicePort: Int) {
+  val port: Int = SocketUtil.temporaryLocalPort()
+
+  val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
+    include "dev-mode"
+    akka {
+      loglevel = ERROR
+      loggers = ["akka.testkit.TestEventListener"]
+      coordinated-shutdown.exit-jvm = off
+      remote.artery.canonical.port = 0
+      remote.artery.bind.port = ""
+    }
+    cloudstate.proxy {
+      http-port = $port
+      user-function-port = $servicePort
+    }
+  """))
+
+  val info: ProxyInfo = EntityDiscoveryManager.proxyInfo(Seq(Crdt.name, StatelessFunction.name, EventSourced.name))
+
+  val system: ActorSystem = CloudStateProxyMain.start(config)
+
+  def isOnline: Boolean =
+    try {
+      new Socket("localhost", port).close()
+      true
+    } catch {
+      case _: ConnectException => false
+    }
+
+  def expectOnline(): Unit = TestKit.awaitCond(isOnline, max = 10.seconds)
+
+  def expectLogError[T](message: String)(block: => T): T =
+    EventFilter.error(message, occurrences = 1).intercept(block)(system)
+
+  def terminate(): Unit = {
+    system.eventStream.publish(Mute(EventFilter.warning(pattern = ".*received dead letter.*")))
+    system.eventStream.publish(Mute(EventFilter.warning(pattern = ".*unhandled message.*")))
+    TestKit.shutdownActorSystem(system)
+  }
+}

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/eventsourced/ExceptionHandlingSpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/eventsourced/ExceptionHandlingSpec.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.proxy.eventsourced
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.grpc.{GrpcClientSettings, GrpcServiceException}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, Uri}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.testkit.TestKit
+import io.cloudstate.proxy.TestProxy
+import io.cloudstate.proxy.test.thing.{Key, Thing, ThingClient}
+import io.cloudstate.testkit.eventsourced.{EventSourcedMessages, TestEventSourcedService}
+import io.grpc.{Status, StatusRuntimeException}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+
+class ExceptionHandlingSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+  import EventSourcedMessages._
+
+  implicit val system = ActorSystem("ExceptionHandlingSpec")
+
+  val service = TestEventSourcedService()
+  val proxy = TestProxy(service.port)
+  val client = ThingClient(GrpcClientSettings.connectToServiceAt("localhost", proxy.port).withTls(false))
+  val spec = TestEventSourcedService.entitySpec(Thing)
+
+  val discovery = service.expectDiscovery()
+  discovery.expect(proxy.info)
+  discovery.send(spec)
+  proxy.expectOnline()
+
+  override def afterAll(): Unit = {
+    client.close().futureValue shouldBe Done
+    TestKit.shutdownActorSystem(system)
+    proxy.terminate()
+    service.terminate()
+  }
+
+  "Cloudstate proxy" should {
+
+    "respond with gRPC error for action failure in entity" in {
+      val call = client.get(Key("one"))
+      val connection = service.expectConnection()
+      connection.expect(init(Thing.name, "one"))
+      connection.expect(command(1, "one", "Get", Key("one")))
+      proxy.expectLogError("User Function responded with a failure: description goes here") {
+        connection.send(actionFailure(1, "description goes here"))
+      }
+      val error = call.failed.futureValue
+      error shouldBe a[StatusRuntimeException]
+      error.getMessage shouldBe "UNKNOWN: description goes here"
+      connection.close()
+    }
+
+    "respond with gRPC error for unexpected failure in entity" in {
+      val call = client.get(Key("two"))
+      val connection = service.expectConnection()
+      connection.expect(init(Thing.name, "two"))
+      connection.expect(command(1, "two", "Get", Key("two")))
+      proxy.expectLogError("User Function responded with a failure: Unexpected entity failure") {
+        proxy.expectLogError("Unexpected entity failure - boom plus details") {
+          connection.send(failure(1, "boom plus details"))
+          connection.expectClosed()
+        }
+      }
+      val error = call.failed.futureValue
+      error shouldBe a[StatusRuntimeException]
+      error.getMessage shouldBe "UNKNOWN: Unexpected entity failure"
+    }
+
+    "respond with gRPC error for stream error in entity" in {
+      val call = client.get(Key("three"))
+      val connection = service.expectConnection()
+      connection.expect(init(Thing.name, "three"))
+      connection.expect(command(1, "three", "Get", Key("three")))
+      proxy.expectLogError("User Function responded with a failure: Unexpected entity termination") {
+        proxy.expectLogError("INTERNAL: stream failed") {
+          connection.sendError(new GrpcServiceException(Status.INTERNAL.withDescription("stream failed")))
+        }
+      }
+      val error = call.failed.futureValue
+      error shouldBe a[StatusRuntimeException]
+      error.getMessage shouldBe "UNKNOWN: Unexpected entity termination"
+    }
+
+    "respond with HTTP error for action failure in entity" in {
+      val call = Http().singleRequest(HttpRequest(uri = Uri(s"http://localhost:${proxy.port}/thing/four")))
+      val connection = service.expectConnection()
+      connection.expect(init(Thing.name, "four"))
+      connection.expect(command(1, "four", "Get", Key("four")))
+      proxy.expectLogError("User Function responded with a failure: description goes here") {
+        connection.send(actionFailure(1, "description goes here"))
+      }
+      val response = call.futureValue
+      response.status.intValue shouldBe 500
+      Unmarshal(response).to[String].futureValue shouldBe "description goes here"
+      connection.close()
+    }
+
+    "respond with HTTP error for unexpected failure in entity" in {
+      val call = Http().singleRequest(HttpRequest(uri = Uri(s"http://localhost:${proxy.port}/thing/five")))
+      val connection = service.expectConnection()
+      connection.expect(init(Thing.name, "five"))
+      connection.expect(command(1, "five", "Get", Key("five")))
+      proxy.expectLogError("User Function responded with a failure: Unexpected entity failure") {
+        proxy.expectLogError("Unexpected entity failure - boom plus details") {
+          connection.send(failure(1, "boom plus details"))
+          connection.expectClosed()
+        }
+      }
+      val response = call.futureValue
+      response.status.intValue shouldBe 500
+      Unmarshal(response).to[String].futureValue shouldBe "Unexpected entity failure"
+    }
+
+    "respond with HTTP error for stream error in entity" in {
+      val call = Http().singleRequest(HttpRequest(uri = Uri(s"http://localhost:${proxy.port}/thing/six")))
+      val connection = service.expectConnection()
+      connection.expect(init(Thing.name, "six"))
+      connection.expect(command(1, "six", "Get", Key("six")))
+      proxy.expectLogError("User Function responded with a failure: Unexpected entity termination") {
+        proxy.expectLogError("INTERNAL: stream failed") {
+          connection.sendError(new GrpcServiceException(Status.INTERNAL.withDescription("stream failed")))
+        }
+      }
+      val response = call.futureValue
+      response.status.intValue shouldBe 500
+      Unmarshal(response).to[String].futureValue shouldBe "Unexpected entity termination"
+    }
+
+  }
+}

--- a/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
+++ b/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
@@ -229,9 +229,9 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
       r
     }
 
-  final def fromFrontend_expectFailure(within: FiniteDuration): Failure =
+  final def fromFrontend_expectActionFailure(within: FiniteDuration): Failure =
     withClue("Failure was not received, or not well-formed: ") {
-      val failure = eventSourcedFromFrontend.expectMsgType[EventSourcedStreamOut](noWait) // FIXME Expects entity.Failure, but gets lientAction.Action.Failure(Failure(commandId, msg)))
+      val failure = eventSourcedFromFrontend.expectMsgType[EventSourcedStreamOut](noWait)
       failure must not be (null)
       failure.message must be('reply)
       failure.message.reply must be(defined)
@@ -331,7 +331,7 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
             correlate(
               cmd,
               if (isReply) fromFrontend_expectReply(events = eventCount, noWait).commandId
-              else fromFrontend_expectFailure(noWait).commandId
+              else fromFrontend_expectActionFailure(noWait).commandId
             )
             init.entityId must be(cmd.entityId)
             set must not contain (cmd.id)

--- a/testkit/src/main/scala/io/cloudstate/testkit/TestService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/TestService.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit
+
+import akka.actor.ActorSystem
+import akka.grpc.ServiceDescription
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.testkit.{SocketUtil, TestKit, TestProbe}
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.Descriptors.{FileDescriptor, ServiceDescriptor}
+import com.google.protobuf.empty.{Empty => ScalaPbEmpty}
+import com.typesafe.config.{Config, ConfigFactory}
+import io.cloudstate.protocol.entity._
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, Promise}
+import scala.util.Success
+
+class TestService {
+  val port: Int = SocketUtil.temporaryLocalPort()
+
+  private val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
+    akka.loglevel = ERROR
+    akka.http.server {
+      preview.enable-http2 = on
+      idle-timeout = infinite
+    }
+  """))
+
+  protected implicit val system: ActorSystem = ActorSystem("TestService", config)
+  protected val probe: TestProbe = TestProbe("TestServiceProbe")
+  private val entityDiscovery = new TestService.TestEntityDiscovery(this)
+
+  protected def handler: PartialFunction[HttpRequest, Future[HttpResponse]] =
+    EntityDiscoveryHandler.partial(entityDiscovery)
+
+  protected def start(): Unit =
+    Await.result(Http().bindAndHandleAsync(handler = handler, interface = "localhost", port = port), 10.seconds)
+
+  def expectDiscovery(): TestService.Discovery = probe.expectMsgType[TestService.Discovery]
+
+  def terminate(): Unit = TestKit.shutdownActorSystem(system)
+}
+
+object TestService {
+  val info: ServiceInfo = ServiceInfo(supportLibraryName = "Cloudstate TestKit")
+
+  def entitySpec(entityType: String, service: ServiceDescription): EntitySpec = {
+    import scala.jdk.CollectionConverters._
+    entitySpec(entityType, service.descriptor.getServices.asScala.toSeq)
+  }
+
+  def entitySpec(entityType: String, descriptors: Seq[ServiceDescriptor]): EntitySpec = {
+    import scala.jdk.CollectionConverters._
+    def allDescriptors(descriptors: Seq[FileDescriptor]): Seq[FileDescriptor] = descriptors.flatMap { d =>
+      d +: allDescriptors(d.getDependencies.asScala.toSeq ++ d.getPublicDependencies.asScala)
+    }
+    val proto = {
+      val descriptorSet = DescriptorProtos.FileDescriptorSet.newBuilder()
+      allDescriptors(descriptors.map(_.getFile)).distinctBy(_.getName).foreach(fd => descriptorSet.addFile(fd.toProto))
+      descriptorSet.build().toByteString
+    }
+    val entities = descriptors.map(d => Entity(entityType, d.getFullName, d.getName))
+    EntitySpec(proto, entities, Some(info))
+  }
+
+  final class TestEntityDiscovery(service: TestService) extends EntityDiscovery {
+    private val discovery = new Discovery(service)
+
+    override def discover(info: ProxyInfo): Future[EntitySpec] = {
+      service.probe.ref ! discovery
+      discovery.info(info)
+      discovery.spec
+    }
+
+    override def reportError(error: UserFunctionError): Future[ScalaPbEmpty] = {
+      discovery.error(error)
+      Future.successful(ScalaPbEmpty.defaultInstance)
+    }
+  }
+
+  final class Discovery(service: TestService) {
+    private val probe = TestProbe("DiscoveryInProbe")(service.system)
+    private val entitySpec = Promise[EntitySpec]()
+
+    private[testkit] def info(info: ProxyInfo): Unit = probe.ref ! info
+
+    private[testkit] def spec: Future[EntitySpec] = entitySpec.future
+
+    private[testkit] def error(error: UserFunctionError): Unit = probe.ref ! error
+
+    def expect(info: ProxyInfo): Unit = probe.expectMsg(info)
+
+    def send(spec: EntitySpec): Unit = entitySpec.complete(Success(spec))
+
+    def expectError(error: UserFunctionError): Unit = probe.expectMsg(error)
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/EventSourcedMessages.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/EventSourcedMessages.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.eventsourced
+
+import com.google.protobuf.any.{Any => ScalaPbAny}
+import com.google.protobuf.{Empty => JavaPbEmpty, Message => JavaPbMessage}
+import io.cloudstate.protocol.entity._
+import io.cloudstate.protocol.event_sourced._
+import scalapb.{GeneratedMessage => ScalaPbMessage}
+
+object EventSourcedMessages {
+  import EventSourcedStreamIn.{Message => InMessage}
+  import EventSourcedStreamOut.{Message => OutMessage}
+
+  val EmptyMessage: InMessage = InMessage.Empty
+  val EmptyPayload: JavaPbMessage = JavaPbEmpty.getDefaultInstance
+  val EmptyAny: ScalaPbAny = protobufAny(EmptyPayload)
+
+  def init(serviceName: String, entityId: String): InMessage =
+    init(serviceName, entityId, None)
+
+  def init(serviceName: String, entityId: String, snapshot: EventSourcedSnapshot): InMessage =
+    init(serviceName, entityId, Option(snapshot))
+
+  def init(serviceName: String, entityId: String, snapshot: Option[EventSourcedSnapshot]): InMessage =
+    InMessage.Init(EventSourcedInit(serviceName, entityId, snapshot))
+
+  def snapshot(sequence: Long, payload: JavaPbMessage): EventSourcedSnapshot =
+    snapshot(sequence, messagePayload(payload))
+
+  def snapshot(sequence: Long, payload: ScalaPbMessage): EventSourcedSnapshot =
+    snapshot(sequence, messagePayload(payload))
+
+  def snapshot(sequence: Long, payload: Option[ScalaPbAny]): EventSourcedSnapshot =
+    EventSourcedSnapshot(sequence, payload)
+
+  def event(sequence: Long, payload: JavaPbMessage): InMessage =
+    event(sequence, messagePayload(payload))
+
+  def event(sequence: Long, payload: ScalaPbMessage): InMessage =
+    event(sequence, messagePayload(payload))
+
+  def event(sequence: Long, payload: Option[ScalaPbAny]): InMessage =
+    InMessage.Event(EventSourcedEvent(sequence, payload))
+
+  def command(id: Long, entityId: String, name: String): InMessage =
+    command(id, entityId, name, EmptyPayload)
+
+  def command(id: Long, entityId: String, name: String, payload: JavaPbMessage): InMessage =
+    command(id, entityId, name, messagePayload(payload))
+
+  def command(id: Long, entityId: String, name: String, payload: ScalaPbMessage): InMessage =
+    command(id, entityId, name, messagePayload(payload))
+
+  def command(id: Long, entityId: String, name: String, payload: Option[ScalaPbAny]): InMessage =
+    InMessage.Command(Command(entityId, id, name, payload))
+
+  def reply(id: Long, payload: JavaPbMessage, events: JavaPbMessage*): OutMessage =
+    reply(id, messagePayload(payload), events.map(protobufAny), None)
+
+  def reply(id: Long, payload: ScalaPbMessage, events: ScalaPbMessage*): OutMessage =
+    reply(id, messagePayload(payload), events.map(protobufAny), None)
+
+  def reply(id: Long, payload: JavaPbMessage, events: Seq[JavaPbMessage], snapshot: JavaPbMessage): OutMessage =
+    reply(id, messagePayload(payload), events.map(protobufAny), messagePayload(snapshot))
+
+  def reply(id: Long, payload: ScalaPbMessage, events: Seq[ScalaPbMessage], snapshot: ScalaPbMessage): OutMessage =
+    reply(id, messagePayload(payload), events.map(protobufAny), messagePayload(snapshot))
+
+  def reply(id: Long, payload: Option[ScalaPbAny], events: Seq[ScalaPbAny], snapshot: Option[ScalaPbAny]): OutMessage =
+    OutMessage.Reply(EventSourcedReply(id, clientActionReply(payload), Seq.empty, events, snapshot))
+
+  def actionFailure(id: Long, description: String): OutMessage =
+    OutMessage.Reply(EventSourcedReply(id, clientActionFailure(id, description)))
+
+  def failure(description: String): OutMessage =
+    failure(id = 0, description)
+
+  def failure(id: Long, description: String): OutMessage =
+    OutMessage.Failure(Failure(id, description))
+
+  def clientActionReply(payload: Option[ScalaPbAny]): Option[ClientAction] =
+    Some(ClientAction(ClientAction.Action.Reply(Reply(payload))))
+
+  def clientActionFailure(description: String): Option[ClientAction] =
+    clientActionFailure(id = 0, description)
+
+  def clientActionFailure(id: Long, description: String): Option[ClientAction] =
+    Some(ClientAction(ClientAction.Action.Failure(Failure(id, description))))
+
+  def messagePayload(message: JavaPbMessage): Option[ScalaPbAny] =
+    Option(message).map(protobufAny)
+
+  def messagePayload(message: ScalaPbMessage): Option[ScalaPbAny] =
+    Option(message).map(protobufAny)
+
+  def protobufAny(message: JavaPbMessage): ScalaPbAny =
+    ScalaPbAny("type.googleapis.com/" + message.getDescriptorForType.getFullName, message.toByteString)
+
+  def protobufAny(message: ScalaPbMessage): ScalaPbAny =
+    ScalaPbAny("type.googleapis.com/" + message.companion.scalaDescriptor.fullName, message.toByteString)
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/TestEventSourcedClient.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/TestEventSourcedClient.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.eventsourced
+
+import akka.actor.ActorSystem
+import akka.grpc.GrpcClientSettings
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestKit
+import com.typesafe.config.{Config, ConfigFactory}
+import io.cloudstate.protocol.event_sourced._
+
+final class TestEventSourcedClient(port: Int) {
+  private val config: Config = ConfigFactory.load(ConfigFactory.parseString("""
+    akka.http.server {
+      preview.enable-http2 = on
+    }
+  """))
+
+  private implicit val system: ActorSystem = ActorSystem("TestEventSourcedClient", config)
+  private val client = EventSourcedClient(GrpcClientSettings.connectToServiceAt("localhost", port).withTls(false))
+
+  def connect: TestEventSourcedClient.Connection = new TestEventSourcedClient.Connection(client, system)
+
+  def terminate(): Unit = {
+    client.close()
+    TestKit.shutdownActorSystem(system)
+  }
+}
+
+object TestEventSourcedClient {
+  def apply(port: Int): TestEventSourcedClient = new TestEventSourcedClient(port)
+
+  final class Connection(client: EventSourcedClient, system: ActorSystem) {
+    private implicit val actorSystem: ActorSystem = system
+    private val in = TestPublisher.probe[EventSourcedStreamIn]()
+    private val out = client.handle(Source.fromPublisher(in)).runWith(TestSink.probe[EventSourcedStreamOut])
+
+    out.ensureSubscription()
+
+    def send(message: EventSourcedStreamIn.Message): Unit =
+      in.sendNext(EventSourcedStreamIn(message))
+
+    def expect(message: EventSourcedStreamOut.Message): Unit =
+      out.request(1).expectNext(EventSourcedStreamOut(message))
+
+    def expectClosed(): Unit = {
+      out.expectComplete()
+      in.expectCancellation()
+    }
+
+    def passivate(): Unit = close()
+
+    def close(): Unit = {
+      in.sendComplete()
+      out.expectComplete()
+    }
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/TestEventSourcedService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/TestEventSourcedService.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.eventsourced
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.grpc.ServiceDescription
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestProbe
+import com.google.protobuf.Descriptors.ServiceDescriptor
+import io.cloudstate.protocol.entity._
+import io.cloudstate.protocol.event_sourced._
+import io.cloudstate.testkit.TestService
+import scala.concurrent.Future
+
+final class TestEventSourcedService extends TestService {
+  private val eventSourced = new TestEventSourcedService.TestEventSourced(system, probe)
+
+  override protected def handler: PartialFunction[HttpRequest, Future[HttpResponse]] =
+    super.handler orElse EventSourcedHandler.partial(eventSourced)
+
+  def expectConnection(): TestEventSourcedService.Connection = probe.expectMsgType[TestEventSourcedService.Connection]
+
+  start()
+}
+
+object TestEventSourcedService {
+  def apply(): TestEventSourcedService = new TestEventSourcedService
+
+  def entitySpec(service: ServiceDescription): EntitySpec =
+    TestService.entitySpec(EventSourced.name, service)
+
+  def entitySpec(descriptors: Seq[ServiceDescriptor]): EntitySpec =
+    TestService.entitySpec(EventSourced.name, descriptors)
+
+  final class TestEventSourced(system: ActorSystem, probe: TestProbe) extends EventSourced {
+    override def handle(source: Source[EventSourcedStreamIn, NotUsed]): Source[EventSourcedStreamOut, NotUsed] = {
+      val connection = new Connection(system, source)
+      probe.ref ! connection
+      connection.outSource
+    }
+  }
+
+  final class Connection(system: ActorSystem, source: Source[EventSourcedStreamIn, NotUsed]) {
+    private implicit val actorSystem: ActorSystem = system
+    private val in = source.runWith(TestSink.probe[EventSourcedStreamIn])
+    private val out = TestPublisher.probe[EventSourcedStreamOut]()
+
+    in.ensureSubscription()
+
+    private[testkit] def outSource: Source[EventSourcedStreamOut, NotUsed] = Source.fromPublisher(out)
+
+    def expect(message: EventSourcedStreamIn.Message): Unit =
+      in.request(1).expectNext(EventSourcedStreamIn(message))
+
+    def send(message: EventSourcedStreamOut.Message): Unit =
+      out.sendNext(EventSourcedStreamOut(message))
+
+    def sendError(error: Throwable): Unit =
+      out.sendError(error)
+
+    def expectClosed(): Unit = {
+      in.expectComplete()
+      close()
+    }
+
+    def close(): Unit =
+      out.sendComplete()
+  }
+}


### PR DESCRIPTION
Resolves #344 and resolves #333. Still to do:

- [x] add tests for the failure paths

Have only manually checked this, will follow up with the tests.

<details>
<summary>Old behaviour - output and proxy logs</summary>

* gRPC request for command using `context.fail`:

  ```
  ❯ grpcurl -plaintext -d '{"user_id": "test", "product_id": "abc"}' localhost:9000 com.example.shoppingcart.ShoppingCart/RemoveItem
  Error invoking method "com.example.shoppingcart.ShoppingCart/RemoveItem": grpc call for "com.example.shoppingcart.ShoppingCart.RemoveItem" failed: EOF
  ```
  Proxy logs:
  ```
  ERROR io.cloudstate.proxy.Serve$ - User Function responded with a failure: Cannot remove item abc because it is not in the cart.
  ```

* HTTP request for command using `context.fail`:

  ```
  ❯ http POST :9000/cart/test/items/abc/remove
  HTTP/1.1 500 Internal Server Error
  Connection: close
  Content-Length: 0
  Server: akka-http/10.1.12
  ```
  Proxy logs:
  ```
  ERROR io.cloudstate.proxy.Serve$ - User Function responded with a failure: Cannot remove item abc because it is not in the cart.
  ERROR akka.actor.ActorSystemImpl - Internal server error, sending 500 response
  java.util.NoSuchElementException: head of empty stream
   at akka.stream.scaladsl.Sink$.$anonfun$head$3(Sink.scala:198)
   [...]
  INFO akka.actor.ActorSystemImpl - Request timeout encountered for request [POST /cart/test/items/abc/remove Empty]
  ```

* gRPC request for command with exception:

  ```
  ❯ grpcurl -plaintext -d '{"user_id": "test"}' localhost:9000 com.example.shoppingcart.ShoppingCart/GetCart
  Error invoking method "com.example.shoppingcart.ShoppingCart/GetCart": grpc call for "com.example.shoppingcart.ShoppingCart.GetCart" failed: EOF
  ```
  Proxy logs:
  ```
  ERROR akka.actor.OneForOneStrategy - INTERNAL
  io.grpc.StatusRuntimeException: INTERNAL
   at io.grpc.Status.asRuntimeException(Status.java:533)
   at akka.grpc.internal.AkkaNettyGrpcClientGraphStage$$anon$1.onCallClosed(AkkaNettyGrpcClientGraphStage.scala:165)
   [...]
  WARN io.cloudstate.proxy.eventsourced.EventSourcedEntity - Stopped but we have a current action id 2:test:1
  ERROR io.cloudstate.proxy.Serve$ - User Function responded with a failure: Unexpected entity termination
  ```

* HTTP request for command with exception:

  ```
  ❯ http :9000/carts/test
  HTTP/1.1 500 Internal Server Error
  Connection: close
  Content-Length: 0
  Server: akka-http/10.1.12
  ```
  Proxy logs:
  ```
  ERROR io.cloudstate.proxy.Serve$ - User Function responded with a failure: Unexpected entity termination
  ERROR akka.actor.ActorSystemImpl - Internal server error, sending 500 response
  java.util.NoSuchElementException: head of empty stream
   at akka.stream.scaladsl.Sink$.$anonfun$head$3(Sink.scala:198)
   [...]
  INFO akka.actor.ActorSystemImpl - Request timeout encountered for request [GET /carts/test Empty]
  ```

</details>


There's already some currently unused code for `Serve.CommandException` and `HttpEndpoint.transformFailedRequest`. Add simple fixes: use the `CommandException` on failures (which already gets converted to gRPC errors), add a default catch for exceptions in `HttpApi`, and add a default catch for exceptions in java-support event sourced and report as errors.


<details>
<summary>New behaviour - output and proxy logs</summary>

* gRPC request for command using `context.fail`:

  ```
  ❯ grpcurl -plaintext -d '{"user_id": "test", "product_id": "abc"}' localhost:9000 com.example.shoppingcart.ShoppingCart/RemoveItem
  ERROR:
    Code: Unknown
    Message: Cannot remove item abc because it is not in the cart.
  ```
  Proxy logs:
  ```
  ERROR io.cloudstate.proxy.Serve$ - User Function responded with a failure: Cannot remove item abc because it is not in the cart.
  ```

* HTTP request for command using `context.fail`:

  ```
  ❯ http POST :9000/cart/test/items/abc/remove
  HTTP/1.1 500 Internal Server Error
  Content-Length: 53
  Content-Type: text/plain; charset=UTF-8
  Server: akka-http/10.1.12
  
  Cannot remove item abc because it is not in the cart.
  ```
  Proxy logs:
  ```
  ERROR io.cloudstate.proxy.Serve$ - User Function responded with a failure: Cannot remove item abc because it is not in the cart.
  ```

* gRPC request for command with exception:

  ```
  ❯ grpcurl -plaintext -d '{"user_id": "test"}' localhost:9000 com.example.shoppingcart.ShoppingCart/GetCart
  ERROR:
    Code: Unknown
    Message: Unexpected failure: boom!
  ```
  Proxy logs:
  ```
  ERROR io.cloudstate.proxy.Serve$ - User Function responded with a failure: Unexpected failure: boom!
  ```

* HTTP request for command with exception:

  ```
  ❯ http :9000/carts/test
  HTTP/1.1 500 Internal Server Error
  Content-Length: 25
  Content-Type: text/plain; charset=UTF-8
  Server: akka-http/10.1.12

  Unexpected failure: boom!
  ```
  Proxy logs:
  ```
  ERROR io.cloudstate.proxy.Serve$ - User Function responded with a failure: Unexpected failure: boom!
  ```

</details>
