### PR TITLE
Add restart on failure option for event sourced entities

### DIFF
--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/Contexts.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/Contexts.scala
@@ -84,9 +84,11 @@ private[impl] trait AbstractClientActionContext extends ClientActionContext {
 
   protected def logError(message: String): Unit = ()
 
-  final def createClientAction(reply: Optional[JavaPbAny], allowNoReply: Boolean): Option[ClientAction] =
+  final def createClientAction(reply: Optional[JavaPbAny],
+                               allowNoReply: Boolean,
+                               restartOnFailure: Boolean): Option[ClientAction] =
     error match {
-      case Some(msg) => Some(ClientAction(ClientAction.Action.Failure(Failure(commandId, msg))))
+      case Some(msg) => Some(ClientAction(ClientAction.Action.Failure(Failure(commandId, msg, restartOnFailure))))
       case None =>
         if (reply.isPresent) {
           if (forward.isDefined) {

--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/crdt/CrdtImpl.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/crdt/CrdtImpl.scala
@@ -199,7 +199,7 @@ class CrdtImpl(system: ActorSystem, services: Map[String, CrdtStatefulService], 
         ctx.deactivate()
       }
 
-      val clientAction = ctx.createClientAction(reply, allowNoReply = true)
+      val clientAction = ctx.createClientAction(reply, allowNoReply = true, restartOnFailure = false)
 
       if (ctx.hasError) {
         verifyNoDelta("failed command handling")
@@ -292,7 +292,7 @@ class CrdtImpl(system: ActorSystem, services: Map[String, CrdtStatefulService], 
               context.deactivate()
             }
 
-            val clientAction = context.createClientAction(reply, allowNoReply = true)
+            val clientAction = context.createClientAction(reply, allowNoReply = true, restartOnFailure = false)
 
             if (context.hasError) {
               subscribers -= id

--- a/protocols/protocol/cloudstate/entity.proto
+++ b/protocols/protocol/cloudstate/entity.proto
@@ -202,6 +202,9 @@ message Failure {
 
     // A description of the error.
     string description = 2;
+
+    // Whether this failure should trigger an entity restart.
+    bool restart = 3;
 }
 
 message EntitySpec {

--- a/proxy/core/src/main/scala/akka/cloudstate/EntityStash.scala
+++ b/proxy/core/src/main/scala/akka/cloudstate/EntityStash.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.cloudstate
+
+import akka.actor.{ActorRef, StashSupport}
+import akka.dispatch.Envelope
+
+// Access package-private akka stash methods, for custom command unstashing
+object EntityStash {
+  def unstash(stash: StashSupport, message: Any, sender: ActorRef): Unit =
+    stash.mailbox.enqueueFirst(stash.self, Envelope(message, sender, stash.context.system))
+}

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/Serve.scala
@@ -107,7 +107,7 @@ object Serve {
           case UserFunctionReply(Some(ClientAction(ClientAction.Action.Forward(_), _)), _, _) =>
             log.error("Cannot serialize forward reply, this should have been handled by the UserFunctionRouter")
             None
-          case UserFunctionReply(Some(ClientAction(ClientAction.Action.Failure(Failure(_, message, _)), _)), _, _) =>
+          case UserFunctionReply(Some(ClientAction(ClientAction.Action.Failure(Failure(_, message, _, _)), _)), _, _) =>
             log.error("User Function responded with a failure: {}", message)
             throw CommandException(message)
           case _ =>

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/eventsourced/EventSourcedRestartSpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/eventsourced/EventSourcedRestartSpec.scala
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.proxy.eventsourced
+
+import akka.actor.{Actor, ActorRef}
+import akka.grpc.GrpcClientSettings
+import akka.testkit.TestEvent.Mute
+import akka.testkit.{EventFilter, TestActorRef, TestBarrier}
+import com.google.protobuf.ByteString
+import com.google.protobuf.any.{Any => ProtoAny}
+import io.cloudstate.protocol.event_sourced._
+import io.cloudstate.proxy.entity.{EntityCommand, UserFunctionReply}
+import io.cloudstate.proxy.telemetry.{AbstractTelemetrySpec, CloudstateTelemetry, PrometheusEventSourcedInstrumentation}
+import io.cloudstate.testkit.TestService
+import io.cloudstate.testkit.eventsourced.EventSourcedMessages
+import io.prometheus.client.CollectorRegistry
+import scala.concurrent.duration._
+
+class EventSourcedRestartSpec extends AbstractTelemetrySpec {
+
+  "EventSourcedEntity" should {
+
+    "restart entity on restart failures" in withTestKit(
+      """
+      | include "test-in-memory"
+      | akka {
+      |   loglevel = ERROR
+      |   loggers = ["akka.testkit.TestEventListener"]
+      |   remote.artery.canonical.port = 0
+      |   remote.artery.bind.port = ""
+      | }
+      """
+    ) { testKit =>
+      import testKit._
+      import EventSourcedMessages._
+      import PrometheusEventSourcedInstrumentation.MetricName._
+      import PrometheusEventSourcedInstrumentation.MetricLabel._
+
+      // silence any dead letters or unhandled messages during shutdown (when using test event listener)
+      system.eventStream.publish(Mute(EventFilter.warning(pattern = ".*received dead letter.*")))
+      system.eventStream.publish(Mute(EventFilter.warning(pattern = ".*unhandled message.*")))
+
+      // use the metrics to wait for particular internal conditions (like commands stashed)
+      implicit val registry: CollectorRegistry = CloudstateTelemetry(system).prometheusRegistry
+
+      implicit val replyTo: ActorRef = testActor
+
+      val service = TestService()
+      val client = EventSourcedClient(GrpcClientSettings.connectToServiceAt("localhost", service.port).withTls(false))
+
+      val entityConfiguration = EventSourcedEntity.Configuration(
+        serviceName = "service",
+        userFunctionName = "test",
+        passivationTimeout = 30.seconds,
+        sendQueueSize = 100
+      )
+
+      val entity = watch(system.actorOf(EventSourcedEntitySupervisor.props(client, entityConfiguration), "entity"))
+
+      val emptyCommand = Some(protobufAny(EmptyJavaMessage))
+
+      // init with empty snapshot
+
+      val connection = service.eventSourced.expectConnection()
+
+      connection.expect(init("service", "entity"))
+      metricValue(ActivatedEntitiesTotal, EntityName -> "test") shouldBe 1
+
+      // first command
+
+      // add a test actor and barrier for the first command reply, so we always send to the mailbox during processing
+      val replyBarrier = TestBarrier(2)
+      val blockReply = TestActorRef(new Actor {
+        def receive: Receive = {
+          case message =>
+            replyTo forward message
+            replyBarrier.await(30.seconds)
+        }
+      })
+
+      entity.tell(EntityCommand(entityId = "test", name = "command1", emptyCommand), blockReply)
+
+      connection.expect(command(1, "entity", "command1"))
+      metricValue(ReceivedCommandsTotal, EntityName -> "test") shouldBe 1
+
+      // second and third commands will be stashed
+
+      entity ! EntityCommand(entityId = "test", name = "command2", emptyCommand)
+      entity ! EntityCommand(entityId = "test", name = "command3", emptyCommand)
+
+      eventually(timeout(5.seconds), interval(100.millis)) {
+        metricValue(ReceivedCommandsTotal, EntityName -> "test") shouldBe 3
+        metricValue(StashedCommandsTotal, EntityName -> "test") shouldBe 2
+      }
+
+      // first command fails with restart
+
+      connection.send(actionFailure(1, "restart please", restart = true))
+
+      expectMsg(UserFunctionReply(clientActionFailure(1, "restart please", restart = true)))
+
+      // send fourth command while still processing first reply, so that both mailbox and command stash have messages
+      entity ! EntityCommand(entityId = "test", name = "command4", emptyCommand)
+
+      EventFilter.error("Restarting entity [entity] after failure: restart please", occurrences = 1).intercept {
+        replyBarrier.await(5.seconds)
+      }
+
+      // reconnection after restart, with new init
+
+      connection.expectClosed()
+
+      eventually(timeout(5.seconds), interval(100.millis)) {
+        metricValue(FailedCommandsTotal, EntityName -> "test") shouldBe 1
+        metricValue(CommandProcessingTimeSeconds + "_count", EntityName -> "test") shouldBe 1
+        metricValue(CompletedCommandsTotal, EntityName -> "test") shouldBe 1
+        metricValue(CommandTotalTimeSeconds + "_count", EntityName -> "test") shouldBe 1
+        metricValue(UnstashedCommandsTotal, EntityName -> "test") shouldBe 2
+        metricValue(CommandStashTimeSeconds + "_count", EntityName -> "test") shouldBe 2
+        metricValue(PassivatedEntitiesTotal, EntityName -> "test") shouldBe 1
+      }
+
+      val connection2 = service.eventSourced.expectConnection()
+
+      connection2.expect(init("service", "entity"))
+      metricValue(ActivatedEntitiesTotal, EntityName -> "test") shouldBe 2
+
+      // second command is processed first after restart
+
+      connection2.expect(command(1, "entity", "command2"))
+
+      eventually(timeout(5.seconds), interval(100.millis)) {
+        // NOTE: the second and third commands are recounted as received, the third recounted as stashed again
+        metricValue(ReceivedCommandsTotal, EntityName -> "test") shouldBe 6
+        metricValue(StashedCommandsTotal, EntityName -> "test") shouldBe 4
+      }
+
+      // finish processing second, third, and fourth commands
+
+      val reply1 = ProtoAny("reply", ByteString.copyFromUtf8("reply1"))
+      val reply2 = ProtoAny("reply", ByteString.copyFromUtf8("reply2"))
+      val reply3 = ProtoAny("reply", ByteString.copyFromUtf8("reply3"))
+
+      connection2.send(reply(1, reply1))
+      expectMsg(UserFunctionReply(clientActionReply(messagePayload(reply1))))
+
+      connection2.expect(command(2, "entity", "command3"))
+      connection2.send(reply(2, reply2))
+      expectMsg(UserFunctionReply(clientActionReply(messagePayload(reply2))))
+
+      connection2.expect(command(3, "entity", "command4"))
+      connection2.send(reply(3, reply3))
+      expectMsg(UserFunctionReply(clientActionReply(messagePayload(reply3))))
+
+      // passivate the entity
+
+      entity ! EventSourcedEntity.Stop
+      connection2.expectClosed()
+      expectTerminated(entity)
+
+      // NOTE: received commands metric has counted second and third commands twice
+      // TODO: should we have another counter for commands reprocessed after restart failures?
+      metricValue(ActivatedEntitiesTotal, EntityName -> "test") shouldBe 2
+      metricValue(ReceivedCommandsTotal, EntityName -> "test") shouldBe 6
+      metricValue(StashedCommandsTotal, EntityName -> "test") shouldBe 4
+      metricValue(UnstashedCommandsTotal, EntityName -> "test") shouldBe 4
+      metricValue(CommandStashTimeSeconds + "_count", EntityName -> "test") shouldBe 4
+      metricValue(FailedCommandsTotal, EntityName -> "test") shouldBe 1
+      metricValue(CommandProcessingTimeSeconds + "_count", EntityName -> "test") shouldBe 4
+      metricValue(CompletedCommandsTotal, EntityName -> "test") shouldBe 4
+      metricValue(CommandTotalTimeSeconds + "_count", EntityName -> "test") shouldBe 4
+      metricValue(PassivatedEntitiesTotal, EntityName -> "test") shouldBe 2
+      metricValue(EntityActiveTimeSeconds + "_count", EntityName -> "test") shouldBe 2
+    }
+
+  }
+}

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentationSpec.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/telemetry/EventSourcedInstrumentationSpec.scala
@@ -19,7 +19,7 @@ package io.cloudstate.proxy.telemetry
 import akka.actor.ActorRef
 import akka.grpc.GrpcClientSettings
 import akka.testkit.TestEvent.Mute
-import akka.testkit.{EventFilter, TestProbe}
+import akka.testkit.EventFilter
 import com.google.protobuf.ByteString
 import com.google.protobuf.any.{Any => ProtoAny}
 import io.cloudstate.protocol.entity.{ClientAction, Failure}

--- a/tck/src/it/scala/io/cloudstate/tck/TCK.scala
+++ b/tck/src/it/scala/io/cloudstate/tck/TCK.scala
@@ -56,10 +56,15 @@ class ManagedCloudStateTCK(config: TckConfiguration) extends CloudStateTCK("for 
 
   val processes: TckProcesses = TckProcesses.create(config)
 
-  override def beforeAll(): Unit = {
+  override def beforeAll(): Unit = try {
     processes.service.start()
     super.beforeAll()
     processes.proxy.start()
+  } catch {
+    case error: Throwable =>
+      processes.service.logs("service")
+      processes.proxy.logs("proxy")
+      throw error
   }
 
   override def afterAll(): Unit = {

--- a/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
+++ b/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
@@ -182,8 +182,6 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
       def sideEffects(ids: String*): Effects =
         ids.foldLeft(Effects.empty) { case (e, id) => e.withSideEffect(ServiceTwo, "Call", Request(id)) }
 
-      // FIXME #375: events applied immediately to state - https://github.com/cloudstateio/cloudstate/issues/375
-
       "verify initial empty state" in eventSourcedTest { id =>
         protocol.eventSourced
           .connect()
@@ -198,7 +196,7 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, emitEvents("A"))))
-          .expect(reply(1, Response(), events("A"))) // FIXME #375: response = "A"
+          .expect(reply(1, Response("A"), events("A")))
           .send(command(2, id, "Process", Request(id)))
           .expect(reply(2, Response("A")))
           .passivate()
@@ -209,7 +207,7 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, emitEvents("A", "B", "C"))))
-          .expect(reply(1, Response(), events("A", "B", "C"))) // FIXME #375: response = "ABC"
+          .expect(reply(1, Response("ABC"), events("A", "B", "C")))
           .send(command(2, id, "Process", Request(id)))
           .expect(reply(2, Response("ABC")))
           .passivate()
@@ -220,21 +218,21 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, emitEvents("A"))))
-          .expect(reply(1, Response(), events("A"))) // FIXME #375: response = "A"
+          .expect(reply(1, Response("A"), events("A")))
           .send(command(2, id, "Process", Request(id, emitEvents("B"))))
-          .expect(reply(2, Response("A"), events("B"))) // FIXME #375: response = "AB"
+          .expect(reply(2, Response("AB"), events("B")))
           .send(command(3, id, "Process", Request(id, emitEvents("C"))))
-          .expect(reply(3, Response("AB"), events("C"))) // FIXME #375: response = "ABC"
+          .expect(reply(3, Response("ABC"), events("C")))
           .send(command(4, id, "Process", Request(id, emitEvents("D"))))
-          .expect(reply(4, Response("ABC"), events("D"))) // FIXME #375: response = "ABCD"
+          .expect(reply(4, Response("ABCD"), events("D")))
           .send(command(5, id, "Process", Request(id, emitEvents("E"))))
-          .expect(reply(5, Response("ABCD"), snapshotAndEvents("ABCDE", "E"))) // FIXME #375: response = "ABCDE"
+          .expect(reply(5, Response("ABCDE"), snapshotAndEvents("ABCDE", "E")))
           .send(command(6, id, "Process", Request(id, emitEvents("F", "G", "H"))))
-          .expect(reply(6, Response("ABCDE"), events("F", "G", "H"))) // FIXME #375: response = "ABCDEFGH"
+          .expect(reply(6, Response("ABCDEFGH"), events("F", "G", "H")))
           .send(command(7, id, "Process", Request(id, emitEvents("I", "J"))))
-          .expect(reply(7, Response("ABCDEFGH"), snapshotAndEvents("ABCDEFGHIJ", "I", "J"))) // FIXME #375: response = "ABCDEFGHIJ"
+          .expect(reply(7, Response("ABCDEFGHIJ"), snapshotAndEvents("ABCDEFGHIJ", "I", "J")))
           .send(command(8, id, "Process", Request(id, emitEvents("K"))))
-          .expect(reply(8, Response("ABCDEFGHIJ"), events("K"))) // FIXME #375: response = "ABCDEFGHIJK"
+          .expect(reply(8, Response("ABCDEFGHIJK"), events("K")))
           .send(command(9, id, "Process", Request(id)))
           .expect(reply(9, Response("ABCDEFGHIJK")))
           .passivate()
@@ -265,13 +263,13 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, emitEvents("A", "B", "C"))))
-          .expect(reply(1, Response(), events("A", "B", "C"))) // FIXME #375: response = "ABC"
+          .expect(reply(1, Response("ABC"), events("A", "B", "C")))
           .send(command(2, id, "Process", Request(id, emitEvents("D", "E"))))
