### PR TITLE
Docs: use cloudstate-antora preview site option

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,7 +27,7 @@ clean: install
 
 managed: attributes
 	mkdir -p build/src/managed
-	cp src/antora.yml build/src/managed/antora.yml
+	cp src/shared/antora.yml build/src/managed/antora.yml
 
 attributes: install
 	mkdir -p build/src/managed/modules/ROOT/partials
@@ -35,14 +35,16 @@ attributes: install
 		> build/src/managed/modules/ROOT/partials/attributes.adoc
 
 descriptor: install
-	mkdir -p build
-	${cloudstate_antora} source --preview --upstream ${upstream} ${sources} > build/source.yml
+	[ -f "build/site.yml" ] || ( \
+		mkdir -p build ;\
+		${cloudstate_antora} source --preview --upstream ${upstream} ${sources} > build/source.yml ;\
+		${cloudstate_antora} site --preview --exclude ${module} build/source.yml > build/site.yml )
 
 validate: descriptor
-	${cloudstate_antora} validate --site-from build/source.yml
+	${cloudstate_antora} validate build/site.yml
 
 html: descriptor
-	${cloudstate_antora} build --site-from build/source.yml
+	${cloudstate_antora} build build/site.yml
 
 preview: build
 	${cloudstate_antora} preview
@@ -50,7 +52,7 @@ preview: build
 build-author-mode: clean managed validate html-author-mode
 
 html-author-mode: descriptor
-	${cloudstate_antora} build --author-mode --site-from build/source.yml
+	${cloudstate_antora} build --author-mode build/site.yml
 
 preview-author-mode: build-author-mode
 	${cloudstate_antora} preview

--- a/java-support/docs/Makefile
+++ b/java-support/docs/Makefile
@@ -42,14 +42,16 @@ apidocs:
 	rsync -a ${root_dir}/java-support/target/api/ build/src/managed/modules/java/attachments/api/
 
 descriptor: install
-	mkdir -p build
-	${cloudstate_antora} source --preview --upstream ${upstream} ${sources} > build/source.yml
+	[ -f "build/site.yml" ] || ( \
+		mkdir -p build ;\
+		${cloudstate_antora} source --preview --upstream ${upstream} ${sources} > build/source.yml ;\
+		${cloudstate_antora} site --preview --exclude ${module} build/source.yml > build/site.yml )
 
 validate: descriptor
-	${cloudstate_antora} validate --site-from config/core.yml build/source.yml
+	${cloudstate_antora} validate build/site.yml
 
 html: descriptor
-	${cloudstate_antora} build --site-from config/core.yml build/source.yml
+	${cloudstate_antora} build build/site.yml
 
 preview: build
 	${cloudstate_antora} preview
@@ -57,7 +59,7 @@ preview: build
 build-author-mode: clean managed validate html-author-mode
 
 html-author-mode: descriptor
-	${cloudstate_antora} build --author-mode --site-from config/core.yml build/source.yml
+	${cloudstate_antora} build --author-mode build/site.yml
 
 preview-author-mode: build-author-mode
 	${cloudstate_antora} preview

--- a/java-support/docs/config/core.yml
+++ b/java-support/docs/config/core.yml
@@ -1,4 +1,0 @@
-url: https://github.com/cloudstateio/cloudstate
-branches: [docs/current]
-start_paths: [docs/src, docs/src/shared, docs/build/src/managed]
-edit_url: https://github.com/cloudstateio/cloudstate/edit/master/{path}

--- a/node-support/docs/Makefile
+++ b/node-support/docs/Makefile
@@ -42,14 +42,16 @@ apidocs:
 	rsync -a ../apidocs/ build/src/managed/modules/javascript/attachments/api/
 
 descriptor: install
-	mkdir -p build
-	${cloudstate_antora} source --preview --upstream ${upstream} ${sources} > build/source.yml
+	[ -f "build/site.yml" ] || ( \
+		mkdir -p build ;\
+		${cloudstate_antora} source --preview --upstream ${upstream} ${sources} > build/source.yml ;\
+		${cloudstate_antora} site --preview --exclude ${module} build/source.yml > build/site.yml )
 
 validate: descriptor
-	${cloudstate_antora} validate --site-from config/core.yml build/source.yml
+	${cloudstate_antora} validate build/site.yml
 
 html: descriptor
-	${cloudstate_antora} build --site-from config/core.yml build/source.yml
+	${cloudstate_antora} build build/site.yml
 
 preview: build
 	${cloudstate_antora} preview
@@ -57,7 +59,7 @@ preview: build
 build-author-mode: clean managed validate html-author-mode
 
 html-author-mode: descriptor
-	${cloudstate_antora} build --author-mode --site-from config/core.yml build/source.yml
+	${cloudstate_antora} build --author-mode build/site.yml
 
 preview-author-mode: build-author-mode
 	${cloudstate_antora} preview

--- a/node-support/docs/config/core.yml
+++ b/node-support/docs/config/core.yml
@@ -1,4 +1,0 @@
-url: https://github.com/cloudstateio/cloudstate
-branches: [docs/current]
-start_paths: [docs/src, docs/src/shared, docs/build/src/managed]
-edit_url: https://github.com/cloudstateio/cloudstate/edit/master/{path}


### PR DESCRIPTION
Update local doc preview so that it downloads the current published versions for all the other modules, so complete docs can be viewed together when working on one of the modules (which will include other language support repos later).