### PR TITLE
Update devcontainer build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,13 +2,9 @@ FROM openjdk:11-jdk
 
 # This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in
 # devcontainer.json to use it. More info: https://aka.ms/vscode-remote/containers/non-root-user.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+# The default user created by the common-setup script is `vscode`.
 
 # Options for common setup script
-ARG INSTALL_ZSH="true"
-ARG UPGRADE_PACKAGES="true"
 ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
@@ -18,7 +14,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends curl ca-certificates 2>&1 \
     && curl -sSL  ${COMMON_SCRIPT_SOURCE} -o /tmp/common-setup.sh \
     && ([ "${COMMON_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/common-setup.sh" | sha256sum -c -)) \
-    && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    && /bin/bash /tmp/common-setup.sh \
     && rm /tmp/common-setup.sh
 
 # Use Docker within a Codespace


### PR DESCRIPTION
This started failing on master, as the common setup script has been updated. It now has more automatic support for creating the user, so I've switched to this (using the defaults, which are the same as we were providing). But we may want to pin the version of this script, rather than using master.