-          .expect(reply(2, Response("ABC"), snapshotAndEvents("ABCDE", "D", "E"))) // FIXME #375: response = "ABCDE"
+          .expect(reply(2, Response("ABCDE"), snapshotAndEvents("ABCDE", "D", "E")))
           .send(command(3, id, "Process", Request(id, emitEvents("F"))))
-          .expect(reply(3, Response("ABCDE"), events("F"))) // FIXME #375: response = "ABCDEF"
+          .expect(reply(3, Response("ABCDEF"), events("F")))
           .send(command(4, id, "Process", Request(id, emitEvents("G"))))
-          .expect(reply(4, Response("ABCDEF"), events("G"))) // FIXME #375: response = "ABCDEFG"
+          .expect(reply(4, Response("ABCDEFG"), events("G")))
           .passivate()
         protocol.eventSourced
           .connect()
@@ -306,7 +304,7 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, emitEvents("A", "B", "C"))))
-          .expect(reply(1, Response(), events("A", "B", "C"))) // FIXME #375: response = "ABC"
+          .expect(reply(1, Response("ABC"), events("A", "B", "C")))
           .send(command(2, id, "Process", Request(id, Seq(emitEvent("D"), emitEvent("E"), forwardTo(id)))))
           .expect(forward(2, EventSourcedTwo.name, "Call", Request(id), snapshotAndEvents("ABCDE", "D", "E")))
           .passivate()
