### PR TITLE
Extend TCK with event-sourced model test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -757,7 +757,7 @@ lazy val `testkit` = (project in file("testkit"))
 lazy val `tck` = (project in file("tck"))
   .enablePlugins(AkkaGrpcPlugin, JavaAppPackaging, DockerPlugin, NoPublish)
   .configs(IntegrationTest)
-  .dependsOn(`akka-client`)
+  .dependsOn(`akka-client`, testkit)
   .settings(
     Defaults.itSettings,
     common,
@@ -780,7 +780,9 @@ lazy val `tck` = (project in file("tck"))
     bashScriptExtraDefines += "addApp io.cloudstate.tck.ConfiguredCloudStateTCK",
     headerSettings(IntegrationTest),
     automateHeaderSettings(IntegrationTest),
-    javaOptions in IntegrationTest := sys.props.get("config.resource").map(r => s"-Dconfig.resource=$r").toSeq,
+    fork in IntegrationTest := true,
+    javaOptions in IntegrationTest := Seq("config.resource", "user.dir")
+        .flatMap(key => sys.props.get(key).map(value => s"-D$key=$value")),
     parallelExecution in IntegrationTest := false,
     executeTests in IntegrationTest := (executeTests in IntegrationTest)
         .dependsOn(`proxy-core` / assembly, `java-shopping-cart` / assembly)

--- a/build.sbt
+++ b/build.sbt
@@ -110,6 +110,7 @@ lazy val root = (project in file("."))
     `protocols`,
     `proxy`,
     `java-support`,
+    `java-support-tck`,
     `java-shopping-cart`,
     `java-pingpong`,
     `akka-client`,
@@ -668,6 +669,20 @@ lazy val `java-support` = (project in file("java-support"))
     )
   )
 
+lazy val `java-support-tck` = (project in file("java-support/tck"))
+  .dependsOn(`java-support`, `java-shopping-cart`)
+  .enablePlugins(AkkaGrpcPlugin, AssemblyPlugin, JavaAppPackaging, DockerPlugin, AutomateHeaderPlugin, NoPublish)
+  .settings(
+    name := "cloudstate-java-tck",
+    dockerSettings,
+    mainClass in Compile := Some("io.cloudstate.javasupport.tck.JavaSupportTck"),
+    akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
+    PB.protoSources in Compile += (baseDirectory in ThisBuild).value / "protocols" / "tck",
+    PB.targets in Compile := Seq(PB.gens.java -> (sourceManaged in Compile).value),
+    javacOptions in Compile ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8"),
+    assemblySettings("cloudstate-java-tck.jar")
+  )
+
 lazy val `java-shopping-cart` = (project in file("samples/java-shopping-cart"))
   .dependsOn(`java-support`)
   .enablePlugins(AkkaGrpcPlugin, AssemblyPlugin, JavaAppPackaging, DockerPlugin, AutomateHeaderPlugin, NoPublish)
@@ -773,7 +788,7 @@ lazy val `tck` = (project in file("tck"))
       ),
     PB.protoSources in Compile ++= {
       val baseDir = (baseDirectory in ThisBuild).value / "protocols"
-      Seq(baseDir / "protocol")
+      Seq(baseDir / "protocol", baseDir / "tck")
     },
     dockerSettings,
     Compile / bashScriptDefines / mainClass := Some("org.scalatest.run"),
@@ -785,7 +800,7 @@ lazy val `tck` = (project in file("tck"))
         .flatMap(key => sys.props.get(key).map(value => s"-D$key=$value")),
     parallelExecution in IntegrationTest := false,
     executeTests in IntegrationTest := (executeTests in IntegrationTest)
-        .dependsOn(`proxy-core` / assembly, `java-shopping-cart` / assembly)
+        .dependsOn(`proxy-core` / assembly, `java-support-tck` / assembly)
         .value
   )
 

--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/Contexts.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/Contexts.scala
@@ -38,12 +38,12 @@ private[impl] trait AbstractEffectContext extends EffectContext {
 
   override final def effect(effect: ServiceCall, synchronous: Boolean): Unit = {
     checkActive()
-    SideEffect(
-      serviceName = effect.ref().method().getService.getFullName,
-      commandName = effect.ref().method().getName,
-      payload = Some(ScalaPbAny.fromJavaProto(effect.message())),
-      synchronous = synchronous
-    ) :: effects
+    effects = SideEffect(
+        serviceName = effect.ref().method().getService.getFullName,
+        commandName = effect.ref().method().getName,
+        payload = Some(ScalaPbAny.fromJavaProto(effect.message())),
+        synchronous = synchronous
+      ) :: effects
   }
 
   final def sideEffects: List[SideEffect] = effects.reverse

--- a/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/EventSourcedImplSpec.scala
+++ b/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/EventSourcedImplSpec.scala
@@ -47,15 +47,17 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
       entity.send(command(1, "cart", "GetCart"))
       entity.expect(reply(1, EmptyCart))
       entity.send(command(2, "cart", "AddItem", addItem("abc", "apple", 1)))
-      entity.expect(reply(2, EmptyJavaMessage, itemAdded("abc", "apple", 1)))
+      entity.expect(reply(2, EmptyJavaMessage, persist(itemAdded("abc", "apple", 1))))
       entity.send(command(3, "cart", "AddItem", addItem("abc", "apple", 2)))
       entity.expect(
-        reply(3, EmptyJavaMessage, Seq(itemAdded("abc", "apple", 2)), cartSnapshot(Item("abc", "apple", 3)))
+        reply(3,
+              EmptyJavaMessage,
+              persist(itemAdded("abc", "apple", 2)).withSnapshot(cartSnapshot(Item("abc", "apple", 3))))
       )
       entity.send(command(4, "cart", "GetCart"))
       entity.expect(reply(4, cart(Item("abc", "apple", 3))))
       entity.send(command(5, "cart", "AddItem", addItem("123", "banana", 4)))
-      entity.expect(reply(5, EmptyJavaMessage, itemAdded("123", "banana", 4)))
+      entity.expect(reply(5, EmptyJavaMessage, persist(itemAdded("123", "banana", 4))))
       entity.passivate()
       val reactivated = protocol.eventSourced.connect()
       reactivated.send(init(ShoppingCart.Name, "cart", snapshot(3, cartSnapshot(Item("abc", "apple", 3)))))

--- a/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/EventSourcedImplSpec.scala
+++ b/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/EventSourcedImplSpec.scala
@@ -19,7 +19,8 @@ package io.cloudstate.javasupport.impl.eventsourced
 import com.google.protobuf.Empty
 import io.cloudstate.javasupport.EntityId
 import io.cloudstate.javasupport.eventsourced._
-import io.cloudstate.testkit.eventsourced.{EventSourcedMessages, TestEventSourcedClient}
+import io.cloudstate.testkit.TestProtocol
+import io.cloudstate.testkit.eventsourced.EventSourcedMessages
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 import scala.collection.mutable
 import scala.reflect.ClassTag
@@ -31,30 +32,32 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
   import ShoppingCart.Protocol._
 
   val service: TestEventSourcedService = ShoppingCart.testService
-  val client: TestEventSourcedClient = TestEventSourcedClient(service.port)
+  val protocol: TestProtocol = TestProtocol(service.port)
 
   override def afterAll(): Unit = {
-    client.terminate()
+    protocol.terminate()
     service.terminate()
   }
 
   "EventSourcedImpl" should {
 
     "manage entities with expected commands and events" in {
-      val entity = client.connect
+      val entity = protocol.eventSourced.connect()
       entity.send(init(ShoppingCart.Name, "cart"))
       entity.send(command(1, "cart", "GetCart"))
       entity.expect(reply(1, EmptyCart))
       entity.send(command(2, "cart", "AddItem", addItem("abc", "apple", 1)))
-      entity.expect(reply(2, EmptyPayload, itemAdded("abc", "apple", 1)))
+      entity.expect(reply(2, EmptyJavaMessage, itemAdded("abc", "apple", 1)))
       entity.send(command(3, "cart", "AddItem", addItem("abc", "apple", 2)))
-      entity.expect(reply(3, EmptyPayload, Seq(itemAdded("abc", "apple", 2)), cartSnapshot(Item("abc", "apple", 3))))
+      entity.expect(
+        reply(3, EmptyJavaMessage, Seq(itemAdded("abc", "apple", 2)), cartSnapshot(Item("abc", "apple", 3)))
+      )
       entity.send(command(4, "cart", "GetCart"))
       entity.expect(reply(4, cart(Item("abc", "apple", 3))))
       entity.send(command(5, "cart", "AddItem", addItem("123", "banana", 4)))
-      entity.expect(reply(5, EmptyPayload, itemAdded("123", "banana", 4)))
+      entity.expect(reply(5, EmptyJavaMessage, itemAdded("123", "banana", 4)))
       entity.passivate()
-      val reactivated = client.connect
+      val reactivated = protocol.eventSourced.connect()
       reactivated.send(init(ShoppingCart.Name, "cart", snapshot(3, cartSnapshot(Item("abc", "apple", 3)))))
       reactivated.send(event(4, itemAdded("123", "banana", 4)))
       reactivated.send(command(1, "cart", "GetCart"))
@@ -64,7 +67,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when first message is not init" in {
       service.expectLogError("Terminating entity due to unexpected failure") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(command(1, "cart", "command"))
         entity.expect(failure("Protocol error: Expected Init message"))
         entity.expectClosed()
@@ -73,7 +76,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when service doesn't exist" in {
       service.expectLogError("Terminating entity [foo] due to unexpected failure") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(serviceName = "DoesNotExist", entityId = "foo"))
         entity.expect(failure("Protocol error: Service not found: DoesNotExist"))
         entity.expectClosed()
@@ -82,7 +85,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when command payload is missing" in {
       service.expectLogError("Terminating entity [cart] due to unexpected failure for command [foo]") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(ShoppingCart.Name, "cart"))
         entity.send(command(1, "cart", "foo", payload = None))
         entity.expect(failure(1, "Protocol error: No command payload"))
@@ -92,7 +95,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when command entity id is incorrect" in {
       service.expectLogError("Terminating entity [cart2] due to unexpected failure for command [foo]") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(ShoppingCart.Name, "cart1"))
         entity.send(command(1, "cart2", "foo"))
         entity.expect(failure(1, "Protocol error: Receiving entity is not the intended recipient of command"))
@@ -102,7 +105,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when entity is sent multiple init" in {
       service.expectLogError("Terminating entity [cart] due to unexpected failure") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(ShoppingCart.Name, "cart"))
         entity.send(init(ShoppingCart.Name, "cart"))
         entity.expect(failure("Protocol error: Entity already inited"))
@@ -112,9 +115,9 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when entity is sent empty message" in {
       service.expectLogError("Terminating entity [cart] due to unexpected failure") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(ShoppingCart.Name, "cart"))
-        entity.send(EmptyMessage)
+        entity.send(EmptyInMessage)
         entity.expect(failure("Protocol error: Received empty/unknown message"))
         entity.expectClosed()
       }
@@ -122,7 +125,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when snapshot handler does not exist" in {
       service.expectLogError("Terminating entity due to unexpected failure") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         val notSnapshot = domainLineItem("?", "not a cart snapshot", 1)
         val snapshotClass = notSnapshot.getClass
         entity.send(init(ShoppingCart.Name, "cart", snapshot(42, notSnapshot)))
@@ -135,7 +138,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when snapshot handler throws exception" in {
       service.expectLogError("Terminating entity due to unexpected failure") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(ShoppingCart.Name, "cart", snapshot(42, cartSnapshot())))
         entity.expect(failure("Unexpected failure: Boom: no items"))
         entity.expectClosed()
@@ -144,7 +147,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when event handler does not exist" in {
       service.expectLogError("Terminating entity due to unexpected failure") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         val notEvent = domainLineItem("?", "not an event", 1)
         val eventClass = notEvent.getClass
         entity.send(init(ShoppingCart.Name, "cart"))
@@ -156,7 +159,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when event handler throws exception" in {
       service.expectLogError("Terminating entity due to unexpected failure") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(ShoppingCart.Name, "cart"))
         entity.send(event(1, itemAdded("123", "FAIL", 42)))
         entity.expect(failure("Unexpected failure: Boom: name is FAIL"))
