### PR TITLE
Remove old go docs link

### DIFF
--- a/docs/src/antora.yml
+++ b/docs/src/antora.yml
@@ -8,7 +8,6 @@ nav:
 - modules/dart/nav.adoc
 - modules/old-dart/nav.adoc
 - modules/go/nav.adoc
-- modules/old-go/nav.adoc
 - modules/java/nav.adoc
 - modules/javascript/nav.adoc
 - modules/kotlin/nav.adoc

--- a/docs/src/modules/ROOT/pages/index.adoc
+++ b/docs/src/modules/ROOT/pages/index.adoc
@@ -43,7 +43,7 @@ This documentation contains information for developers who want to use Cloudstat
 | Develop Cloudstate services
 | Developers
 | * xref:old-dart:index.adoc[Implementing in Dart]
-  * xref:old-go:index.adoc[Implementing in Go]
+  * xref:go:index.adoc[Implementing in Go]
   * xref:java:index.adoc[Implementing in Java]
   * xref:javascript:index.adoc[Implementing in JavaScript]
   * xref:kotlin:index.adoc[Implementing in Kotlin]

--- a/docs/src/modules/old-go/nav.adoc
+++ b/docs/src/modules/old-go/nav.adoc
@@ -1,1 +1,0 @@
-* xref:index.adoc[Implementing in Go]

--- a/docs/src/modules/old-go/pages/index.adoc
+++ b/docs/src/modules/old-go/pages/index.adoc
@@ -1,5 +1,0 @@
-= Implementing in Go
-
-Information on implementing Cloudstate services in Go is published at:
-
-https://cloudstate.io/old/docs/go/current/


### PR DESCRIPTION
Go docs converted and published to https://cloudstate.io/docs/go/