@@ -355,7 +353,7 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, actions)))
-          .expect(reply(1, Response(), effects)) // FIXME #375: response = "ABCDE"
+          .expect(reply(1, Response("ABCDE"), effects))
           .passivate()
       }
 
@@ -373,7 +371,7 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, Seq(emitEvent("A")))))
-          .expect(reply(1, Response(), events("A"))) // FIXME #375: response = "A"
+          .expect(reply(1, Response("A"), events("A")))
           .send(command(2, id, "Process", Request(id, Seq(failWith("expected failure")))))
           .expect(actionFailure(2, "expected failure"))
           .send(command(3, id, "Process", Request(id)))
@@ -381,20 +379,35 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .passivate()
       }
 
-      "verify failure actions do not persist events or snapshots" in eventSourcedTest { id =>
+      "verify failure actions do not retain emitted events, by requesting entity restart" in eventSourcedTest { id =>
         protocol.eventSourced
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, emitEvents("A", "B", "C"))))
-          .expect(reply(1, Response(), events("A", "B", "C"))) // FIXME #375: response = "ABC"
+          .expect(reply(1, Response("ABC"), events("A", "B", "C")))
           .send(command(2, id, "Process", Request(id, Seq(emitEvent("4"), emitEvent("5"), failWith("failure 1")))))
