### PR TITLE
Remove scala version from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: scala
 dist: xenial
 jdk:
   - openjdk11
-scala:
-  - 2.12.11
 before_install:
   - sudo apt-get -y install jq
 env:


### PR DESCRIPTION
Resolves #397. Remove scala version from travis as we're not using it and it shouldn't be needed. Scala versions are controlled by sbt. We're not cross building in sbt or travis.