### PR TITLE
Remove old kotlin docs link

### DIFF
--- a/docs/src/antora.yml
+++ b/docs/src/antora.yml
@@ -12,7 +12,6 @@ nav:
 - modules/java/nav.adoc
 - modules/javascript/nav.adoc
 - modules/kotlin/nav.adoc
-- modules/old-kotlin/nav.adoc
 - modules/python/nav.adoc
 - modules/old-python/nav.adoc
 - modules/springboot/nav.adoc

--- a/docs/src/modules/ROOT/pages/index.adoc
+++ b/docs/src/modules/ROOT/pages/index.adoc
@@ -46,7 +46,7 @@ This documentation contains information for developers who want to use Cloudstat
   * xref:old-go:index.adoc[Implementing in Go]
   * xref:java:index.adoc[Implementing in Java]
   * xref:javascript:index.adoc[Implementing in JavaScript]
-  * xref:old-kotlin:index.adoc[Implementing in Kotlin]
+  * xref:kotlin:index.adoc[Implementing in Kotlin]
   * xref:old-python:index.adoc[Implementing in Python]
   * xref:old-springboot:index.adoc[Implementing in Spring Boot]
   * xref:old-dotnet:index.adoc[Implementing in .Net]

--- a/docs/src/modules/old-kotlin/nav.adoc
+++ b/docs/src/modules/old-kotlin/nav.adoc
@@ -1,1 +1,0 @@
-* xref:index.adoc[Implementing in Kotlin]

--- a/docs/src/modules/old-kotlin/pages/index.adoc
+++ b/docs/src/modules/old-kotlin/pages/index.adoc
@@ -1,5 +1,0 @@
-= Implementing in Kotlin
-
-Information on implementing Cloudstate services in Kotlin is published at:
-
-https://cloudstate.io/old/docs/core/current/user/lang/kotlin/


### PR DESCRIPTION
Kotlin docs are converted and moved to kotlin-support repo now.