-          .expect(actionFailure(2, "failure 1"))
-          .send(command(3, id, "Process", Request(id, emitEvents("D"))))
-          .expect(reply(3, Response("ABC"), events("D"))) // FIXME #375: response = "ABCD"
-          .send(command(4, id, "Process", Request(id, Seq(emitEvent("6"), failWith("failure 2"), emitEvent("7")))))
-          .expect(actionFailure(4, "failure 2"))
-          .send(command(5, id, "Process", Request(id, emitEvents("E"))))
-          .expect(reply(5, Response("ABCD"), snapshotAndEvents("ABCDE", "E"))) // FIXME #375: response = "ABCDE"
+          .expect(actionFailure(2, "failure 1", restart = true))
+          .passivate()
+        protocol.eventSourced
+          .connect()
+          .send(init(EventSourcedTckModel.name, id))
+          .send(event(1, persisted("A")))
+          .send(event(2, persisted("B")))
+          .send(event(3, persisted("C")))
+          .send(command(1, id, "Process", Request(id, emitEvents("D"))))
+          .expect(reply(1, Response("ABCD"), events("D")))
+          .send(command(2, id, "Process", Request(id, Seq(emitEvent("6"), failWith("failure 2"), emitEvent("7")))))
+          .expect(actionFailure(2, "failure 2", restart = true))
+          .passivate()
+        protocol.eventSourced
+          .connect()
+          .send(init(EventSourcedTckModel.name, id))
+          .send(event(1, persisted("A")))
+          .send(event(2, persisted("B")))
+          .send(event(3, persisted("C")))
+          .send(event(4, persisted("D")))
+          .send(command(1, id, "Process", Request(id, emitEvents("E"))))
+          .expect(reply(1, Response("ABCDE"), snapshotAndEvents("ABCDE", "E")))
           .passivate()
       }
 

