### PR TITLE
Fix proxy native image builds for postgres and cassandra

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -473,10 +473,14 @@ lazy val `proxy-core` = (project in file("proxy/core"))
 
 lazy val `proxy-spanner` = (project in file("proxy/spanner"))
   .enablePlugins(DockerPlugin, JavaAgent, GraalVMPlugin)
-  .dependsOn(`proxy-core`)
+  .dependsOn(
+    `proxy-core`,
+    `graal-tools` % Provided // only needed for compilation
+  )
   .settings(
     common,
     name := "cloudstate-proxy-spanner",
+    dependencyOverrides += "io.grpc" % "grpc-netty-shaded" % GrpcNettyShadedVersion,
     libraryDependencies ++= Seq(
         "com.lightbend.akka" %% "akka-persistence-spanner" % AkkaPersistenceSpannerVersion,
         akkaDependency("akka-cluster-typed"), // Transitive dependency of akka-persistence-spanner
@@ -491,10 +495,14 @@ lazy val `proxy-spanner` = (project in file("proxy/spanner"))
 
 lazy val `proxy-cassandra` = (project in file("proxy/cassandra"))
   .enablePlugins(DockerPlugin, JavaAgent, GraalVMPlugin)
-  .dependsOn(`proxy-core`)
+  .dependsOn(
+    `proxy-core`,
+    `graal-tools` % Provided // only needed for compilation
+  )
   .settings(
     common,
     name := "cloudstate-proxy-cassandra",
+    dependencyOverrides += "io.grpc" % "grpc-netty-shaded" % GrpcNettyShadedVersion,
     libraryDependencies ++= Seq(
         akkaPersistenceCassandraDependency("akka-persistence-cassandra", ExclusionRule("com.github.jnr")),
         akkaPersistenceCassandraDependency("akka-persistence-cassandra-launcher") % Test
@@ -508,10 +516,14 @@ lazy val `proxy-cassandra` = (project in file("proxy/cassandra"))
   )
 
 lazy val `proxy-jdbc` = (project in file("proxy/jdbc"))
-  .dependsOn(`proxy-core`)
+  .dependsOn(
+    `proxy-core`,
+    `graal-tools` % Provided // only needed for compilation
+  )
   .settings(
     common,
     name := "cloudstate-proxy-jdbc",
+    dependencyOverrides += "io.grpc" % "grpc-netty-shaded" % GrpcNettyShadedVersion,
     libraryDependencies ++= Seq(
         "com.github.dnvriend" %% "akka-persistence-jdbc" % "3.5.2"
       ),
@@ -521,10 +533,14 @@ lazy val `proxy-jdbc` = (project in file("proxy/jdbc"))
 
 lazy val `proxy-postgres` = (project in file("proxy/postgres"))
   .enablePlugins(DockerPlugin, JavaAgent, GraalVMPlugin, AssemblyPlugin)
-  .dependsOn(`proxy-jdbc`)
+  .dependsOn(
+    `proxy-jdbc`,
+    `graal-tools` % Provided // only needed for compilation
+  )
   .settings(
     common,
     name := "cloudstate-proxy-postgres",
+    dependencyOverrides += "io.grpc" % "grpc-netty-shaded" % GrpcNettyShadedVersion,
     libraryDependencies ++= Seq(
         "org.postgresql" % "postgresql" % "42.2.6"
       ),

--- a/operator/deploy/02-operator-config.yaml
+++ b/operator/deploy/02-operator-config.yaml
@@ -17,7 +17,7 @@ data:
       proxy {
         image {
           cassandra = "cloudstateio/cloudstate-proxy-native-cassandra:latest"
-          postgres =  "cloudstateio/cloudstate-proxy-postgres:latest"
+          postgres =  "cloudstateio/cloudstate-proxy-native-postgres:latest"
           no-store = "cloudstateio/cloudstate-proxy-native-no-store:latest"
           in-memory = "cloudstateio/cloudstate-proxy-native-in-memory:latest"
         }

--- a/proxy/cassandra/src/graal/META-INF/native-image/net.java.openjdk/base/reflect-config.json.conf
+++ b/proxy/cassandra/src/graal/META-INF/native-image/net.java.openjdk/base/reflect-config.json.conf
@@ -112,4 +112,8 @@
   allDeclaredMethods: true
   allPublicMethods: true
 }
+{
+  name: "java.util.concurrent.CopyOnWriteArrayList"
+  fields: [{name: "lock", allowWrite: true}]
+}
 ]

--- a/proxy/postgres/src/graal/META-INF/native-image/com.zaxxer/HikariCP/reflect-config.json.conf
+++ b/proxy/postgres/src/graal/META-INF/native-image/com.zaxxer/HikariCP/reflect-config.json.conf
@@ -3,4 +3,8 @@
   name: "com.zaxxer.hikari.HikariConfig"
   allDeclaredFields: true
 }
+{
+  name: "com.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry[]"
+  allDeclaredConstructors: true
+}
 ]

--- a/proxy/postgres/src/graal/META-INF/native-image/io.cloudstate/cloudstate-proxy-jdbc/native-image.properties
+++ b/proxy/postgres/src/graal/META-INF/native-image/io.cloudstate/cloudstate-proxy-jdbc/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflect-config.json

--- a/proxy/postgres/src/graal/META-INF/native-image/io.cloudstate/cloudstate-proxy-jdbc/reflect-config.json.conf
+++ b/proxy/postgres/src/graal/META-INF/native-image/io.cloudstate/cloudstate-proxy-jdbc/reflect-config.json.conf
@@ -1,0 +1,6 @@
+[
+{
+  name: "io.cloudstate.proxy.jdbc.SlickEnsureTablesExistReadyCheck"
+  methods: [{name: "<init>", parameterTypes: ["akka.actor.ActorSystem"]}]
+}
+]

--- a/proxy/postgres/src/graal/META-INF/native-image/net.java.openjdk/base/reflect-config.json.conf
+++ b/proxy/postgres/src/graal/META-INF/native-image/net.java.openjdk/base/reflect-config.json.conf
@@ -52,4 +52,8 @@
 {
   name: "java.sql.Statement[]"
 }
+{
+  name: "java.util.concurrent.CopyOnWriteArrayList"
+  fields: [{name: "lock", allowWrite: true}]
+}
 ]


### PR DESCRIPTION
Should resolve #331 and resolve #404.

Fix the postgres and cassandra native image builds. Add graal-tools, dependency override for shaded netty, and reflection config. Tested manually in docker and then minikube.

I'll look at following up with some automated tests, which will need to be in Circle where we can build native images (see also #379).