@@ -166,7 +169,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when command handler does not exist" in {
       service.expectLogError("Terminating entity [cart] due to unexpected failure for command [foo]") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(ShoppingCart.Name, "cart"))
         entity.send(command(1, "cart", "foo"))
         entity.expect(failure(1, s"No command handler found for command [foo] on ${ShoppingCart.TestCartClass}"))
@@ -178,14 +181,14 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
       service.expectLogError(
         "Fail invoked for command [AddItem] for entity [cart]: Cannot add negative quantity of item [foo]"
       ) {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(ShoppingCart.Name, "cart"))
         entity.send(command(1, "cart", "AddItem", addItem("foo", "bar", -1)))
         entity.expect(actionFailure(1, "Cannot add negative quantity of item [foo]"))
         entity.send(command(2, "cart", "GetCart"))
         entity.expect(reply(2, EmptyCart)) // check emit-then-fail doesn't change entity state
         entity.passivate()
-        val reactivated = client.connect
+        val reactivated = protocol.eventSourced.connect()
         reactivated.send(init(ShoppingCart.Name, "cart"))
         reactivated.send(command(1, "cart", "GetCart"))
         reactivated.expect(reply(1, EmptyCart))
@@ -195,7 +198,7 @@ class EventSourcedImplSpec extends WordSpec with Matchers with BeforeAndAfterAll
 
     "fail when command handler throws exception" in {
       service.expectLogError("Terminating entity [cart] due to unexpected failure for command [RemoveItem]") {
-        val entity = client.connect
+        val entity = protocol.eventSourced.connect()
         entity.send(init(ShoppingCart.Name, "cart"))
         entity.send(command(1, "cart", "RemoveItem", removeItem("foo")))
         entity.expect(failure(1, "Unexpected failure: Boom: foo"))

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/JavaSupportTck.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/JavaSupportTck.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.javasupport.tck;
+
+import com.example.shoppingcart.Shoppingcart;
+import io.cloudstate.javasupport.CloudState;
+import io.cloudstate.javasupport.tck.model.eventsourced.EventSourcedTckModelEntity;
+import io.cloudstate.javasupport.tck.model.eventsourced.EventSourcedTwoEntity;
+import io.cloudstate.samples.shoppingcart.ShoppingCartEntity;
+import io.cloudstate.tck.model.Eventsourced;
+
+public final class JavaSupportTck {
+  public static final void main(String[] args) throws Exception {
+    new CloudState()
+        .registerEventSourcedEntity(
+            EventSourcedTckModelEntity.class,
+            Eventsourced.getDescriptor().findServiceByName("EventSourcedTckModel"),
+            Eventsourced.getDescriptor())
+        .registerEventSourcedEntity(
+            EventSourcedTwoEntity.class,
+            Eventsourced.getDescriptor().findServiceByName("EventSourcedTwo"))
+        .registerEventSourcedEntity(
+            ShoppingCartEntity.class,
+            Shoppingcart.getDescriptor().findServiceByName("ShoppingCart"),
+            com.example.shoppingcart.persistence.Domain.getDescriptor())
+        .start()
+        .toCompletableFuture()
+        .get();
+  }
+}

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/eventsourced/EventSourcedTckModelEntity.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/eventsourced/EventSourcedTckModelEntity.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.javasupport.tck.model.eventsourced;
+
+import io.cloudstate.javasupport.Context;
+import io.cloudstate.javasupport.ServiceCall;
+import io.cloudstate.javasupport.ServiceCallRef;
+import io.cloudstate.javasupport.eventsourced.*;
+import io.cloudstate.tck.model.Eventsourced.*;
+import java.util.Optional;
+
+@EventSourcedEntity(persistenceId = "event-sourced-tck-model", snapshotEvery = 5)
+public class EventSourcedTckModelEntity {
+
+  private final ServiceCallRef<Request> serviceTwoCall;
+
+  private String state = "";
+
+  public EventSourcedTckModelEntity(Context context) {
+    serviceTwoCall =
+        context
+            .serviceCallFactory()
+            .lookup("cloudstate.tck.model.EventSourcedTwo", "Call", Request.class);
+  }
+
+  @Snapshot
+  public Persisted snapshot() {
+    return Persisted.newBuilder().setValue(state).build();
+  }
+
+  @SnapshotHandler
+  public void handleSnapshot(Persisted snapshot) {
+    state = snapshot.getValue();
+  }
+
+  @EventHandler
+  public void handleEvent(Persisted event) {
+    state += event.getValue();
+  }
+
+  @CommandHandler
+  public Optional<Response> process(Request request, CommandContext context) {
+    boolean forwarding = false;
+    for (RequestAction action : request.getActionsList()) {
+      switch (action.getActionCase()) {
+        case EMIT:
+          context.emit(Persisted.newBuilder().setValue(action.getEmit().getValue()).build());
+          break;
+        case FORWARD:
+          forwarding = true;
+          context.forward(serviceTwoRequest(action.getForward().getId()));
+          break;
+        case EFFECT:
+          Effect effect = action.getEffect();
+          context.effect(serviceTwoRequest(effect.getId()), effect.getSynchronous());
+          break;
+        case FAIL:
+          context.fail(action.getFail().getMessage());
+          break;
+      }
+    }
+    return forwarding
+        ? Optional.empty()
+        : Optional.of(Response.newBuilder().setMessage(state).build());
+  }
+
+  private ServiceCall serviceTwoRequest(String id) {
+    return serviceTwoCall.createCall(Request.newBuilder().setId(id).build());
+  }
+}

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/eventsourced/EventSourcedTwoEntity.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/eventsourced/EventSourcedTwoEntity.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.javasupport.tck.model.eventsourced;
+
+import io.cloudstate.javasupport.eventsourced.*;
+import io.cloudstate.tck.model.Eventsourced.*;
+
+@EventSourcedEntity
+public class EventSourcedTwoEntity {
+  public EventSourcedTwoEntity() {}
+
+  @CommandHandler
+  public Response call(Request request) {
+    return Response.newBuilder().build();
+  }
+}

--- a/node-support/src/command-helper.js
+++ b/node-support/src/command-helper.js
@@ -150,9 +150,7 @@ module.exports = class CommandHelper {
         ctx.reply.clientAction = {
           reply: {
             payload: AnySupport.serialize(grpcMethod.resolvedResponseType.create(userReply), false, false),
-            metadata: {
-              entries: ctx.replyMetadata.entries
-            }
+            metadata: (ctx.replyMetadata.entries.length) ? { entries: ctx.replyMetadata.entries } : null
           }
         };
         ctx.commandDebug("%s reply with type [%s] with %d side effects.", desc, ctx.reply.clientAction.reply.payload.type_url, ctx.effects.length);

--- a/protocols/tck/cloudstate/tck/model/eventsourced.proto
+++ b/protocols/tck/cloudstate/tck/model/eventsourced.proto
@@ -1,0 +1,123 @@
+// Copyright 2019 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// == Cloudstate TCK model test for event-sourced entities ==
+//
+
+syntax = "proto3";
+
+package cloudstate.tck.model;
+
+import "cloudstate/entity_key.proto";
+
+option java_package = "io.cloudstate.tck.model";
+
+//
+// The `EventSourcedTckModel` service should be implemented in the following ways:
+//
+// - The entity persistence-id must be `event-sourced-tck-model`.
+// - Snapshots must be configured for every 5 events.
+// - The state of the entity is simply a string.
+// - Event and snapshot string values are wrapped in `Persisted` messages.
+// - The snapshot handler must set the state to the value of a `Persisted` message.
+// - The event handler must append the value of a `Persisted` message to the state string.
+// - The `Process` method receives a `Request` message with actions to take.
+// - Request actions must be processed in order, and can require emitting events, forwarding, side effects, or failing.
+// - The `Process` method must reply with the state in a `Response`, after taking actions, unless forwarding or failing.
+// - Forwarding and side effects must always be made to the second service `EventSourcedTwo`.
+//
+service EventSourcedTckModel {
+  rpc Process(Request) returns (Response);
+}
+
+//
+// The `EventSourcedTwo` service is only for verifying forward actions and side effects.
+// The `Call` method is not required to do anything, and may simply return an empty `Response` message.
+//
+service EventSourcedTwo {
+  rpc Call(Request) returns (Response);
+}
+
+//
+// A `Request` message contains any actions that the entity should process.
+// Actions must be processed in order. Any actions after a `Fail` may be ignored.
+//
+message Request {
+  string id = 1 [(.cloudstate.entity_key) = true];
+  repeated RequestAction actions = 2;
+}
+
+//
+// Each `RequestAction` is one of:
+//
+// - Emit: emit an event, with a given value.
+// - Forward: forward to another service, in place of replying with a Response.
+// - Effect: add a side effect to another service to the reply.
+// - Fail: fail the current `Process` command.
+//
+message RequestAction {
+  oneof action {
+    Emit emit = 1;
+    Forward forward = 2;
+    Effect effect = 3;
+    Fail fail = 4;
+  }
+}
+
+//
+// Emit an event, with the event value in a `Persisted` message.
+//
+message Emit {
+  string value = 1;
+}
+
+//
+// Replace the response with a forward to `cloudstate.tck.model.EventSourcedTwo/Call`.
+// The payload must be a `Request` message with the given `id`.
+//
+message Forward {
+  string id = 1;
+}
+
+//
+// Add a side effect to the reply, to `cloudstate.tck.model.EventSourcedTwo/Call`.
+// The payload must be a `Request` message with the given `id`.
+// The side effect should be marked synchronous based on the given `synchronous` value.
+//
+message Effect {
+  string id = 1;
+  bool synchronous = 2;
+}
+
+//
+// Fail the current command with the given description `message`.
+//
+message Fail {
+  string message = 1;
+}
+
+//
+// The `Response` message for the `Process` must contain the current state (after processing actions).
+//
+message Response {
+  string message = 1;
+}
+
+//
+// The `Persisted` message wraps both snapshot and event values.
+//
+message Persisted {
+  string value = 1;
+}

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
@@ -16,7 +16,7 @@
 
 package io.cloudstate.proxy
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.annotation.tailrec
 import akka.grpc.internal.{
@@ -46,7 +46,6 @@ import io.cloudstate.proxy.EntityDiscoveryManager.ServableEntity
 import io.cloudstate.proxy.entity.UserFunctionReply
 import io.cloudstate.proxy.protobuf.Types
 import io.grpc.{Status, StatusRuntimeException}
-import org.slf4j.{Logger, LoggerFactory}
 
 object Serve {
   private[this] final val fallback: Any => Any = _ => fallback
@@ -165,7 +164,7 @@ object Serve {
       HttpApi.serve(entities.map(_.serviceDescriptor -> grpcProxy).toList),
       handleNetworkProbe(),
       ServerReflectionHandler.partial(
-        ServerReflectionImpl(fileDescriptors, entities.map(_.serviceName).toList)
+        ServerReflectionImpl(fileDescriptors, entities.map(_.serviceName).sorted.toList)
       )
     )
 

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentationSpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentationSpec.scala
@@ -130,7 +130,7 @@ class EventSourcedInstrumentationSpec extends AbstractTelemetrySpec {
       val event3 = ProtoAny("event", ByteString.copyFromUtf8("event3"))
       val snapshot1 = ProtoAny("snapshot", ByteString.copyFromUtf8("snapshot1"))
 
-      connection.send(reply(1, reply1, Seq(event1, event2, event3), snapshot1))
+      connection.send(reply(1, reply1, persist(event1, event2, event3).withSnapshot(snapshot1)))
 
       expectMsg(UserFunctionReply(clientActionReply(messagePayload(reply1))))
 
@@ -169,7 +169,7 @@ class EventSourcedInstrumentationSpec extends AbstractTelemetrySpec {
       val event4 = ProtoAny("event", ByteString.copyFromUtf8("event4"))
       val event5 = ProtoAny("event", ByteString.copyFromUtf8("event5"))
 
-      connection.send(reply(2, reply2, event4, event5))
+      connection.send(reply(2, reply2, persist(event4, event5)))
 
       expectMsg(UserFunctionReply(clientActionReply(messagePayload(reply2))))
 

--- a/tck/src/it/resources/application.conf
+++ b/tck/src/it/resources/application.conf
@@ -25,7 +25,7 @@ cloudstate-tck.combinations = [{
     }
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
     port = 8080
     directory = ${user.dir}/samples/js-shopping-cart
@@ -52,7 +52,7 @@ cloudstate-tck.combinations = [{
     }
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
     port = 8088
     directory = ${user.dir}/samples/java-shopping-cart
@@ -78,7 +78,7 @@ cloudstate-tck.combinations = [{
     }
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
     port = 8080
     directory = ${user.dir}
@@ -104,7 +104,7 @@ cloudstate-tck.combinations = [{
     }
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
     port = 8088
     directory = ${user.dir}

--- a/tck/src/it/resources/application.conf
+++ b/tck/src/it/resources/application.conf
@@ -55,8 +55,8 @@ cloudstate-tck.combinations = [{
   service {
     hostname = "127.0.0.1"
     port = 8088
-    directory = ${user.dir}/samples/java-shopping-cart
-    command = ["java","-Xmx512M", "-Xms128M", "-jar", "target/scala-2.13/java-shopping-cart.jar"]
+    directory = ${user.dir}/java-support/tck
+    command = ["java","-Xmx512M", "-Xms128M", "-jar", "target/scala-2.13/cloudstate-java-tck.jar"]
     env-vars {
       HOST = "127.0.0.1"
       PORT = "8088"

--- a/tck/src/it/resources/native-image.conf
+++ b/tck/src/it/resources/native-image.conf
@@ -10,7 +10,7 @@ cloudstate-tck.combinations = [{
     docker-image = "cloudstateio/cloudstate-proxy-native-dev-mode:latest"
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
     command = ["docker", "run", "--rm", "-p", "127.0.0.1:8080:8080", "cloudstateio/samples-js-shopping-cart"]
     env-vars {
@@ -28,7 +28,7 @@ cloudstate-tck.combinations = [{
     docker-image = "cloudstateio/cloudstate-proxy-native-dev-mode:latest"
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
     port = 8088
     directory = ${user.dir}/samples/java-shopping-cart
@@ -49,7 +49,7 @@ cloudstate-tck.combinations = [{
     docker-image = "cloudstateio/cloudstate-proxy-native-dev-mode:latest"
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
     port = 8080
     directory = ${user.dir}
@@ -70,7 +70,7 @@ cloudstate-tck.combinations = [{
     docker-image = "cloudstateio/cloudstate-proxy-native-dev-mode:latest"
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
     port = 8088
     directory = ${user.dir}

--- a/tck/src/it/resources/native-image.conf
+++ b/tck/src/it/resources/native-image.conf
@@ -31,8 +31,8 @@ cloudstate-tck.combinations = [{
   service {
     hostname = "127.0.0.1"
     port = 8088
-    directory = ${user.dir}/samples/java-shopping-cart
-    command = ["java", "-Xmx512M", "-Xms128M", "-jar", "target/scala-2.13/java-shopping-cart.jar"]
+    directory = ${user.dir}/java-support/tck
+    command = ["java", "-Xmx512M", "-Xms128M", "-jar", "target/scala-2.13/cloudstate-java-tck.jar"]
     env-vars {
       HOST = "127.0.0.1"
       PORT = "8088"

--- a/tck/src/it/resources/reference.conf
+++ b/tck/src/it/resources/reference.conf
@@ -1,7 +1,7 @@
 cloudstate-tck {
   #verify is a list of names of combinations to run for the TCK
   verify = []
-  #combinations is a list of config objects with a name, a proxy, and a frontend
+  #combinations is a list of config objects with a name, a proxy, and a service
   combinations = []
 
   tck {
@@ -24,7 +24,7 @@ cloudstate-tck {
     docker-image = ""
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
     hostname = ${?HOST}
     port = 8080

--- a/tck/src/it/scala/io/cloudstate/tck/TCK.scala
+++ b/tck/src/it/scala/io/cloudstate/tck/TCK.scala
@@ -18,8 +18,8 @@ package io.cloudstate.tck
 
 import org.scalatest._
 import com.typesafe.config.ConfigFactory
-
-import scala.collection.JavaConverters._
+import io.cloudstate.testkit.ServiceAddress
+import scala.jdk.CollectionConverters._
 
 class TCK extends Suites({
   val config = ConfigFactory.load()
@@ -44,9 +44,9 @@ class TCK extends Suites({
 object ManagedCloudStateTCK {
   def settings(config: TckConfiguration): CloudStateTCK.Settings = {
     CloudStateTCK.Settings(
-      CloudStateTCK.Address(config.tckHostname, config.tckPort),
-      CloudStateTCK.Address(config.proxy.hostname, config.proxy.port),
-      CloudStateTCK.Address(config.frontend.hostname, config.frontend.port)
+      ServiceAddress(config.tckHostname, config.tckPort),
+      ServiceAddress(config.proxy.hostname, config.proxy.port),
+      ServiceAddress(config.service.hostname, config.service.port)
     )
   }
 }
@@ -54,17 +54,29 @@ object ManagedCloudStateTCK {
 class ManagedCloudStateTCK(config: TckConfiguration) extends CloudStateTCK("for " + config.name, ManagedCloudStateTCK.settings(config)) {
   config.validate()
 
-  val processes: TckProcesses =  TckProcesses.create(config)
+  val processes: TckProcesses = TckProcesses.create(config)
 
   override def beforeAll(): Unit = {
-    processes.frontend.start()
+    processes.service.start()
     super.beforeAll()
     processes.proxy.start()
   }
 
   override def afterAll(): Unit = {
-    try Option(processes).foreach(_.proxy.stop())
-    finally try Option(processes).foreach(_.frontend.stop())
+    try processes.proxy.stop()
+    finally try processes.service.stop()
     finally super.afterAll()
+  }
+
+  // only print the process logs on failures
+  override protected def withFixture(test: NoArgTest): Outcome = {
+    super.withFixture(test) match {
+      case failed: Failed =>
+        alert("Playing buffered logs for failed test:")
+        processes.proxy.logs("proxy")
+        processes.service.logs("service")
+        failed
+      case other => other
+    }
   }
 }

--- a/tck/src/it/scala/io/cloudstate/tck/TckConfiguration.scala
+++ b/tck/src/it/scala/io/cloudstate/tck/TckConfiguration.scala
@@ -58,13 +58,13 @@ object TckProcessConfig {
 
 final case class TckConfiguration private (name: String,
                                            proxy: TckProcessConfig,
-                                           frontend: TckProcessConfig,
+                                           service: TckProcessConfig,
                                            tckHostname: String,
                                            tckPort: Int) {
 
   def validate(): Unit = {
     proxy.validate()
-    frontend.validate()
+    service.validate()
     // FIXME implement
   }
 }
@@ -76,7 +76,7 @@ object TckConfiguration {
     TckConfiguration(
       name = c.getString("name"),
       proxy = TckProcessConfig.parseFrom(c.getConfig("proxy")),
-      frontend = TckProcessConfig.parseFrom(c.getConfig("frontend")),
+      service = TckProcessConfig.parseFrom(c.getConfig("service")),
       tckHostname = c.getString("tck.hostname"),
       tckPort = c.getInt("tck.port")
     )

--- a/tck/src/it/scala/io/cloudstate/tck/TckProcesses.scala
+++ b/tck/src/it/scala/io/cloudstate/tck/TckProcesses.scala
@@ -17,61 +17,48 @@
 package io.cloudstate.tck
 
 import java.net.InetAddress
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.sys.process._
 
 object TckProcesses {
 
   def create(config: TckConfiguration): TckProcesses = {
-    val frontend = if (config.frontend.dockerImage.nonEmpty) {
-      createDockerFrontend(config)
-    } else createCommandProcess(config.frontend)
+    val service = if (config.service.dockerImage.nonEmpty) {
+      createDockerService(config)
+    } else createCommandProcess(config.service)
     val proxy = if (config.proxy.dockerImage.nonEmpty) {
       createDockerProxy(config)
     } else createCommandProcess(config.proxy)
 
-    TckProcesses(proxy, frontend)
+    TckProcesses(proxy, service)
   }
 
   private def createCommandProcess(spec: TckProcessConfig): TckProcess =
     new TckProcess {
       private var process: Option[Process] = None
+      private val logger = new TckProcessLogger
 
       override def start(): Unit = {
         require(process.isEmpty, "Process already started")
         val localhost = InetAddress.getLocalHost.getHostAddress
-        val pb =
-          new ProcessBuilder(spec.command.map(_.replace("%LOCALHOST%", localhost)): _*)
-            .inheritIO()
-            .directory(spec.directory)
-
-        val env = pb.environment
-
-        spec.envVars.foreach {
-          case (key, value) =>
-            env.put(key, value)
-        }
-        process = Some(pb.start())
+        val command = spec.command.map(_.replace("%LOCALHOST%", localhost))
+        val pb = Process(command, spec.directory, spec.envVars.toSeq: _*)
+        process = Some(pb.run(logger))
       }
 
       override def stop(): Unit =
         process match {
           case Some(p) =>
             spec.stopCommand match {
-              case Some(stopCommand) =>
-                new ProcessBuilder(stopCommand: _*)
-                  .inheritIO()
-                  .directory(spec.directory)
-                  .start()
-              case None => p.destroy()
-            }
-            p.waitFor(5, TimeUnit.SECONDS) || {
-              p.destroyForcibly()
-              true
+              case Some(stopCommand) => Process(stopCommand, spec.directory).run(logger)
+              case None => p.destroy(); p.exitValue() // waits for process to terminate
             }
             process = None
           case None =>
             sys.error("Process not started")
         }
+
+      override def logs(name: String): Unit = logger.printBufferedLogs(name)
     }
 
   private def createDockerProxy(config: TckConfiguration) = {
@@ -96,11 +83,11 @@ object TckProcesses {
     )
   }
 
-  private def createDockerFrontend(config: TckConfiguration) =
-    createDocker(config.frontend,
-                 "cloudstate-tck-frontend",
+  private def createDockerService(config: TckConfiguration) =
+    createDocker(config.service,
+                 "cloudstate-tck-service",
                  Map(
-                   "PORT" -> config.frontend.port.toString
+                   "PORT" -> config.service.port.toString
                  ),
                  Nil)
 
@@ -109,6 +96,8 @@ object TckProcesses {
                            extraEnv: Map[String, String],
                            extraArgs: Seq[String]): TckProcess =
     new TckProcess {
+      private val logger = new TckProcessLogger
+
       override def start(): Unit = {
         val env = extraEnv ++ spec.envVars
 
@@ -119,23 +108,31 @@ object TckProcesses {
           } :+
           spec.dockerImage
 
-        new ProcessBuilder(command: _*)
-          .inheritIO()
-          .start()
+        Process(command).run(logger)
       }
 
       override def stop(): Unit =
-        new ProcessBuilder("docker", "stop", name)
-          .inheritIO()
-          .start()
+        Process(Seq("docker", "stop", name)).run(logger).exitValue() // waits for process to terminate
+
+      override def logs(name: String): Unit = logger.printBufferedLogs(name)
     }
 
 }
 
-case class TckProcesses(proxy: TckProcess, frontend: TckProcess)
+case class TckProcesses(proxy: TckProcess, service: TckProcess)
 
 trait TckProcess {
   def start(): Unit
-
   def stop(): Unit
+  def logs(name: String): Unit
+}
+
+final class TckProcessLogger extends ProcessLogger {
+  private val buffer = new ConcurrentLinkedQueue[String]
+
+  override def out(s: => String): Unit = buffer.add(s)
+  override def err(s: => String): Unit = buffer.add(s)
+  override def buffer[T](f: => T): T = f
+
+  def printBufferedLogs(name: String): Unit = buffer.forEach(line => println(s"[$name] $line"))
 }

--- a/tck/src/main/resources/reference.conf
+++ b/tck/src/main/resources/reference.conf
@@ -11,10 +11,10 @@ cloudstate.tck {
     port = ${?TCK_PROXY_PORT}
   }
 
-  frontend {
+  service {
     hostname = "127.0.0.1"
-    hostname = ${?TCK_FRONTEND_HOST}
+    hostname = ${?TCK_SERVICE_HOST}
     port = 8080
-    port = ${?TCK_FRONTEND_PORT}
+    port = ${?TCK_SERVICE_PORT}
   }
 }

--- a/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
+++ b/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
@@ -16,488 +16,336 @@
 
 package io.cloudstate.tck
 
-import akka.NotUsed
-import akka.actor.{ActorSystem, Scheduler}
-import akka.grpc.GrpcClientSettings
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.Http.ServerBinding
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.unmarshalling._
-import akka.pattern.after
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Sink, Source}
-import akka.testkit.TestProbe
+import akka.actor.ActorSystem
+import akka.grpc.ServiceDescription
+import akka.testkit.TestKit
+import com.example.shoppingcart.persistence.domain
 import com.example.shoppingcart.shoppingcart._
-import com.google.protobuf.empty.Empty
-import com.google.protobuf.{ByteString => ProtobufByteString}
+import com.google.protobuf.DescriptorProtos
 import com.typesafe.config.{Config, ConfigFactory}
-import io.cloudstate.protocol.entity._
+import io.cloudstate.protocol.crdt.Crdt
 import io.cloudstate.protocol.event_sourced._
-import org.scalatest._
-
+import io.cloudstate.protocol.function.StatelessFunction
+import io.cloudstate.testkit.InterceptService.InterceptorSettings
+import io.cloudstate.testkit.eventsourced.{EventSourcedMessages, InterceptEventSourcedService}
+import io.cloudstate.testkit.{InterceptService, ServiceAddress, TestClient}
+import io.grpc.StatusRuntimeException
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, MustMatchers, WordSpec}
+import scala.collection.mutable
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.util.Try
 
 object CloudStateTCK {
-  final case class Address(hostname: String, port: Int)
-  final case class Settings(tck: Address, proxy: Address, frontend: Address)
+  final case class Settings(tck: ServiceAddress, proxy: ServiceAddress, service: ServiceAddress)
 
   object Settings {
     def fromConfig(config: Config): Settings = {
       val tckConfig = config.getConfig("cloudstate.tck")
       Settings(
-        Address(tckConfig.getString("hostname"), tckConfig.getInt("port")),
-        Address(tckConfig.getString("proxy.hostname"), tckConfig.getInt("proxy.port")),
-        Address(tckConfig.getString("frontend.hostname"), tckConfig.getInt("frontend.port"))
+        ServiceAddress(tckConfig.getString("hostname"), tckConfig.getInt("port")),
+        ServiceAddress(tckConfig.getString("proxy.hostname"), tckConfig.getInt("proxy.port")),
+        ServiceAddress(tckConfig.getString("service.hostname"), tckConfig.getInt("service.port"))
       )
     }
   }
-
-  final val noWait = 0.seconds
-
-  // FIXME add interception to enable asserting exchanges
-  final class EventSourcedInterceptor(val client: EventSourcedClient,
-                                      val fromBackend: TestProbe,
-                                      val fromFrontend: TestProbe)(implicit ec: ExecutionContext)
-      extends EventSourced {
-
-    private final val fromBackendInterceptor = Sink.actorRef[AnyRef](fromBackend.ref, "BACKEND_TERMINATED")
-    private final val fromFrontendInterceptor = Sink.actorRef[AnyRef](fromFrontend.ref, "FRONTEND_TERMINATED")
-
-    override def handle(in: Source[EventSourcedStreamIn, NotUsed]): Source[EventSourcedStreamOut, NotUsed] =
-      client.handle(in.alsoTo(fromBackendInterceptor)).alsoTo(fromFrontendInterceptor)
-  }
-
-  // FIXME add interception to enable asserting exchanges
-  final class EntityDiscoveryInterceptor(val client: EntityDiscoveryClient,
-                                         val fromBackend: TestProbe,
-                                         val fromFrontend: TestProbe)(implicit ec: ExecutionContext)
-      extends EntityDiscovery {
-    import scala.util.{Failure, Success}
-
-    override def discover(info: ProxyInfo): Future[EntitySpec] = {
-      fromBackend.ref ! info
-      client.discover(info).andThen {
-        case Success(es) => fromFrontend.ref ! es
-        case Failure(f) =>
-          // If a failure occurs during discovery, don't record it. The proxy will continue retrying until it
-          // succeeds.
-          //fromFrontend.ref ! f
-          println(s"[warn] TCK: Intercepted discovery call failed: $f")
-      }
-    }
-
-    override def reportError(error: UserFunctionError): Future[Empty] = {
-      fromBackend.ref ! error
-      client.reportError(error).andThen {
-        case Success(e) => fromFrontend.ref ! e
-        case Failure(f) => fromFrontend.ref ! f
-      }
-    }
-  }
-
-  def attempt[T](op: => Future[T], delay: FiniteDuration, retries: Int)(implicit ec: ExecutionContext,
-                                                                        s: Scheduler): Future[T] =
-    Future.unit.flatMap(_ => op) recoverWith {
-      case _ if retries > 0 => after(delay, s)(attempt(op, delay, retries - 1))
-    }
-
-  final val proxyInfo = ProxyInfo(
-    protocolMajorVersion = 0,
-    protocolMinorVersion = 1,
-    proxyName = "TCK",
-    proxyVersion = "0.1",
-    supportedEntityTypes = Seq(EventSourced.name)
-  )
 }
 
 class ConfiguredCloudStateTCK extends CloudStateTCK(CloudStateTCK.Settings.fromConfig(ConfigFactory.load()))
 
 class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
-    extends AsyncWordSpec
+    extends WordSpec
     with MustMatchers
-    with BeforeAndAfterAll {
-  import CloudStateTCK._
+    with BeforeAndAfterAll
+    with ScalaFutures {
 
   def this(settings: CloudStateTCK.Settings) = this("", settings)
 
   private[this] final val system = ActorSystem("CloudStateTCK", ConfigFactory.load("tck"))
-  private[this] final val mat = ActorMaterializer()(system)
-  private[this] final val discoveryFromBackend = TestProbe("discoveryFromBackend")(system)
-  private[this] final val discoveryFromFrontend = TestProbe("discoveryFromFrontend")(system)
-  private[this] final val eventSourcedFromBackend = TestProbe("eventSourcedFromBackend")(system)
-  private[this] final val eventSourcedFromFrontend = TestProbe("eventSourcedFromFrontend")(system)
-  @volatile private[this] final var shoppingClient: ShoppingCartClient = _
-  @volatile private[this] final var entityDiscoveryClient: EntityDiscoveryClient = _
-  @volatile private[this] final var eventSourcedClient: EventSourcedClient = _
-  @volatile private[this] final var tckProxy: ServerBinding = _
 
-  def buildTCKProxy(entityDiscovery: EntityDiscovery, eventSourced: EventSourced): Future[ServerBinding] = {
-    implicit val s = system
-    implicit val m = mat
-    Http().bindAndHandleAsync(
-      handler = EntityDiscoveryHandler.partial(entityDiscovery) orElse EventSourcedHandler.partial(eventSourced),
-      interface = settings.tck.hostname,
-      port = settings.tck.port
-    )
-  }
+  private[this] final val client = TestClient(settings.proxy.host, settings.proxy.port)
+  private[this] final val shoppingCartClient = ShoppingCartClient(client.settings)(system)
 
-  override def beforeAll(): Unit = {
-    val clientSettings =
-      GrpcClientSettings.connectToServiceAt(settings.frontend.hostname, settings.frontend.port)(system).withTls(false)
+  @volatile private[this] final var interceptor: InterceptService = _
+  @volatile private[this] final var enabledServices = Seq.empty[String]
 
-    val edc = EntityDiscoveryClient(clientSettings)(system)
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 3.seconds, interval = 100.millis)
 
-    entityDiscoveryClient = edc
-
-    val esc = EventSourcedClient(clientSettings)(system)
-
-    eventSourcedClient = esc
-
-    val tp = Await.result(
-      buildTCKProxy(
-        new EntityDiscoveryInterceptor(edc, discoveryFromBackend, discoveryFromFrontend),
-        new EventSourcedInterceptor(esc, eventSourcedFromBackend, eventSourcedFromFrontend)(system.dispatcher)
-      ),
-      10.seconds
-    )
-
-    tckProxy = tp
-
-    // Wait for the frontend to come up before starting the backend, otherwise the discovery call from the backend,
-    // if it happens before the frontend starts, will cause the proxy probes to have failures in them
-    Await.ready(attempt(entityDiscoveryClient.discover(proxyInfo), 4.seconds, 10)(system.dispatcher, system.scheduler),
-                1.minute)
-
-    val sc = ShoppingCartClient(
-      GrpcClientSettings.connectToServiceAt(settings.proxy.hostname, settings.proxy.port)(system).withTls(false)
-    )(system)
-
-    shoppingClient = sc
-  }
+  override def beforeAll(): Unit =
+    interceptor = new InterceptService(InterceptorSettings(bind = settings.tck, intercept = settings.service))
 
   override def afterAll(): Unit =
-    try Option(shoppingClient).foreach(c => Await.result(c.close(), 10.seconds))
-    finally try Seq(entityDiscoveryClient, eventSourcedClient).foreach(c => Await.result(c.close(), 10.seconds))
-    finally Await.ready(tckProxy.unbind().transformWith(_ => system.terminate())(system.dispatcher), 30.seconds)
+    try shoppingCartClient.close().futureValue
+    finally try client.terminate()
+    finally interceptor.terminate()
 
-  final def fromFrontend_expectEntitySpec(within: FiniteDuration): EntitySpec =
-    withClue("EntitySpec was not received, or not well-formed: ") {
-      val spec = discoveryFromFrontend.expectMsgType[EntitySpec](within)
-      spec.proto must not be ProtobufByteString.EMPTY
-      spec.entities must not be empty
-      spec.entities.head.serviceName must not be empty
-      spec.entities.head.persistenceId must not be empty
-      // fixme event sourced?
-      spec.entities.head.entityType must not be empty
-      spec
-    }
+  def expectProxyOnline(): Unit =
+    TestKit.awaitCond(client.http.probe(), max = 10.seconds)
 
-  final def fromBackend_expectInit(within: FiniteDuration): EventSourcedInit =
-    withClue("Init message was not received, or not well-formed: ") {
-      val init = eventSourcedFromBackend.expectMsgType[EventSourcedStreamIn](noWait)
-      init must not be (null)
-      init.message must be('init)
-      init.message.init must be(defined)
-      init.message.init.get
-    }
-
-  final def fromBackend_expectCommand(within: FiniteDuration): Command =
-    withClue("Command was not received, or not well-formed: ") {
-      val command = eventSourcedFromBackend.expectMsgType[EventSourcedStreamIn](noWait)
-      command must not be (null) // FIXME validate Command
-      command.message must be('command)
-      command.message.command must be(defined)
-      val c = command.message.command.get
-      c.entityId must not be (empty)
-      c
-    }
-
-  final def fromFrontend_expectReply(events: Int, within: FiniteDuration): EventSourcedReply =
-    withClue("Reply was not received, or not well-formed: ") {
-      val reply = eventSourcedFromFrontend.expectMsgType[EventSourcedStreamOut](noWait)
-      reply must not be (null)
-      reply.message must be('reply)
-      reply.message.reply must be(defined)
-      val r = reply.message.reply.get
-      r.clientAction must be(defined)
-      val clientAction = r.clientAction.get
-      clientAction.action must be('reply)
-      clientAction.action.reply must be('defined)
-      withClue("Reply did not have the expected number of events: ") { r.events.size must be(events) }
-      r
-    }
-
-  final def fromFrontend_expectActionFailure(within: FiniteDuration): Failure =
-    withClue("Failure was not received, or not well-formed: ") {
-      val failure = eventSourcedFromFrontend.expectMsgType[EventSourcedStreamOut](noWait)
-      failure must not be (null)
-      failure.message must be('reply)
-      failure.message.reply must be(defined)
-      failure.message.reply.get.clientAction must be(defined)
-      val clientAction = failure.message.reply.get.clientAction.get
-      clientAction.action must be('failure)
-      clientAction.action.failure must be('defined)
-      clientAction.action.failure.get
-    }
-
-  final def correlate(cmd: Command, commandId: Long) = withClue("Command had the wrong id: ") {
-    cmd.id must be(commandId)
-  }
-  final def unrelated(cmd: Command, commandId: Long) = withClue("Command had the wrong id: ") {
-    cmd.id must not be commandId
+  def testFor(services: ServiceDescription*)(test: => Any): Unit = {
+    val enabled = services.map(_.name).forall(enabledServices.contains)
+    if (enabled) test else pending
   }
 
-  ("Cloudstate TCK " + description) must {
-    implicit val scheduler = system.scheduler
+  ("Cloudstate TCK " + description) when {
 
-    "verify that the user function process responds" in {
-      attempt(entityDiscoveryClient.discover(proxyInfo), 4.seconds, 10) map { spec =>
-        spec.proto must not be ProtobufByteString.EMPTY
-        spec.entities must not be empty
-        spec.entities.head.serviceName must not be empty
-        spec.entities.head.persistenceId must not be empty
-      }
-    }
+    "verifying discovery protocol" must {
+      "verify proxy info and entity discovery" in {
+        import scala.jdk.CollectionConverters._
 
-    "verify that an initial GetShoppingCart request succeeds" in {
-      val userId = "testuser:1"
-      attempt(shoppingClient.getCart(GetShoppingCart(userId)), 4.seconds, 10) map { cart =>
-        // Interaction test
-        val proxyInfo = discoveryFromBackend.expectMsgType[ProxyInfo]
-        proxyInfo.supportedEntityTypes must contain(EventSourced.name)
-        proxyInfo.protocolMajorVersion must be >= 0
-        proxyInfo.protocolMinorVersion must be >= 0
+        expectProxyOnline()
 
-        fromFrontend_expectEntitySpec(noWait)
+        val discovery = interceptor.expectEntityDiscovery()
 
-        fromBackend_expectInit(noWait)
+        val info = discovery.expectProxyInfo()
 
-        correlate(fromBackend_expectCommand(noWait), fromFrontend_expectReply(events = 0, noWait).commandId)
+        info.protocolMajorVersion mustBe 0
+        info.protocolMinorVersion mustBe 1
 
-        eventSourcedFromBackend.expectNoMsg(noWait)
-        eventSourcedFromFrontend.expectNoMsg(noWait)
+        info.supportedEntityTypes must contain theSameElementsAs Seq(
+          EventSourced.name,
+          Crdt.name,
+          StatelessFunction.name
+        )
 
-        // Semantical test
-        cart must not be (null)
-        cart.items must be(empty)
+        val spec = discovery.expectEntitySpec()
+
+        val descriptorSet = DescriptorProtos.FileDescriptorSet.parseFrom(spec.proto)
+        val serviceNames = descriptorSet.getFileList.asScala.flatMap(_.getServiceList.asScala.map(_.getName))
+
+        serviceNames.size mustBe spec.entities.size
+
+        spec.entities.find(_.serviceName == ShoppingCart.name).foreach { entity =>
+          serviceNames must contain("ShoppingCart")
+          entity.entityType mustBe EventSourced.name
+          entity.persistenceId must not be empty
+        }
+
+        enabledServices = spec.entities.map(_.serviceName)
       }
     }
 
     // TODO convert this into a ScalaCheck generated test case
-    "verify that items can be added to, and removed from, a shopping cart" in {
-      val sc = shoppingClient
-      import sc.{addItem, getCart, removeItem}
+    "verifying app test: event-sourced shopping cart" must {
+      import EventSourcedMessages._
+      import ShoppingCartVerifier._
 
-      val userId = "testuser:2"
-      val productId1 = "testproduct:1"
-      val productId2 = "testproduct:2"
-      val productName1 = "Test Product 1"
-      val productName2 = "Test Product 2"
+      def verifyGetInitialEmptyCart(session: ShoppingCartVerifier, cartId: String): Unit = {
+        shoppingCartClient.getCart(GetShoppingCart(cartId)).futureValue mustBe Cart()
+        session.verifyConnection()
+        session.verifyGetInitialEmptyCart(cartId)
+      }
 
-      for {
-        Cart(Nil, _) <- getCart(GetShoppingCart(userId)) // Test initial state
-        Empty(_) <- addItem(AddLineItem(userId, productId1, productName1, 1)) // Test add the first product
-        Empty(_) <- addItem(AddLineItem(userId, productId2, productName2, 2)) // Test add the second product
-        Empty(_) <- addItem(AddLineItem(userId, productId1, productName1, 11)) // Test increase quantity
-        Empty(_) <- addItem(AddLineItem(userId, productId2, productName2, 31)) // Test increase quantity
-        Cart(items1, _) <- getCart(GetShoppingCart(userId)) // Test intermediate state
-        Empty(_) <- removeItem(RemoveLineItem(userId, productId1)) // Test removal of first product
-        addNeg <- addItem(AddLineItem(userId, productId2, productName2, -7))
-          .transform(scala.util.Success(_)) // Test decrement quantity of second product
-        add0 <- addItem(AddLineItem(userId, productId1, productName1, 0))
-          .transform(scala.util.Success(_)) // Test add 0 of new product
-        removeNone <- removeItem(RemoveLineItem(userId, productId1))
-          .transform(scala.util.Success(_)) // Test remove non-exiting product
-        Cart(items2, _) <- getCart(GetShoppingCart(userId)) // Test end state
-      } yield {
-        val init = fromBackend_expectInit(noWait)
-        init.entityId must not be (empty)
+      def verifyGetCart(session: ShoppingCartVerifier, cartId: String, expected: Item*): Unit = {
+        val expectedCart = shoppingCart(expected: _*)
+        shoppingCartClient.getCart(GetShoppingCart(cartId)).futureValue mustBe expectedCart
+        session.verifyGetCart(cartId, expectedCart)
+      }
 
-        val commands = Seq((true, 0),
-                           (true, 1),
-                           (true, 1),
-                           (true, 1),
-                           (true, 1),
-                           (true, 0),
-                           (true, 1),
-                           (false, 0),
-                           (false, 0),
-                           (false, 0),
-                           (true, 0)).foldLeft(Set.empty[Long]) {
-          case (set, (isReply, eventCount)) =>
-            val cmd = fromBackend_expectCommand(noWait)
-            correlate(
-              cmd,
-              if (isReply) fromFrontend_expectReply(events = eventCount, noWait).commandId
-              else fromFrontend_expectActionFailure(noWait).commandId
-            )
-            init.entityId must be(cmd.entityId)
-            set must not contain (cmd.id)
-            set + cmd.id
-        }
+      def verifyAddItem(session: ShoppingCartVerifier, cartId: String, item: Item): Unit = {
+        val addLineItem = AddLineItem(cartId, item.id, item.name, item.quantity)
+        shoppingCartClient.addItem(addLineItem).futureValue mustBe EmptyScalaMessage
+        session.verifyAddItem(cartId, item)
+      }
 
-        eventSourcedFromBackend.expectNoMsg(noWait)
-        eventSourcedFromFrontend.expectNoMsg(noWait)
+      def verifyRemoveItem(session: ShoppingCartVerifier, cartId: String, itemId: String): Unit = {
+        val removeLineItem = RemoveLineItem(cartId, itemId)
+        shoppingCartClient.removeItem(removeLineItem).futureValue mustBe EmptyScalaMessage
+        session.verifyRemoveItem(cartId, itemId)
+      }
 
-        commands must have(size(11)) // Verify command id uniqueness
+      def verifyAddItemFailure(session: ShoppingCartVerifier, cartId: String, item: Item): Unit = {
+        val addLineItem = AddLineItem(cartId, item.id, item.name, item.quantity)
+        val error = shoppingCartClient.addItem(addLineItem).failed.futureValue
+        error mustBe a[StatusRuntimeException]
+        val description = error.asInstanceOf[StatusRuntimeException].getStatus.getDescription
+        session.verifyAddItemFailure(cartId, item, description)
+      }
 
-        addNeg must be('failure) // Verfify that we get a failure when adding a negative quantity
-        add0 must be('failure) // Verify that we get a failure when adding a line item of 0 items
-        removeNone must be('failure) // Verify that we get a failure when removing a non-existing item
+      def verifyRemoveItemFailure(session: ShoppingCartVerifier, cartId: String, itemId: String): Unit = {
+        val removeLineItem = RemoveLineItem(cartId, itemId)
+        val error = shoppingCartClient.removeItem(removeLineItem).failed.futureValue
+        error mustBe a[StatusRuntimeException]
+        val description = error.asInstanceOf[StatusRuntimeException].getStatus.getDescription
+        session.verifyRemoveItemFailure(cartId, itemId, description)
+      }
 
-        //Semantical test
-        items1.toSet must equal(Set(LineItem(productId1, productName1, 12), LineItem(productId2, productName2, 33)))
-        items2.toSet must equal(Set(LineItem(productId2, productName2, 33)))
+      "verify get cart, add item, remove item, and failures" in testFor(ShoppingCart) {
+        val session = shoppingCartSession(interceptor)
+        verifyGetInitialEmptyCart(session, "cart:1") // initial empty state
+        verifyAddItem(session, "cart:1", Item("product:1", "Product1", 1)) // add the first product
+        verifyAddItem(session, "cart:1", Item("product:2", "Product2", 2)) // add the second product
+        verifyAddItem(session, "cart:1", Item("product:1", "Product1", 11)) // increase first product
+        verifyAddItem(session, "cart:1", Item("product:2", "Product2", 31)) // increase second product
+        verifyGetCart(session, "cart:1", Item("product:1", "Product1", 12), Item("product:2", "Product2", 33)) // check state
+        verifyRemoveItem(session, "cart:1", "product:1") // remove first product
+        verifyAddItemFailure(session, "cart:1", Item("product:2", "Product2", -7)) // add negative quantity
+        verifyAddItemFailure(session, "cart:1", Item("product:1", "Product1", 0)) // add zero quantity
+        verifyRemoveItemFailure(session, "cart:1", "product:1") // remove non-existing product
+        verifyGetCart(session, "cart:1", Item("product:2", "Product2", 33)) // check final state
       }
     }
 
-    "verify that the backend supports the ServerReflection API" in {
-      import grpc.reflection.v1alpha.reflection._
-      import ServerReflectionRequest.{MessageRequest => In}
-      import ServerReflectionResponse.{MessageResponse => Out}
+    "verifying proxy test: gRPC ServerReflection API" must {
+      "verify that the proxy supports server reflection" in {
+        import grpc.reflection.v1alpha.reflection._
+        import ServerReflectionRequest.{MessageRequest => In}
+        import ServerReflectionResponse.{MessageResponse => Out}
 
-      val reflectionClient = ServerReflectionClient(
-        GrpcClientSettings.connectToServiceAt(settings.proxy.hostname, settings.proxy.port)(system).withTls(false)
-      )(system)
+        val expectedServices = Seq(ServerReflection.name) ++ enabledServices.sorted
 
-      val Host = settings.proxy.hostname
-      val ShoppingCart = "com.example.shoppingcart.ShoppingCart"
+        val connection = client.serverReflection.connect()
 
-      val testData = List[(In, Out)](
-          (In.ListServices(""),
-           Out.ListServicesResponse(
-             ListServiceResponse(Vector(ServiceResponse(ServerReflection.name), ServiceResponse(ShoppingCart)))
-           )),
-          (In.ListServices("nonsense.blabla."),
-           Out.ListServicesResponse(
-             ListServiceResponse(Vector(ServiceResponse(ServerReflection.name), ServiceResponse(ShoppingCart)))
-           )),
-          (In.FileContainingSymbol("nonsense.blabla.Void"), Out.FileDescriptorResponse(FileDescriptorResponse(Nil)))
-        ) map {
-          case (in, out) =>
-            val req = ServerReflectionRequest(Host, in)
-            val res = ServerReflectionResponse(Host, Some(req), out)
-            (req, res)
-        }
-      val input = testData.map(_._1)
-      val expected = testData.map(_._2)
-      val test = for {
-        output <- reflectionClient.serverReflectionInfo(Source(input)).runWith(Sink.seq)(mat)
-      } yield {
-        testData.zip(output) foreach {
-          case ((in, exp), out) => (in, out) must equal((in, exp))
-        }
-        output must not(be(empty))
-      }
+        connection.sendAndExpect(
+          In.ListServices(""),
+          Out.ListServicesResponse(ListServiceResponse(expectedServices.map(s => ServiceResponse(s))))
+        )
 
-      test andThen {
-        case _ => Try(reflectionClient.close())
+        connection.sendAndExpect(
+          In.ListServices("nonsense.blabla."),
+          Out.ListServicesResponse(ListServiceResponse(expectedServices.map(s => ServiceResponse(s))))
+        )
+
+        connection.sendAndExpect(
+          In.FileContainingSymbol("nonsense.blabla.Void"),
+          Out.FileDescriptorResponse(FileDescriptorResponse(Nil))
+        )
+
+        connection.close()
       }
     }
 
-    "verify that the HTTP API of ShoppingCart protocol works" in {
-      implicit val s = system
-      implicit val m = mat
+    "verifying proxy test: HTTP API" must {
+      "verify the HTTP API for ShoppingCart service" in testFor(ShoppingCart) {
+        import ShoppingCartVerifier._
 
-      def validateResponse(response: HttpResponse): Future[String] = {
-        response.status must be(StatusCodes.OK)
-        response.entity.contentType must be(ContentTypes.`application/json`)
-        Unmarshal(response).to[String]
-      }
+        def checkHttpRequest(path: String, body: String = null)(expected: => String): Unit = {
+          val response = client.http.request(path, body)
+          val expectedResponse = expected
+          response.futureValue mustBe expectedResponse
+        }
 
-      def getCart(userId: String): Future[String] =
-        Http()
-          .singleRequest(
-            HttpRequest(
-              method = HttpMethods.GET,
-              headers = Nil,
-              uri = s"http://${settings.proxy.hostname}:${settings.proxy.port}/carts/${userId}",
-              entity = HttpEntity.Empty,
-              protocol = HttpProtocols.`HTTP/1.1`
-            )
-          )
-          .flatMap(validateResponse)
+        val session = shoppingCartSession(interceptor)
 
-      def getItems(userId: String): Future[String] =
-        Http()
-          .singleRequest(
-            HttpRequest(
-              method = HttpMethods.GET,
-              headers = Nil,
-              uri = s"http://${settings.proxy.hostname}:${settings.proxy.port}/carts/${userId}/items",
-              entity = HttpEntity.Empty,
-              protocol = HttpProtocols.`HTTP/1.1`
-            )
-          )
-          .flatMap(validateResponse)
+        checkHttpRequest("carts/foo") {
+          session.verifyConnection()
+          session.verifyGetInitialEmptyCart("foo")
+          """{"items":[]}"""
+        }
 
-      def addItem(userId: String, productId: String, productName: String, quantity: Int): Future[String] =
-        Http()
-          .singleRequest(
-            HttpRequest(
-              method = HttpMethods.POST,
-              headers = Nil,
-              uri = s"http://${settings.proxy.hostname}:${settings.proxy.port}/cart/${userId}/items/add",
-              entity = HttpEntity(
-                ContentTypes.`application/json`,
-                s"""
-              {
-                "product_id": "${productId}",
-                "name": "${productName}",
-                "quantity": ${quantity}
-              }
-              """.trim
-              ),
-              protocol = HttpProtocols.`HTTP/1.1`
-            )
-          )
-          .flatMap(validateResponse)
+        checkHttpRequest("cart/foo/items/add", """{"productId": "A14362347", "name": "Deluxe", "quantity": 5}""") {
+          session.verifyAddItem("foo", Item("A14362347", "Deluxe", 5))
+          "{}"
+        }
 
-      def removeItem(userId: String, productId: String): Future[String] =
-        Http()
-          .singleRequest(
-            HttpRequest(
-              method = HttpMethods.POST,
-              headers = Nil,
-              uri = s"http://${settings.proxy.hostname}:${settings.proxy.port}/cart/${userId}/items/${productId}/remove",
-              entity = HttpEntity.Empty,
-              protocol = HttpProtocols.`HTTP/1.1`
-            )
-          )
-          .flatMap(validateResponse)
+        checkHttpRequest("cart/foo/items/add", """{"productId": "B14623482", "name": "Basic", "quantity": 1}""") {
+          session.verifyAddItem("foo", Item("B14623482", "Basic", 1))
+          "{}"
+        }
 
-      val userId = "foo"
-      for {
-        c0 <- getCart(userId)
-        a0 <- addItem(userId, "A14362347", "Deluxe", 5)
-        a1 <- addItem(userId, "B14623482", "Basic", 1)
-        a2 <- addItem(userId, "A14362347", "Deluxe", 2)
-        c1 <- getCart(userId)
-        l0 <- getItems(userId)
-        r0 <- removeItem(userId, "A14362347")
-        c2 <- getCart(userId)
-        l1 <- getItems(userId)
-      } yield {
-        c0 must equal("""{"items":[]}""")
-        a0 must equal("""{}""")
-        a1 must equal("""{}""")
-        a2 must equal("""{}""")
-        c1 must equal(
+        checkHttpRequest("cart/foo/items/add", """{"productId": "A14362347", "name": "Deluxe", "quantity": 2}""") {
+          session.verifyAddItem("foo", Item("A14362347", "Deluxe", 2))
+          "{}"
+        }
+
+        checkHttpRequest("carts/foo") {
+          session.verifyGetCart("foo", shoppingCart(Item("A14362347", "Deluxe", 7), Item("B14623482", "Basic", 1)))
           """{"items":[{"productId":"A14362347","name":"Deluxe","quantity":7},{"productId":"B14623482","name":"Basic","quantity":1}]}"""
-        )
-        l0 must equal(
+        }
+
+        checkHttpRequest("carts/foo/items") {
+          session.verifyGetCart("foo", shoppingCart(Item("A14362347", "Deluxe", 7), Item("B14623482", "Basic", 1)))
           """[{"productId":"A14362347","name":"Deluxe","quantity":7.0},{"productId":"B14623482","name":"Basic","quantity":1.0}]"""
-        )
-        r0 must equal("""{}""")
-        c2 must equal(
+        }
+
+        checkHttpRequest("cart/foo/items/A14362347/remove", "") {
+          session.verifyRemoveItem("foo", "A14362347")
+          "{}"
+        }
+
+        checkHttpRequest("carts/foo") {
+          session.verifyGetCart("foo", shoppingCart(Item("B14623482", "Basic", 1)))
           """{"items":[{"productId":"B14623482","name":"Basic","quantity":1}]}"""
-        )
-        l1 must equal(
+        }
+
+        checkHttpRequest("carts/foo/items") {
+          session.verifyGetCart("foo", shoppingCart(Item("B14623482", "Basic", 1)))
           """[{"productId":"B14623482","name":"Basic","quantity":1.0}]"""
-        )
+        }
       }
     }
+
+  }
+}
+
+object ShoppingCartVerifier {
+  case class Item(id: String, name: String, quantity: Int)
+
+  def shoppingCartSession(interceptor: InterceptService): ShoppingCartVerifier = new ShoppingCartVerifier(interceptor)
+
+  def shoppingCart(items: Item*): Cart = Cart(items.map(i => LineItem(i.id, i.name, i.quantity)))
+}
+
+class ShoppingCartVerifier(interceptor: InterceptService) extends MustMatchers {
+  import EventSourcedMessages._
+  import ShoppingCartVerifier.Item
+
+  private val commandIds = mutable.Map.empty[String, Long]
+  private def nextCommandId(cartId: String): Long = commandIds.updateWith(cartId)(_.map(_ + 1).orElse(Some(1L))).get
+
+  private var connection: InterceptEventSourcedService.Connection = _
+
+  def verifyConnection(): Unit = connection = interceptor.expectEventSourcedConnection()
+
+  def verifyGetInitialEmptyCart(cartId: String): Unit = {
+    val commandId = nextCommandId(cartId)
+    connection.expectClient(init(ShoppingCart.name, cartId))
+    connection.expectClient(command(commandId, cartId, "GetCart", GetShoppingCart(cartId)))
+    connection.expectService(reply(commandId, Cart()))
+    connection.expectNoInteraction()
+  }
+
+  def verifyGetCart(cartId: String, expected: Cart): Unit = {
+    val commandId = nextCommandId(cartId)
+    connection.expectClient(command(commandId, cartId, "GetCart", GetShoppingCart(cartId)))
+    connection.expectService(reply(commandId, expected))
+    connection.expectNoInteraction()
+  }
+
+  def verifyAddItem(cartId: String, item: Item): Unit = {
+    val commandId = nextCommandId(cartId)
+    val addLineItem = AddLineItem(cartId, item.id, item.name, item.quantity)
+    val itemAdded = domain.ItemAdded(Some(domain.LineItem(item.id, item.name, item.quantity)))
+    connection.expectClient(command(commandId, cartId, "AddItem", addLineItem))
+    // shopping cart implementations may or may not have snapshots configured, so match without snapshot
+    val replied = connection.expectServiceMessage[EventSourcedStreamOut.Message.Reply]
+    replied.copy(value = replied.value.clearSnapshot) mustBe reply(commandId, EmptyScalaMessage, itemAdded)
+    connection.expectNoInteraction()
+  }
+
+  def verifyRemoveItem(cartId: String, itemId: String): Unit = {
+    val commandId = nextCommandId(cartId)
+    val removeLineItem = RemoveLineItem(cartId, itemId)
+    val itemRemoved = domain.ItemRemoved(itemId)
+    connection.expectClient(command(commandId, cartId, "RemoveItem", removeLineItem))
+    // shopping cart implementations may or may not have snapshots configured, so match without snapshot
+    val replied = connection.expectServiceMessage[EventSourcedStreamOut.Message.Reply]
+    replied.copy(value = replied.value.clearSnapshot) mustBe reply(commandId, EmptyScalaMessage, itemRemoved)
+    connection.expectNoInteraction()
+  }
+
+  def verifyAddItemFailure(cartId: String, item: Item, failure: String): Unit = {
+    val commandId = nextCommandId(cartId)
+    val addLineItem = AddLineItem(cartId, item.id, item.name, item.quantity)
+    connection.expectClient(command(commandId, cartId, "AddItem", addLineItem))
+    connection.expectService(actionFailure(commandId, failure))
+    connection.expectNoInteraction()
+  }
+
+  def verifyRemoveItemFailure(cartId: String, itemId: String, failure: String): Unit = {
+    val commandId = nextCommandId(cartId)
+    val removeLineItem = RemoveLineItem(cartId, itemId)
+    connection.expectClient(command(commandId, cartId, "RemoveItem", removeLineItem))
+    connection.expectService(actionFailure(commandId, failure))
+    connection.expectNoInteraction()
   }
 }

--- a/testkit/src/main/scala/io/cloudstate/testkit/InterceptService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/InterceptService.scala
@@ -38,7 +38,7 @@ final class InterceptService(settings: InterceptorSettings) {
 
   import context.system
 
-  entityDiscovery.expectOnline(30.seconds)
+  entityDiscovery.expectOnline(60.seconds)
 
   Await.result(
     Http().bindAndHandleAsync(

--- a/testkit/src/main/scala/io/cloudstate/testkit/InterceptService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/InterceptService.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit
+
+import akka.actor.ActorSystem
+import akka.grpc.GrpcClientSettings
+import akka.http.scaladsl.Http
+import akka.testkit.{TestKit, TestProbe}
+import com.typesafe.config.{Config, ConfigFactory}
+import io.cloudstate.testkit.InterceptService.InterceptorSettings
+import io.cloudstate.testkit.discovery.InterceptEntityDiscovery
+import io.cloudstate.testkit.eventsourced.InterceptEventSourcedService
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+final case class ServiceAddress(host: String, port: Int)
+
+final class InterceptService(settings: InterceptorSettings) {
+  import InterceptService._
+
+  private val context = new InterceptorContext(settings.intercept.host, settings.intercept.port)
+  private val entityDiscovery = new InterceptEntityDiscovery(context)
+  private val eventSourced = new InterceptEventSourcedService(context)
+
+  import context.system
+
+  entityDiscovery.expectOnline(30.seconds)
+
+  Await.result(
+    Http().bindAndHandleAsync(
+      handler = entityDiscovery.handler orElse eventSourced.handler,
+      interface = settings.bind.host,
+      port = settings.bind.port
+    ),
+    10.seconds
+  )
+
+  def expectEntityDiscovery(): InterceptEntityDiscovery.Discovery = entityDiscovery.expectDiscovery()
+
+  def expectEventSourcedConnection(): InterceptEventSourcedService.Connection = eventSourced.expectConnection()
+
+  def terminate(): Unit = {
+    entityDiscovery.terminate()
+    eventSourced.terminate()
+    context.terminate()
+  }
+}
+
+object InterceptService {
+  final case class InterceptorSettings(bind: ServiceAddress, intercept: ServiceAddress)
+
+  object InterceptorSettings {
+    def apply(bindHost: String, bindPort: Int, interceptHost: String, interceptPort: Int): InterceptorSettings =
+      InterceptorSettings(ServiceAddress(bindHost, bindPort), ServiceAddress(interceptHost, interceptPort))
+  }
+
+  final class InterceptorContext(val host: String, val port: Int) {
+    val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
+      akka.loglevel = ERROR
+      akka.http.server {
+        preview.enable-http2 = on
+        idle-timeout = infinite
+      }
+    """))
+
+    implicit val system: ActorSystem = ActorSystem("Interceptor", config)
+
+    val clientSettings: GrpcClientSettings = GrpcClientSettings.connectToServiceAt(host, port).withTls(false)
+
+    val probe: TestProbe = TestProbe("InterceptorProbe")
+
+    def terminate(): Unit = TestKit.shutdownActorSystem(system)
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/TestClient.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/TestClient.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit
+
+import akka.actor.ActorSystem
+import akka.grpc.GrpcClientSettings
+import akka.testkit.TestKit
+import com.typesafe.config.{Config, ConfigFactory}
+import io.cloudstate.testkit.http.TestHttpClient
+import io.cloudstate.testkit.reflection.TestServerReflectionClient
+
+final class TestClient(host: String, port: Int) {
+  import TestClient._
+
+  val context = new TestClientContext(host, port)
+
+  val http = new TestHttpClient(context)
+
+  val serverReflection = new TestServerReflectionClient(context)
+
+  def settings: GrpcClientSettings = context.clientSettings
+
+  def terminate(): Unit = {
+    http.terminate()
+    serverReflection.terminate()
+    context.terminate()
+  }
+}
+
+object TestClient {
+  def apply(port: Int): TestClient = apply("localhost", port)
+  def apply(host: String, port: Int): TestClient = new TestClient(host, port)
+
+  final class TestClientContext(val host: String, val port: Int) {
+    val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
+      akka.loglevel = ERROR
+      akka.http.server {
+        preview.enable-http2 = on
+      }
+    """))
+
+    implicit val system: ActorSystem = ActorSystem("TestClient", config)
+
+    val clientSettings: GrpcClientSettings = GrpcClientSettings.connectToServiceAt(host, port).withTls(false)
+
+    def terminate(): Unit = TestKit.shutdownActorSystem(system)
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/TestProtocol.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/TestProtocol.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit
+
+import akka.actor.ActorSystem
+import akka.grpc.GrpcClientSettings
+import akka.testkit.TestKit
+import com.typesafe.config.{Config, ConfigFactory}
+import io.cloudstate.testkit.eventsourced.TestEventSourcedProtocol
+
+final class TestProtocol(host: String, port: Int) {
+  import TestProtocol._
+
+  val context = new TestProtocolContext(host, port)
+
+  val eventSourced = new TestEventSourcedProtocol(context)
+
+  def settings: GrpcClientSettings = context.clientSettings
+
+  def terminate(): Unit = {
+    eventSourced.terminate()
+    context.terminate()
+  }
+}
+
+object TestProtocol {
+  def apply(port: Int): TestProtocol = apply("localhost", port)
+  def apply(host: String, port: Int): TestProtocol = new TestProtocol(host, port)
+
+  final class TestProtocolContext(val host: String, val port: Int) {
+    val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
+      akka.loglevel = ERROR
+      akka.http.server {
+        preview.enable-http2 = on
+      }
+    """))
+
+    implicit val system: ActorSystem = ActorSystem("TestProtocol", config)
+
+    val clientSettings: GrpcClientSettings = GrpcClientSettings.connectToServiceAt(host, port).withTls(false)
+
+    def terminate(): Unit = TestKit.shutdownActorSystem(system)
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/TestService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/TestService.scala
@@ -17,96 +17,55 @@
 package io.cloudstate.testkit
 
 import akka.actor.ActorSystem
-import akka.grpc.ServiceDescription
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.testkit.{SocketUtil, TestKit, TestProbe}
-import com.google.protobuf.DescriptorProtos
-import com.google.protobuf.Descriptors.{FileDescriptor, ServiceDescriptor}
-import com.google.protobuf.empty.{Empty => ScalaPbEmpty}
 import com.typesafe.config.{Config, ConfigFactory}
-import io.cloudstate.protocol.entity._
+import io.cloudstate.testkit.discovery.TestEntityDiscoveryService
+import io.cloudstate.testkit.eventsourced.TestEventSourcedService
+import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future, Promise}
-import scala.util.Success
 
-class TestService {
+final class TestService {
+  import TestService._
+
   val port: Int = SocketUtil.temporaryLocalPort()
 
-  private val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
-    akka.loglevel = ERROR
-    akka.http.server {
-      preview.enable-http2 = on
-      idle-timeout = infinite
-    }
-  """))
+  val context = new TestServiceContext(port)
 
-  protected implicit val system: ActorSystem = ActorSystem("TestService", config)
-  protected val probe: TestProbe = TestProbe("TestServiceProbe")
-  private val entityDiscovery = new TestService.TestEntityDiscovery(this)
+  val entityDiscovery = new TestEntityDiscoveryService(context)
 
-  protected def handler: PartialFunction[HttpRequest, Future[HttpResponse]] =
-    EntityDiscoveryHandler.partial(entityDiscovery)
+  val eventSourced = new TestEventSourcedService(context)
 
-  protected def start(): Unit =
-    Await.result(Http().bindAndHandleAsync(handler = handler, interface = "localhost", port = port), 10.seconds)
+  import context.system
 
-  def expectDiscovery(): TestService.Discovery = probe.expectMsgType[TestService.Discovery]
+  Await.result(
+    Http().bindAndHandleAsync(
+      handler = entityDiscovery.handler orElse eventSourced.handler,
+      interface = "localhost",
+      port = port
+    ),
+    10.seconds
+  )
 
-  def terminate(): Unit = TestKit.shutdownActorSystem(system)
+  def terminate(): Unit = context.terminate()
 }
 
 object TestService {
-  val info: ServiceInfo = ServiceInfo(supportLibraryName = "Cloudstate TestKit")
+  def apply(): TestService = new TestService
 
-  def entitySpec(entityType: String, service: ServiceDescription): EntitySpec = {
-    import scala.jdk.CollectionConverters._
-    entitySpec(entityType, service.descriptor.getServices.asScala.toSeq)
-  }
+  final class TestServiceContext(val port: Int) {
+    val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
+      akka.loglevel = ERROR
+      akka.http.server {
+        preview.enable-http2 = on
+        idle-timeout = infinite
+      }
+    """))
 
-  def entitySpec(entityType: String, descriptors: Seq[ServiceDescriptor]): EntitySpec = {
-    import scala.jdk.CollectionConverters._
-    def allDescriptors(descriptors: Seq[FileDescriptor]): Seq[FileDescriptor] = descriptors.flatMap { d =>
-      d +: allDescriptors(d.getDependencies.asScala.toSeq ++ d.getPublicDependencies.asScala)
-    }
-    val proto = {
-      val descriptorSet = DescriptorProtos.FileDescriptorSet.newBuilder()
-      allDescriptors(descriptors.map(_.getFile)).distinctBy(_.getName).foreach(fd => descriptorSet.addFile(fd.toProto))
-      descriptorSet.build().toByteString
-    }
-    val entities = descriptors.map(d => Entity(entityType, d.getFullName, d.getName))
-    EntitySpec(proto, entities, Some(info))
-  }
+    implicit val system: ActorSystem = ActorSystem("TestService", config)
 
-  final class TestEntityDiscovery(service: TestService) extends EntityDiscovery {
-    private val discovery = new Discovery(service)
+    val probe: TestProbe = TestProbe("TestServiceProbe")
 
-    override def discover(info: ProxyInfo): Future[EntitySpec] = {
-      service.probe.ref ! discovery
-      discovery.info(info)
-      discovery.spec
-    }
-
-    override def reportError(error: UserFunctionError): Future[ScalaPbEmpty] = {
-      discovery.error(error)
-      Future.successful(ScalaPbEmpty.defaultInstance)
-    }
-  }
-
-  final class Discovery(service: TestService) {
-    private val probe = TestProbe("DiscoveryInProbe")(service.system)
-    private val entitySpec = Promise[EntitySpec]()
-
-    private[testkit] def info(info: ProxyInfo): Unit = probe.ref ! info
-
-    private[testkit] def spec: Future[EntitySpec] = entitySpec.future
-
-    private[testkit] def error(error: UserFunctionError): Unit = probe.ref ! error
-
-    def expect(info: ProxyInfo): Unit = probe.expectMsg(info)
-
-    def send(spec: EntitySpec): Unit = entitySpec.complete(Success(spec))
-
-    def expectError(error: UserFunctionError): Unit = probe.expectMsg(error)
+    def terminate(): Unit = TestKit.shutdownActorSystem(system)
   }
 }

--- a/testkit/src/main/scala/io/cloudstate/testkit/discovery/InterceptEntityDiscovery.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/discovery/InterceptEntityDiscovery.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.discovery
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.testkit.{TestKit, TestProbe}
+import com.google.protobuf.empty.{Empty => ScalaPbEmpty}
+import io.cloudstate.protocol.entity._
+import io.cloudstate.testkit.InterceptService.InterceptorContext
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success}
+
+final class InterceptEntityDiscovery(context: InterceptorContext) {
+  import InterceptEntityDiscovery._
+
+  private val interceptor = new EntityDiscoveryInterceptor(context)
+
+  def expectOnline(timeout: FiniteDuration): Unit = InterceptEntityDiscovery.expectOnline(context, timeout)
+
+  def expectDiscovery(): Discovery = context.probe.expectMsgType[Discovery]
+
+  def handler: PartialFunction[HttpRequest, Future[HttpResponse]] =
+    EntityDiscoveryHandler.partial(interceptor)(context.system)
+
+  def terminate(): Unit = interceptor.terminate()
+}
+
+object InterceptEntityDiscovery {
+  final class EntityDiscoveryInterceptor(context: InterceptorContext) extends EntityDiscovery {
+    private val client = EntityDiscoveryClient(context.clientSettings)(context.system)
+    private val discovery = new Discovery(context)
+
+    override def discover(info: ProxyInfo): Future[EntitySpec] = {
+      context.probe.ref ! discovery
+      discovery.in.ref ! info
+      client
+        .discover(info)
+        .andThen {
+          case Success(spec) => discovery.out.ref ! spec
+          case Failure(error) => discovery.out.ref ! error
+        }(context.system.dispatcher)
+    }
+
+    override def reportError(error: UserFunctionError): Future[ScalaPbEmpty] = {
+      discovery.in.ref ! error
+      client.reportError(error)
+    }
+
+    def terminate(): Unit = client.close()
+  }
+
+  final class Discovery(context: InterceptorContext) {
+    private[testkit] val in = TestProbe("DiscoveryInProbe")(context.system)
+    private[testkit] val out = TestProbe("DiscoveryOutProbe")(context.system)
+
+    def expectProxyInfo(): ProxyInfo = in.expectMsgType[ProxyInfo]
+    def expectEntitySpec(): EntitySpec = out.expectMsgType[EntitySpec]
+  }
+
+  def expectOnline(context: InterceptorContext, timeout: FiniteDuration): Unit = {
+    val client = EntityDiscoveryClient(context.clientSettings)(context.system)
+    try TestKit.awaitCond(Await.ready(client.discover(ProxyInfo()), timeout).value.get.isSuccess, timeout)
+    finally client.close()
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/discovery/TestEntityDiscoveryService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/discovery/TestEntityDiscoveryService.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.discovery
+
+import akka.grpc.ServiceDescription
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.testkit.TestProbe
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.Descriptors.{FileDescriptor, ServiceDescriptor}
+import com.google.protobuf.empty.{Empty => ScalaPbEmpty}
+import io.cloudstate.protocol.entity._
+import io.cloudstate.testkit.TestService.TestServiceContext
+import scala.concurrent.{Future, Promise}
+import scala.util.Success
+
+final class TestEntityDiscoveryService(context: TestServiceContext) {
+  import TestEntityDiscoveryService._
+
+  private val testEntityDiscovery = new TestEntityDiscovery(context)
+
+  def expectDiscovery(): Discovery = context.probe.expectMsgType[Discovery]
+
+  def handler: PartialFunction[HttpRequest, Future[HttpResponse]] =
+    EntityDiscoveryHandler.partial(testEntityDiscovery)(context.system)
+}
+
+object TestEntityDiscoveryService {
+  val info: ServiceInfo = ServiceInfo(supportLibraryName = "Cloudstate TestKit")
+
+  def entitySpec(entityType: String, service: ServiceDescription): EntitySpec = {
+    import scala.jdk.CollectionConverters._
+    entitySpec(entityType, service.descriptor.getServices.asScala.toSeq)
+  }
+
+  def entitySpec(entityType: String, descriptors: Seq[ServiceDescriptor]): EntitySpec = {
+    import scala.jdk.CollectionConverters._
+    def allDescriptors(descriptors: Seq[FileDescriptor]): Seq[FileDescriptor] = descriptors.flatMap { d =>
+      d +: allDescriptors(d.getDependencies.asScala.toSeq ++ d.getPublicDependencies.asScala)
+    }
+    val proto = {
+      val descriptorSet = DescriptorProtos.FileDescriptorSet.newBuilder()
+      allDescriptors(descriptors.map(_.getFile)).distinctBy(_.getName).foreach(fd => descriptorSet.addFile(fd.toProto))
+      descriptorSet.build().toByteString
+    }
+    val entities = descriptors.map(d => Entity(entityType, d.getFullName, d.getName))
+    EntitySpec(proto, entities, Some(info))
+  }
+
+  final class TestEntityDiscovery(context: TestServiceContext) extends EntityDiscovery {
+    private val discovery = new Discovery(context)
+
+    override def discover(info: ProxyInfo): Future[EntitySpec] = {
+      context.probe.ref ! discovery
+      discovery.info(info)
+      discovery.spec
+    }
+
+    override def reportError(error: UserFunctionError): Future[ScalaPbEmpty] = {
+      discovery.error(error)
+      Future.successful(ScalaPbEmpty.defaultInstance)
+    }
+  }
+
+  final class Discovery(context: TestServiceContext) {
+    private val probe = TestProbe("DiscoveryInProbe")(context.system)
+    private val entitySpec = Promise[EntitySpec]()
+
+    private[testkit] def info(info: ProxyInfo): Unit = probe.ref ! info
+
+    private[testkit] def spec: Future[EntitySpec] = entitySpec.future
+
+    private[testkit] def error(error: UserFunctionError): Unit = probe.ref ! error
+
+    def expect(info: ProxyInfo): Discovery = {
+      probe.expectMsg(info)
+      this
+    }
+
+    def send(spec: EntitySpec): Discovery = {
+      entitySpec.complete(Success(spec))
+      this
+    }
+
+    def expectError(error: UserFunctionError): Discovery = {
+      probe.expectMsg(error)
+      this
+    }
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/EventSourcedMessages.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/EventSourcedMessages.scala
@@ -17,6 +17,7 @@
 package io.cloudstate.testkit.eventsourced
 
 import com.google.protobuf.any.{Any => ScalaPbAny}
+import com.google.protobuf.empty.{Empty => ScalaPbEmpty}
 import com.google.protobuf.{Empty => JavaPbEmpty, Message => JavaPbMessage}
 import io.cloudstate.protocol.entity._
 import io.cloudstate.protocol.event_sourced._
@@ -26,9 +27,9 @@ object EventSourcedMessages {
   import EventSourcedStreamIn.{Message => InMessage}
   import EventSourcedStreamOut.{Message => OutMessage}
 
-  val EmptyMessage: InMessage = InMessage.Empty
-  val EmptyPayload: JavaPbMessage = JavaPbEmpty.getDefaultInstance
-  val EmptyAny: ScalaPbAny = protobufAny(EmptyPayload)
+  val EmptyInMessage: InMessage = InMessage.Empty
+  val EmptyJavaMessage: JavaPbMessage = JavaPbEmpty.getDefaultInstance
+  val EmptyScalaMessage: ScalaPbMessage = ScalaPbEmpty.defaultInstance
 
   def init(serviceName: String, entityId: String): InMessage =
     init(serviceName, entityId, None)
@@ -58,7 +59,7 @@ object EventSourcedMessages {
     InMessage.Event(EventSourcedEvent(sequence, payload))
 
   def command(id: Long, entityId: String, name: String): InMessage =
-    command(id, entityId, name, EmptyPayload)
+    command(id, entityId, name, EmptyJavaMessage)
 
   def command(id: Long, entityId: String, name: String, payload: JavaPbMessage): InMessage =
     command(id, entityId, name, messagePayload(payload))

--- a/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/InterceptEventSourcedService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/InterceptEventSourcedService.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.eventsourced
+
+import akka.NotUsed
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestProbe
+import io.cloudstate.protocol.event_sourced._
+import io.cloudstate.testkit.InterceptService.InterceptorContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+final class InterceptEventSourcedService(context: InterceptorContext) {
+  import InterceptEventSourcedService._
+
+  private val interceptor = new EventSourcedInterceptor(context)
+
+  def expectConnection(): Connection = context.probe.expectMsgType[Connection]
+
+  def handler: PartialFunction[HttpRequest, Future[HttpResponse]] =
+    EventSourcedHandler.partial(interceptor)(context.system)
+
+  def terminate(): Unit = interceptor.terminate()
+}
+
+object InterceptEventSourcedService {
+  final class EventSourcedInterceptor(context: InterceptorContext) extends EventSourced {
+    private val client = EventSourcedClient(context.clientSettings)(context.system)
+
+    override def handle(in: Source[EventSourcedStreamIn, NotUsed]): Source[EventSourcedStreamOut, NotUsed] = {
+      val connection = new Connection(context)
+      context.probe.ref ! connection
+      client.handle(in.alsoTo(connection.inSink)).alsoTo(connection.outSink)
+    }
+
+    def terminate(): Unit = client.close()
+  }
+
+  object Connection {
+    case object Complete
+    final case class Error(cause: Throwable)
+  }
+
+  final class Connection(context: InterceptorContext) {
+    import Connection._
+
+    private[this] val in = TestProbe("EventSourcedInProbe")(context.system)
+    private[this] val out = TestProbe("EventSourcedOutProbe")(context.system)
+
+    private[testkit] def inSink: Sink[EventSourcedStreamIn, NotUsed] = Sink.actorRef(in.ref, Complete, Error.apply)
+    private[testkit] def outSink: Sink[EventSourcedStreamOut, NotUsed] = Sink.actorRef(out.ref, Complete, Error.apply)
+
+    def expectClient(message: EventSourcedStreamIn.Message): Connection = {
+      in.expectMsg(EventSourcedStreamIn(message))
+      this
+    }
+
+    def expectService(message: EventSourcedStreamOut.Message): Connection = {
+      out.expectMsg(EventSourcedStreamOut(message))
+      this
+    }
+
+    def expectServiceMessage[T](implicit classTag: ClassTag[T]): T =
+      expectServiceMessageClass(classTag.runtimeClass.asInstanceOf[Class[T]])
+
+    def expectServiceMessageClass[T](messageClass: Class[T]): T = {
+      val message = out.expectMsgType[EventSourcedStreamOut].message
+      assert(messageClass.isInstance(message), s"expected message $messageClass, found ${message.getClass} ($message)")
+      message.asInstanceOf[T]
+    }
+
+    def expectNoInteraction(timeout: FiniteDuration = 0.seconds): Connection = {
+      in.expectNoMessage(timeout)
+      out.expectNoMessage(timeout)
+      this
+    }
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/http/TestHttpClient.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/http/TestHttpClient.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.http
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.settings.ConnectionPoolSettings
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import io.cloudstate.testkit.TestClient.TestClientContext
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+final class TestHttpClient(context: TestClientContext) {
+  import context.system
+  import context.system.dispatcher
+
+  def request(path: String, body: String = null): Future[String] =
+    Http()
+      .singleRequest(
+        HttpRequest(
+          method = if (body eq null) HttpMethods.GET else HttpMethods.POST,
+          uri = s"http://${context.host}:${context.port}/$path",
+          entity = if (body eq null) HttpEntity.Empty else HttpEntity(ContentTypes.`application/json`, body.trim),
+          protocol = HttpProtocols.`HTTP/1.1`
+        )
+      )
+      .flatMap { response =>
+        assert(response.status == StatusCodes.OK, "response status was not OK")
+        assert(response.entity.contentType == ContentTypes.`application/json`, "response content type was not json")
+        Unmarshal(response).to[String]
+      }
+
+  private val noRetries = ConnectionPoolSettings(context.system).withMaxRetries(0)
+  private val probeRequest = HttpRequest(uri = s"http://${context.host}:${context.port}")
+
+  def probe(): Boolean =
+    Await.ready(Http().singleRequest(probeRequest, settings = noRetries), 10.seconds).value.exists(_.isSuccess)
+
+  def terminate(): Unit =
+    Await.ready(Http().shutdownAllConnectionPools(), 10.seconds)
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/reflection/TestServerReflectionClient.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/reflection/TestServerReflectionClient.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.reflection
+
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.scaladsl.TestSink
+import grpc.reflection.v1alpha.reflection.ServerReflectionClient
+import io.cloudstate.testkit.TestClient.TestClientContext
+
+final class TestServerReflectionClient(context: TestClientContext) {
+  private val client = ServerReflectionClient(context.clientSettings)(context.system)
+
+  def connect(): TestServerReflectionClient.Connection = new TestServerReflectionClient.Connection(client, context)
+
+  def terminate(): Unit = client.close()
+}
+
+object TestServerReflectionClient {
+  import grpc.reflection.v1alpha.reflection.{ServerReflectionRequest => Request}
+  import grpc.reflection.v1alpha.reflection.{ServerReflectionResponse => Response}
+
+  final class Connection(client: ServerReflectionClient, context: TestClientContext) {
+    import context.system
+
+    private val in = TestPublisher.probe[Request]()
+    private val out = client.serverReflectionInfo(Source.fromPublisher(in)).runWith(TestSink.probe[Response])
+
+    out.ensureSubscription()
+
+    def send(request: Request.MessageRequest): Connection = {
+      in.sendNext(Request(context.host, request))
+      this
+    }
+
+    def expect(request: Request.MessageRequest, response: Response.MessageResponse): Connection = {
+      out.request(1).expectNext(Response(context.host, Some(Request(context.host, request)), response))
+      this
+    }
+
+    def sendAndExpect(request: Request.MessageRequest, response: Response.MessageResponse): Connection = {
+      send(request)
+      expect(request, response)
+      this
+    }
+
+    def close(): Unit = {
+      in.sendComplete()
+      out.expectComplete()
+    }
+  }
+}


### PR DESCRIPTION
First step in evolving the TCK, #316.

Moves the testing infrastructure for the TCK to the common testkit, and updates it to use a send/expect style (and closer to the generic testkit that we've discussed).

Adds a model test for event-sourced entities. This model test requires implementing simple event-sourced entities, where the tests send actions to take (emitting events, forwarding, side effects, failing). The TCK determines which tests to run based on which entities/services have been implemented — marking unimplemented tests as pending.
 
The event-sourced model test has only been implemented for Java support so far. This uncovered one small bug, where side effects were not actually being recorded. I want to look at fixing https://github.com/cloudstateio/cloudstate/issues/375#issuecomment-672336020 and updating the TCK tests to reflect these changes — currently have FIXMEs where the updated state should be returned — before implementing the new tests for other language supports. And then add a state model test for CRDT entities as well.

Event-sourced tests also cover verifying passivation on the language support side (#359) by testing the event-sourced entity protocol directly.