--- a/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/EventSourcedMessages.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/eventsourced/EventSourcedMessages.scala
@@ -144,7 +144,10 @@ object EventSourcedMessages {
     replyAction(id, clientActionForward(service, command, payload), effects)
 
   def actionFailure(id: Long, description: String): OutMessage =
-    OutMessage.Reply(EventSourcedReply(id, clientActionFailure(id, description)))
+    OutMessage.Reply(EventSourcedReply(id, clientActionFailure(id, description, restart = false)))
+
+  def actionFailure(id: Long, description: String, restart: Boolean): OutMessage =
+    OutMessage.Reply(EventSourcedReply(id, clientActionFailure(id, description, restart)))
 
   def failure(description: String): OutMessage =
     failure(id = 0, description)
@@ -162,7 +165,10 @@ object EventSourcedMessages {
     clientActionFailure(id = 0, description)
 
   def clientActionFailure(id: Long, description: String): Option[ClientAction] =
-    Some(ClientAction(ClientAction.Action.Failure(Failure(id, description))))
+    clientActionFailure(id, description, restart = false)
+
+  def clientActionFailure(id: Long, description: String, restart: Boolean): Option[ClientAction] =
+    Some(ClientAction(ClientAction.Action.Failure(Failure(id, description, restart))))
 
   def persist(event: JavaPbMessage, events: JavaPbMessage*): Effects =
     Effects.empty.withEvents(event, events: _*)


### PR DESCRIPTION
For #375. This adds support for restarting entities on user failures, for the case of emitted events before fail is called, while allowing events to be applied immediately to have updated state.

Use actor restart to retain the mailbox. The stream relay functionality is moved to a separate actor, so that it can be a stable relay actor ref for the entity when reconnecting the stream. The entity actor still has its own custom command stash. We could use standard actor stash (and persistent actors use a separate stash internally) but because there are only `stash` and `unstashAll` public methods, with several commands queued it would mean un-stashing all of them and then re-stashing messages again, for each command processed. We would also lose the instrumentation for the command stash that we have now. So instead use the (akka private) prepending to the mailbox that actor stash uses, but only unstash back to the mailbox on restarts. Prepending means that we always retain command order, even if there are recently arrived messages in the mailbox.

Update java-support to apply emitted events immediately, reverting back to the earlier behaviour, and use the entity restart option on failures if events have been emitted. Update the TCK model test for event sourced, now that state is updated in responses again. For the emit-then-fail test in the TCK, it currently always expects the restart option to be used. If language supports optimise this by keeping local snapshots, or have a different approach to atomicity, then this test will need to be updated to test either approach. We can wait until we get to that point though.