### PR TITLE
Asciidoc: strip leading indentation from included examples

### DIFF
--- a/docs-asciidoc/shared-content/modules/java/pages/crdt.adoc
+++ b/docs-asciidoc/shared-content/modules/java/pages/crdt.adoc
@@ -4,7 +4,7 @@ This page documents how to implement Cloudstate CRDT entities in Java. For infor
 
 A CRDT can be created by annotating it with the @javadoc[`@CrdtEntity`](io.cloudstate.javasupport.crdt.CrdtEntity) annotation.
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/crdt/ShoppingCartEntity.java[tag=entity-class]
 ----
@@ -19,7 +19,7 @@ An entity's CRDT can be created from the entity's constructor using the `CrdtFac
 
 For most use cases, simply injecting the CRDT directly into the constructor, and storing in a local field, will be the most convenient and straightforward method of using a CRDT. In our shopping cart example, we're going to use an @javadoc[`LWWRegisterMap`](io.cloudstate.javasupport.crdt.LWWRegisterMap), this shows how it may be injected:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/crdt/ShoppingCartEntity.java[tag=creation]
 ----
@@ -38,7 +38,7 @@ The return type of the command handler must be the output type for the gRPC serv
 
 The following shows the implementation of the `GetCart` command handler. This command handler is a read-only command handler, it doesn't update the CRDT, it just returns some state:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/crdt/ShoppingCartEntity.java[tag=get-cart]
 ----
@@ -49,7 +49,7 @@ Due to CloudState's xref:concepts:crdts.adoc#_approach_to_crdts_in_cloudstate[ta
 
 Here's a command handler for the `AddItem` command that adds the item to the shopping cart:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/crdt/ShoppingCartEntity.java[tag=add-item]
 ----
@@ -79,7 +79,7 @@ rpc WatchCart(GetShoppingCart) returns (stream Cart);
 
 that could be implemented like this:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/crdt/ShoppingCartEntity.java[tag=WATCH-CART]
 ----
@@ -161,7 +161,7 @@ Some wrapper classes are also provided for ORMap. These provide more convenient 
 Once you've created your entity, you can register it with the @javadoc[`CloudState`](io.cloudstate.javasupport.CloudState) server, by invoking the @javadoc[`registerCrdtEntity`](io.cloudstate.javasupport.CloudState#registerCrdtEntity-java.lang.Class-com.google.protobuf.Descriptors.ServiceDescriptor-com.google.protobuf.Descriptors.FileDescriptor...-) method.
 In addition to passing your entity class and service descriptor, if you use protobuf for serialization and any protobuf message definitions are missing from your service descriptor (they are not declared directly in the file, nor as dependencies), then you'll need to pass those protobuf descriptors as well.
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/crdt/ShoppingCartEntity.java[tag=register]
 ----

--- a/docs-asciidoc/shared-content/modules/java/pages/effects.adoc
+++ b/docs-asciidoc/shared-content/modules/java/pages/effects.adoc
@@ -8,7 +8,7 @@ To forward a command or emit an effect, a reference to the service call that wil
 
 For example, if a user function serves two entity types, a shopping cart, and a CRDT that tracks which items are currently in hot demand, it might want to invoke the `ItemAddedToCart` command on `example.shoppingcart.HotItems` as a side effect of the `AddItem` shopping cart command. This reference can be looked up like so:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/effects/ShoppingCartEntity.java[tag=lookup]
 ----
@@ -19,7 +19,7 @@ This could be looked up in the constructor of the entity, for later use, so it d
 
 The `CommandContext` for each entity type implements `ClientActionContext` to allow forwarding a command by invoking @javadoc[`ClientActionContext.forward()`](io.cloudstate.javasupport.ClientActionContext#forward-io.cloudstate.javasupport.ServiceCall-). For example, if the item being processed in the `addItem` command is a "hot" item, we can make the `HotItems` entity aware of that item by forwarding a command:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/effects/ShoppingCartEntity.java[tag=FORWARD]
 ----
@@ -28,7 +28,7 @@ include::example$docs/user/effects/ShoppingCartEntity.java[tag=FORWARD]
 
 The `CommandContext` for each entity type implements `EffectContext` to allow emitting an effect by invoking @javadoc[`EffectContext.effect()`](io.cloudstate.javasupport.EffectContext#effect-io.cloudstate.javasupport.ServiceCall-boolean-). For example, upon successful completion of the `addItem` command by `ShoppingCartEntity`, if we also want to emit an effect on the `HotItems` entity, we would invoke the effectful service call as:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/effects/ShoppingCartEntity.java[tag=effect]
 ----

--- a/docs-asciidoc/shared-content/modules/java/pages/eventsourced.adoc
+++ b/docs-asciidoc/shared-content/modules/java/pages/eventsourced.adoc
@@ -4,7 +4,7 @@ This page documents how to implement Cloudstate event sourced entities in Java. 
 
 An event sourced entity can be created by annotating it with the @javadoc[`@EventSourcedEntity`](io.cloudstate.javasupport.eventsourced.EventSourcedEntity) annotation.
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=entity-class]
 ----
@@ -21,7 +21,7 @@ While protobuf is the recommended format for persisting events, it is recommende
 
 For our shopping cart example, we'll create a new file called `domain.proto`, the name domain is selected to indicate that these are my applications domain objects:
 
-[source,proto]
+[source,proto,indent=0]
 ----
 include::proto:example$domain.proto[]
 ----
@@ -30,7 +30,7 @@ include::proto:example$domain.proto[]
 
 Each entity should store its state locally in a mutable variable, either a mutable field or a multiple structure such as a collection. For our shopping cart, the state is a map of product ids to products, so we'll create a map to contain that:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=entity-state]
 ----
@@ -39,7 +39,7 @@ include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=entity-state
 
 The context available for injection into the constructor is a @javadoc[`EventSourcedEntityCreationContext`](io.cloudstate.javasupport.eventsourced.EventSourcedEntityCreationContext). While you don't necessarily need to define a constructor, you can define one and have that context injected in. The constructor below shows how the `entityId` is injected:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=constructing]
 ----
@@ -56,7 +56,7 @@ The return type of the command handler must be the output type for the gRPC serv
 
 The following shows the implementation of the `GetCart` command handler. This command handler is a read-only command handler, it doesn't emit any events, it just returns some state:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=get-cart]
 ----
@@ -74,7 +74,7 @@ A command handler may emit an event by taking in a @javadoc[`CommandContext`](io
 
 Here's an example of a command handler that emits an event:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=add-item]
 ----
@@ -93,7 +93,7 @@ Event handlers may be declared for a superclass or interface of the types they h
 
 Here's an example event handler for the `ItemAdded` event. A utility method, `convert` is also defined to assist it.
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=item-added]
 ----
@@ -102,7 +102,7 @@ include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=item-added]
 
 Snapshots are an important optimisation for event sourced entities that may contain many events, to ensure that they can be loaded quickly even when they have very long journals. To produce a snapshot, a method annotated with @javadoc[`@Snapshot`](io.cloudstate.javasupport.eventsourced.Snapshot) must be declared. It takes a context class of type @javadoc[`SnapshotContext`](io.cloudstate.javasupport.eventsourced.SnapshotContext), and must return a snapshot of the current state in serializable form.
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=snapshot]
 ----
@@ -111,7 +111,7 @@ When the entity is loaded again, the snapshot will first be loaded before any ot
 
 Multiple snapshot handlers may be defined to handle multiple different types of snapshots, the type matching is done in the same way as for events.
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=handle-snapshot]
 ----
@@ -120,7 +120,7 @@ include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=handle-snaps
 
 Once you've created your entity, you can register it with the @javadoc[`CloudState`](io.cloudstate.javasupport.CloudState) server, by invoking the `registerEventSourcedEntity` method. In addition to passing your entity class and service descriptor, you also need to pass any descriptors that you use for persisting events, for example, the `domain.proto` descriptor.
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/eventsourced/ShoppingCartEntity.java[tag=register]
 ----

--- a/docs-asciidoc/shared-content/modules/java/pages/getting-started.adoc
+++ b/docs-asciidoc/shared-content/modules/java/pages/getting-started.adoc
@@ -185,7 +185,7 @@ Now if you run `mvn compile`, you'll find your generated protobuf files in `targ
 
 Your main class will be responsible for creating the Cloudstate gRPC server, registering the entities for it to serve, and starting it. To do this, you can use the @javadoc[`CloudState`](io.cloudstate.javasupport.CloudState) server builder, for example:
 
