### PR TITLE
Update akka to 2.6.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ val GrpcJavaVersion = "1.30.2" // Note: sync with gRPC version in Akka gRPC
 // native-image
 val GrpcNettyShadedVersion = "1.28.1"
 val GraalAkkaVersion = "0.5.0"
-val AkkaVersion = "2.6.8"
+val AkkaVersion = "2.6.9"
 val AkkaHttpVersion = "10.1.12" // Note: sync with Akka HTTP version in Akka gRPC
 val AkkaManagementVersion = "1.0.8"
 val AkkaPersistenceCassandraVersion = "0.102"

--- a/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/TestEventSourced.scala
+++ b/java-support/src/test/scala/io/cloudstate/javasupport/impl/eventsourced/TestEventSourced.scala
@@ -17,10 +17,11 @@
 package io.cloudstate.javasupport.impl.eventsourced
 
 import akka.actor.ActorSystem
-import akka.testkit.{EventFilter, SocketUtil}
+import akka.testkit.EventFilter
 import com.google.protobuf.Descriptors.{FileDescriptor, ServiceDescriptor}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.cloudstate.javasupport.{CloudState, CloudStateRunner}
+import io.cloudstate.testkit.Sockets
 import scala.reflect.ClassTag
 
 object TestEventSourced {
@@ -31,7 +32,7 @@ object TestEventSourced {
 class TestEventSourcedService(entityClass: Class[_],
                               descriptor: ServiceDescriptor,
                               fileDescriptors: Seq[FileDescriptor]) {
-  val port: Int = SocketUtil.temporaryLocalPort()
+  val port: Int = Sockets.temporaryLocalPort()
 
   val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
     cloudstate.user-function-port = $port

--- a/proxy/core/src/test/scala/io/cloudstate/proxy/TestProxy.scala
+++ b/proxy/core/src/test/scala/io/cloudstate/proxy/TestProxy.scala
@@ -18,12 +18,13 @@ package io.cloudstate.proxy
 
 import akka.actor.ActorSystem
 import akka.testkit.TestEvent.Mute
-import akka.testkit.{EventFilter, SocketUtil, TestKit}
+import akka.testkit.{EventFilter, TestKit}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.cloudstate.protocol.crdt.Crdt
 import io.cloudstate.protocol.entity.ProxyInfo
 import io.cloudstate.protocol.event_sourced.EventSourced
 import io.cloudstate.protocol.action.ActionProtocol
+import io.cloudstate.testkit.Sockets
 import java.net.{ConnectException, Socket}
 import scala.concurrent.duration._
 
@@ -32,7 +33,7 @@ object TestProxy {
 }
 
 class TestProxy(servicePort: Int) {
-  val port: Int = SocketUtil.temporaryLocalPort()
+  val port: Int = Sockets.temporaryLocalPort()
 
   val config: Config = ConfigFactory.load(ConfigFactory.parseString(s"""
     include "dev-mode"

--- a/testkit/src/main/scala/io/cloudstate/testkit/Sockets.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/Sockets.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit
+
+object Sockets {
+  // We were using akka.testkit.SocketUtil.temporaryLocalPort but that is broken
+  // in akka 2.6.9 (and will be fixed by https://github.com/akka/akka/pull/29607).
+  def temporaryLocalPort(): Int = {
+    val address = new java.net.InetSocketAddress("localhost", 0)
+    val socket = java.nio.channels.ServerSocketChannel.open().socket()
+    try {
+      socket.bind(address)
+      socket.getLocalPort
+    } finally socket.close()
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/TestService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/TestService.scala
@@ -18,7 +18,7 @@ package io.cloudstate.testkit
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.testkit.{SocketUtil, TestKit, TestProbe}
+import akka.testkit.{TestKit, TestProbe}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.cloudstate.testkit.discovery.TestEntityDiscoveryService
 import io.cloudstate.testkit.eventsourced.TestEventSourcedService
@@ -28,7 +28,7 @@ import scala.concurrent.duration._
 final class TestService {
   import TestService._
 
-  val port: Int = SocketUtil.temporaryLocalPort()
+  val port: Int = Sockets.temporaryLocalPort()
 
   val context = new TestServiceContext(port)
 


### PR DESCRIPTION
Mainly to align versions with Akka Serverless. Needs a (temporary) workaround for use of `SocketUtil.temporaryLocalPort` on macOS.