-[source,java]
+[source,java,indent=0]
 ----
 include::example$docs/user/gettingstarted/ShoppingCartMain.java[tag=shopping-cart-main]
 ----

--- a/docs-asciidoc/shared-content/modules/javascript/pages/eventsourced.adoc
+++ b/docs-asciidoc/shared-content/modules/javascript/pages/eventsourced.adoc
@@ -10,7 +10,7 @@ While protobufs are the recommended format for persisting events, it is recommen
 
 For our shopping cart example, we'll create a new file called `domain.proto`, the name domain is selected to indicate that these are my applications domain objects:
 
-[source,proto]
+[source,proto,indent=0]
 ----
 include::proto:example$domain.proto[]
 ----
@@ -21,7 +21,7 @@ In this file, the `Cart` message is the state, while `ItemAdded` and `ItemRemove
 
 An event sourced entity can be created using the @extref:[EventSourced](jsdoc:EventSourced.html) class.
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=entity-class]
 ----
@@ -40,7 +40,7 @@ When you pass an event or snapshot to Cloudstate to persist, it needs to know ho
 
 The `EventSourced` class provides a helper method called @extref:[`lookupType`](jsdoc:EventSourced.html#lookupType) to facilitate this. So before implementing anything, we'll look up these types so we can use them later.
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=lookup-type]
 ----
@@ -51,7 +51,7 @@ When there are no snapshots persisted for an entity (such as when the entity is 
 
 To create the initial state, we set the @extref:[`initial`](jsdoc:EventSourced.html#initial) callback. This takes the id of the entity being created, and returns a new empty state, in this case, an empty shopping cart:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=initial]
 ----
@@ -72,7 +72,7 @@ The command handler must return a message of the same type as the output type of
 
 The following shows the implementation of the `GetCart` command handler. This command handler is a read-only command handler, it doesn't emit any events, it just returns some state:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=get-cart]
 ----
@@ -87,7 +87,7 @@ A command handler may emit an event by using the @extref:[`emit`](jsdoc:EventSou
 
 Here's an example of a command handler that emits an event:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=add-item]
 ----
@@ -104,7 +104,7 @@ Event handlers take the event they are handling, and the state, and must return 
 
 Here's an example event handler for the `ItemAdded` event:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=item-added]
 ----
@@ -115,7 +115,7 @@ Once you have your command handler and event handler functions implemented, you 
 
 The behavior callback can be set by setting the @extref:[`behavior`](jsdoc:EventSourced.html#behavior) property on the entity:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=behavior]
 ----
@@ -132,7 +132,7 @@ The entities behavior can be changed by returning different sets of handlers fro
 
 In the example below, we show a shopping cart that also has a checkout command. Once checked out, the shopping cart no longer accepts any commands to add or remove items, its state and therefore behavior changes:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=multiple-behaviors]
 ----
@@ -141,14 +141,14 @@ include::example$test/eventsourced/shoppingcart.js[tag=multiple-behaviors]
 
 If you only have a single entity, as a convenience, you can start it directly, by invoking the @extref:[`start`](jsdoc:EventSourced.html#start) method, like so:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=start]
 ----
 
 Alternatively, you can add it to the `Cloudstate` server explicitly:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/eventsourced/shoppingcart.js[tag=add-entity]
 ----

--- a/docs-asciidoc/shared-content/modules/javascript/pages/getting-started.adoc
+++ b/docs-asciidoc/shared-content/modules/javascript/pages/getting-started.adoc
@@ -65,14 +65,14 @@ You can place protobuf files in your project wherever you like, for example, in 
 
 There are two ways to create and start a Cloudstate gRPC server. The first is to create an @extref:[`Entity`](jsdoc:Entity.html), and invoke @extref:[`start`](jsdoc:Entity.html#start) on it. This allows creating a server that serves a single entity, with the default options. We'll look at this more in the subsequent pages. Alternatively, you can use the @extref:[`CloudState`](jsdoc:CloudState.html) class, add one or more entities to it, and then invoke @extref:[`start`](jsdoc:CloudState.html#start), like so:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/gettingstarted/index.js[tag=start]
 ----
 
 If you created your protobuf file descriptor set at a different location to the default of `user-function.desc`, you can configure that here:
 
-[source,js]
+[source,js,indent=0]
 ----
 include::example$test/gettingstarted/index.js[tag=custom-desc]
 ----


### PR DESCRIPTION
Add the source option to strip leading indentation from code snippets. To keep things simple, add to all source includes, whether they have extra indentation or not.