### PR TITLE
Switched to single core docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,21 +72,21 @@ commands:
 
 jobs:
 
-  build-core-native-images:
+  build-core-native-image:
     machine: true
     resource_class: large
-    description: "Build core native images"
+    description: "Build core native image"
     steps:
     - checkout
     - install-java-11
     - setup_sbt
     - restore_sbt_cache
     - run:
-        name: Build sbt native images
-        command: sbt "dockerBuildNativeDevMode publishLocal" "dockerBuildNativeInMemory publishLocal"
+        name: Build sbt native image
+        command: sbt "dockerBuildNativeCore publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-core.tar
-        docker_image: cloudstateio/cloudstate-proxy-native-in-memory:latest cloudstateio/cloudstate-proxy-native-dev-mode:latest
+        docker_image: cloudstateio/cloudstate-proxy-native-core:latest
     - persist_to_workspace:
         root: /tmp/workspace
         paths:
@@ -147,14 +147,13 @@ jobs:
     - run:
         name: Build sbt images
         command: |
-          sbt 'dockerBuildDevMode publishLocal' \
-            'dockerBuildInMemory publishLocal' \
+          sbt 'dockerBuildCore publishLocal' \
             'dockerBuildPostgres publishLocal' \
             'dockerBuildCassandra publishLocal' \
             java-shopping-cart/docker:publishLocal
     - save_docker_image:
         tar_file: cloudstate-sbt-images.tar
-        docker_image: cloudstateio/cloudstate-proxy-dev-mode:latest cloudstateio/cloudstate-proxy-in-memory:latest cloudstateio/cloudstate-proxy-postgres:latest cloudstateio/cloudstate-proxy-cassandra:latest cloudstateio/java-shopping-cart:latest
+        docker_image: cloudstateio/cloudstate-proxy-core:latest cloudstateio/cloudstate-proxy-postgres:latest cloudstateio/cloudstate-proxy-cassandra:latest cloudstateio/java-shopping-cart:latest
     - persist_to_workspace:
         root: /tmp/workspace
         paths:
@@ -338,8 +337,7 @@ jobs:
           name: Push docker images
           command: |
             echo "$DOCKER_PASSWORD" | docker login -u cloudstatebot --password-stdin
-            docker push cloudstateio/cloudstate-proxy-native-dev-mode:latest
-            docker push cloudstateio/cloudstate-proxy-native-in-memory:latest
+            docker push cloudstateio/cloudstate-proxy-native-core:latest
             docker push cloudstateio/cloudstate-proxy-native-postgres:latest
             docker push cloudstateio/cloudstate-proxy-native-cassandra:latest
 
@@ -348,13 +346,13 @@ workflows:
     jobs:
       - build-operator
       - build-sbt-images
-      - build-core-native-images
+      - build-core-native-image
       - build-postgres-native-image
       - build-cassandra-native-image
       - native-image-it-test:
           name: Native-image TCK integration tests
           requires:
-            - build-core-native-images
+            - build-core-native-image
       - minikube-smoke-test:
           name: Minikube smoke test
           requires:
@@ -366,7 +364,7 @@ workflows:
           requires:
           - build-operator
           - build-sbt-images
-          - build-core-native-images
+          - build-core-native-image
       - native-image-smoke-test:
           name: Native-image Postgres smoke test
           proxy-store: Postgres
@@ -384,7 +382,7 @@ workflows:
       - publish-native-images:
           name: Publish native images to docker hub
           requires:
-            - build-core-native-images
+            - build-core-native-image
             - build-postgres-native-image
             - build-cassandra-native-image
           filters:

--- a/build.sbt
+++ b/build.sbt
@@ -161,8 +161,8 @@ lazy val protocols = (project in file("protocols"))
       )
   )
 
-lazy val proxyDockerBuild = settingKey[Option[(String, Option[String])]](
-  "Docker artifact name and configuration file which gets overridden by the buildProxy command"
+lazy val proxyDockerBuild = settingKey[Option[String]](
+  "Docker artifact name which gets overridden by the buildProxy command"
 )
 
 def dockerSettings: Seq[Setting[_]] = Seq(
@@ -176,7 +176,7 @@ def dockerSettings: Seq[Setting[_]] = Seq(
   dockerAlias := {
     val old = dockerAlias.value
     proxyDockerBuild.value match {
-      case Some((dockerName, _)) => old.withName(dockerName)
+      case Some(dockerName) => old.withName(dockerName)
       case None => old
     }
   },
@@ -201,27 +201,19 @@ def buildProxyHelp(commandName: String, name: String) =
      s"Execute the given docker scoped task (eg, publishLocal or publish) for the $name build of the proxy.")
   )
 
-def buildProxyCommand(commandName: String,
-                      project: => Project,
-                      name: String,
-                      configResource: Option[String],
-                      native: Boolean): Command = {
+def buildProxyCommand(commandName: String, project: => Project, name: String, native: Boolean): Command = {
   val cn =
     if (native) s"dockerBuildNative$commandName"
     else s"dockerBuild$commandName"
   val imageName =
     if (native) s"native-$name"
     else name
-  val configResourceSetting = configResource match {
-    case Some(resource) => "Some(\"" + resource + "\")"
-    case None => "None"
-  }
   Command.single(
     cn,
     buildProxyHelp(cn, name)
   ) { (state, command) =>
     List(
-      s"""set proxyDockerBuild in `${project.id}` := Some(("cloudstate-proxy-$imageName", $configResourceSetting))""",
+      s"""set proxyDockerBuild in `${project.id}` := Some("cloudstate-proxy-$imageName")""",
       s"""set graalVMDockerPublishLocalBuild in ThisBuild := $native""",
       s"${project.id}/docker:$command",
       s"set proxyDockerBuild in `${project.id}` := None"
@@ -230,25 +222,21 @@ def buildProxyCommand(commandName: String,
 }
 
 commands ++= Seq(
-  buildProxyCommand("DevMode", `proxy-core`, "dev-mode", Some("dev-mode.conf"), true),
-  buildProxyCommand("DevMode", `proxy-core`, "dev-mode", Some("dev-mode.conf"), false),
-  buildProxyCommand("NoStore", `proxy-core`, "no-store", Some("no-store.conf"), true),
-  buildProxyCommand("NoStore", `proxy-core`, "no-store", Some("no-store.conf"), false),
-  buildProxyCommand("InMemory", `proxy-core`, "in-memory", Some("in-memory.conf"), true),
-  buildProxyCommand("InMemory", `proxy-core`, "in-memory", Some("in-memory.conf"), false),
-  buildProxyCommand("Cassandra", `proxy-cassandra`, "cassandra", None, true),
-  buildProxyCommand("Cassandra", `proxy-cassandra`, "cassandra", None, false),
-  buildProxyCommand("Spanner", `proxy-spanner`, "spanner", None, true),
-  buildProxyCommand("Spanner", `proxy-spanner`, "spanner", None, false),
-  buildProxyCommand("Postgres", `proxy-postgres`, "postgres", None, true),
-  buildProxyCommand("Postgres", `proxy-postgres`, "postgres", None, false),
+  buildProxyCommand("Core", `proxy-core`, "core", true),
+  buildProxyCommand("Core", `proxy-core`, "core", false),
+  buildProxyCommand("Cassandra", `proxy-cassandra`, "cassandra", true),
+  buildProxyCommand("Cassandra", `proxy-cassandra`, "cassandra", false),
+  buildProxyCommand("Spanner", `proxy-spanner`, "spanner", true),
+  buildProxyCommand("Spanner", `proxy-spanner`, "spanner", false),
+  buildProxyCommand("Postgres", `proxy-postgres`, "postgres", true),
+  buildProxyCommand("Postgres", `proxy-postgres`, "postgres", false),
   Command.single("dockerBuildAllNonNative", buildProxyHelp("dockerBuildAllNonNative", "all non native")) {
     (state, command) =>
-      List("DevMode", "NoStore", "InMemory", "Cassandra", "Postgres", "Spanner")
+      List("Core", "Cassandra", "Postgres", "Spanner")
         .map(c => s"dockerBuild$c $command") ::: state
   },
   Command.single("dockerBuildAllNative", buildProxyHelp("dockerBuildAllNative", "all native")) { (state, command) =>
-    List("DevMode", "NoStore", "InMemory", "Cassandra", "Postgres", "Spanner")
+    List("Core", "Cassandra", "Postgres", "Spanner")
       .map(c => s"dockerBuildNative$c $command") ::: state
   }
 )
@@ -266,13 +254,9 @@ def nativeImageDockerSettings: Seq[Setting[_]] = dockerSettings ++ Seq(
     }, graalVMBuildServer.value),
   dockerEntrypoint := {
     val old = dockerEntrypoint.value
-    val withLibraryPath = if (graalVMDockerPublishLocalBuild.value) {
+    if (graalVMDockerPublishLocalBuild.value) {
       old :+ s"-Djava.library.path=${DockerBaseImageJavaLibraryPath}"
     } else old
-    proxyDockerBuild.value match {
-      case Some((_, Some(configResource))) => withLibraryPath :+ s"-Dconfig.resource=$configResource"
-      case _ => withLibraryPath
-    }
   }
 )
 

--- a/cloudstate-operator/config/manager/configmap.yaml
+++ b/cloudstate-operator/config/manager/configmap.yaml
@@ -5,9 +5,13 @@ metadata:
 data:
   config.yaml: |
     noStore:
-      image: cloudstateio/cloudstate-proxy-no-store:latest
+      image: cloudstateio/cloudstate-proxy-core:latest
+      # args:
+      # - "-Dconfig.resource=no-store.conf"
     inMemory:
-      image: cloudstateio/cloudstate-proxy-in-memory:latest
+      image: cloudstateio/cloudstate-proxy-core:latest
+      # args:
+      # - "-Dconfig.resource=in-memory.conf"
     postgres:
       image: cloudstateio/cloudstate-proxy-postgres:latest
     cassandra:

--- a/cloudstate-operator/config/native-image/cloudstate-config-patch.yaml
+++ b/cloudstate-operator/config/native-image/cloudstate-config-patch.yaml
@@ -6,9 +6,13 @@ metadata:
 data:
   config.yaml: |
     noStore:
-      image: cloudstateio/cloudstate-proxy-native-no-store:latest
+      image: cloudstateio/cloudstate-proxy-native-core:latest
+      # args:
+      # - "-Dconfig.resource=no-store.conf"
     inMemory:
-      image: cloudstateio/cloudstate-proxy-native-in-memory:latest
+      image: cloudstateio/cloudstate-proxy-native-core:latest
+      # args:
+      # - "-Dconfig.resource=in-memory.conf"
     postgres:
       image: cloudstateio/cloudstate-proxy-native-postgres:latest
     cassandra:

--- a/cloudstate-operator/manifests/cloudstate-operator-native.yaml
+++ b/cloudstate-operator/manifests/cloudstate-operator-native.yaml
@@ -1923,9 +1923,13 @@ apiVersion: v1
 data:
   config.yaml: |
     noStore:
-      image: cloudstateio/cloudstate-proxy-native-no-store:latest
+      image: cloudstateio/cloudstate-proxy-native-core:latest
+      # args:
+      # - "-Dconfig.resource=no-store.conf"
     inMemory:
-      image: cloudstateio/cloudstate-proxy-native-in-memory:latest
+      image: cloudstateio/cloudstate-proxy-native-core:latest
+      # args:
+      # - "-Dconfig.resource=in-memory.conf"
     postgres:
       image: cloudstateio/cloudstate-proxy-native-postgres:latest
     cassandra:

--- a/cloudstate-operator/manifests/cloudstate-operator.yaml
+++ b/cloudstate-operator/manifests/cloudstate-operator.yaml
@@ -1923,9 +1923,13 @@ apiVersion: v1
 data:
   config.yaml: |
     noStore:
-      image: cloudstateio/cloudstate-proxy-no-store:latest
+      image: cloudstateio/cloudstate-proxy-core:latest
+      # args:
+      # - "-Dconfig.resource=no-store.conf"
     inMemory:
-      image: cloudstateio/cloudstate-proxy-in-memory:latest
+      image: cloudstateio/cloudstate-proxy-core:latest
+      # args:
+      # - "-Dconfig.resource=in-memory.conf"
     postgres:
       image: cloudstateio/cloudstate-proxy-postgres:latest
     cassandra:

--- a/cloudstate-operator/pkg/config/operator_config.go
+++ b/cloudstate-operator/pkg/config/operator_config.go
@@ -31,19 +31,23 @@ type OperatorConfig struct {
 }
 
 type NoStoreConfig struct {
-	Image string `yaml:"image" env:"NO_STORE_IMAGE"`
+	Image string   `yaml:"image" env:"NO_STORE_IMAGE"`
+	Args  []string `yaml:"args"`
 }
 
 type InMemoryConfig struct {
-	Image string `yaml:"image" env:"IN_MEMORY_IMAGE"`
+	Image string   `yaml:"image" env:"IN_MEMORY_IMAGE"`
+	Args  []string `yaml:"args"`
 }
 
 type CassandraConfig struct {
-	Image string `yaml:"image" env:"CASSANDRA_IMAGE"`
+	Image string   `yaml:"image" env:"CASSANDRA_IMAGE"`
+	Args  []string `yaml:"args"`
 }
 
 type PostgresConfig struct {
-	Image string `yaml:"image" env:"POSTGRES_IMAGE"`
+	Image string   `yaml:"image" env:"POSTGRES_IMAGE"`
+	Args  []string `yaml:"args"`
 
 	GoogleCloudSQL PostgresGoogleCloudSQLConfig `yaml:"googleCloudSql"`
 }
@@ -59,7 +63,8 @@ type PostgresGoogleCloudSQLConfig struct {
 }
 
 type SpannerConfig struct {
-	Image string `yaml:"image" env:"SPANNER_IMAGE"`
+	Image string   `yaml:"image" env:"SPANNER_IMAGE"`
+	Args  []string `yaml:"args"`
 }
 
 type GCPConfig struct {
@@ -96,4 +101,11 @@ func SetDefaults(config *OperatorConfig) {
 	config.Postgres.GoogleCloudSQL.DefaultCores = 1
 	config.Postgres.GoogleCloudSQL.DefaultMemory = "3840"
 	config.SidecarMetrics.Port = 9099
+
+	config.NoStore.Args = []string{
+		"-Dconfig.resource=no-store.conf",
+	}
+	config.InMemory.Args = []string{
+		"-Dconfig.resource=in-memory.conf",
+	}
 }

--- a/cloudstate-operator/pkg/stores/cassandra_store.go
+++ b/cloudstate-operator/pkg/stores/cassandra_store.go
@@ -67,6 +67,9 @@ func (s *CassandraStore) SetupWithStatefulServiceController(builder *builder.Bui
 
 func (s *CassandraStore) InjectPodStoreConfig(ctx context.Context, name string, namespace string, pod *corev1.Pod, container *corev1.Container, store *cloudstate.StatefulStore) error {
 	container.Image = s.Config.Image
+	if s.Config.Args != nil {
+		container.Args = s.Config.Args
+	}
 	spec := store.Spec.Cassandra
 	if spec == nil {
 		return errors.New("nil Cassandra store")

--- a/cloudstate-operator/pkg/stores/in_memory_store.go
+++ b/cloudstate-operator/pkg/stores/in_memory_store.go
@@ -40,6 +40,9 @@ func (s *InMemoryStore) SetupWithStatefulStoreController(builder *builder.Builde
 
 func (s *InMemoryStore) InjectPodStoreConfig(ctx context.Context, name string, namespace string, pod *corev1.Pod, cloudstateSidecarContainer *corev1.Container, store *cloudstate.StatefulStore) error {
 	cloudstateSidecarContainer.Image = s.Config.Image
+	if s.Config.Args != nil {
+		cloudstateSidecarContainer.Args = s.Config.Args
+	}
 	return nil
 }
 

--- a/cloudstate-operator/pkg/stores/no_store.go
+++ b/cloudstate-operator/pkg/stores/no_store.go
@@ -41,6 +41,9 @@ func (s *NoStore) SetupWithStatefulStoreController(builder *builder.Builder) err
 
 func (s *NoStore) InjectPodStoreConfig(ctx context.Context, name string, namespace string, pod *corev1.Pod, cloudstateSidecarContainer *corev1.Container, store *cloudstate.StatefulStore) error {
 	cloudstateSidecarContainer.Image = s.Config.Image
+	if s.Config.Args != nil {
+		cloudstateSidecarContainer.Args = s.Config.Args
+	}
 	return nil
 }
 

--- a/cloudstate-operator/pkg/stores/postgres_store.go
+++ b/cloudstate-operator/pkg/stores/postgres_store.go
@@ -99,6 +99,9 @@ func (s *PostgresStore) SetupWithStatefulStoreController(builder *builder.Builde
 
 func (s *PostgresStore) InjectPodStoreConfig(ctx context.Context, name string, namespace string, pod *corev1.Pod, container *corev1.Container, store *cloudstate.StatefulStore) error {
 	container.Image = s.Config.Image
+	if s.Config.Args != nil {
+		container.Args = s.Config.Args
+	}
 	spec := store.Spec.Postgres
 	if spec == nil {
 		return errors.New("nil Postgres store")

--- a/cloudstate-operator/pkg/stores/spanner_store.go
+++ b/cloudstate-operator/pkg/stores/spanner_store.go
@@ -58,6 +58,9 @@ func (s *SpannerStore) SetupWithStatefulStoreController(builder *builder.Builder
 func (s *SpannerStore) InjectPodStoreConfig(ctx context.Context, name string, namespace string, pod *corev1.Pod,
 	container *corev1.Container, store *cloudstate.StatefulStore) error {
 	container.Image = s.Config.Image
+	if s.Config.Args != nil {
+		container.Args = s.Config.Args
+	}
 	spec := store.Spec.Spanner
 	if spec == nil {
 		return errors.New("nil Spanner store")

--- a/docs/src/modules/contribute/pages/build-native.adoc
+++ b/docs/src/modules/contribute/pages/build-native.adoc
@@ -46,12 +46,10 @@ This way, the same instance will be reused, rather than having to pay the cost o
 
 In our build, we have multiple different images that we want to build from the same project - both native and non native images, along with different configurations. To support this, we need to reconfigure sbt for each image we want to build. To support this, we have a number of command helpers that dynamically configure sbt, then run a selected command. These are:
 
-* `dockerBuildInMemory`
-* `dockerBuildNativeInMemory`
+* `dockerBuildCore`
+* `dockerBuildNativeCore`
 * `dockerBuildCassandra`
 * `dockerBuildNativeCassandra`
-* `dockerBuildNoStore`
-* `dockerBuildNativeNoStore`
 * `dockerBuildPostgres`
 * `dockerBuildNativePostgres`
 * `dockerBuildAllNonNative`
@@ -63,7 +61,7 @@ To just build a native image, run the selected command above, followed by `publi
 
 [source,sh]
 ----
-dockerBuildNativeInMemory publishLocal
+dockerBuildNativeCore publishLocal
 ----
 
 Contrary to the name of the command, this will build the image remotely if you have that enabled - the reason for this is that the remote build agent support doesn't redefine any of the sbt docker plugin commands, it simply configures the sbt docker plugin to run against the remote docker daemon. So `publishLocal` usually means just build an image in the docker daemon, but don't push it, and since our docker daemon happens to be running remotely through ssh port forwarding, it's done remotely.
@@ -83,7 +81,7 @@ Now you can build and push an image to that repo by running:
 
 [source,sh]
 ----
-dockerBuildNativeInMemory publish
+dockerBuildNativeCore publish
 ----
 
 === Building and pulling an image
@@ -128,7 +126,7 @@ Now after building the dev mode native image, you can run the integration tests:
 
 [source,sh]
 ----
-dockerBuildNativeDevMode publishLocalPull
+dockerBuildNativeCore publishLocalPull
 tck/it:test
 ----
 

--- a/docs/src/modules/contribute/pages/getting-started.adoc
+++ b/docs/src/modules/contribute/pages/getting-started.adoc
@@ -73,21 +73,19 @@ Start sbt:
 sbt
 ----
 
-Now build one or more proxy images. Cloudstate has a different image for each database backend, and in most cases, is able to build either a native image, or an image that runs a regular JVM. It takes at least 5 minutes to compile the native images, so for most development purposes, we recommend using the regular JVM images. For example, to compile the `InMemory` proxy image, run:
+Now build one or more proxy images. Cloudstate has a different image for each database backend, and in most cases, is able to build either a native image, or an image that runs a regular JVM. It takes at least 5 minutes to compile the native images, so for most development purposes, we recommend using the regular JVM images. For example, to compile the core proxy image, run:
 
 [source,sh]
 ----
-dockerBuildInMemory publishLocal
+dockerBuildCore publishLocal
 ----
 
 The following commands are available:
 
-* `dockerBuildInMemory`
-* `dockerBuildNativeInMemory`
+* `dockerBuildCore`
+* `dockerBuildNativeCore`
 * `dockerBuildCassandra`
 * `dockerBuildNativeCassandra`
-* `dockerBuildNoStore`
-* `dockerBuildNativeNoStore`
 * `dockerBuildPostgres`
 * `dockerBuildNativePostgres`
 * `dockerBuildAllNonNative`
@@ -275,7 +273,7 @@ Once you've installed Cloudstate and got a user function running, the proxy can 
 
 [source,sh]
 ----
-sbt:cloudstate> dockerBuildInMemory publishLocal
+sbt:cloudstate> dockerBuildCore publishLocal
 ----
 
 Now, after each time you make changes and rebuild the docker image, the simplest way to ensure your Cloudstate functions pick it up is to delete the pods for it and let the deployment recreate them, eg:

--- a/docs/src/modules/contribute/pages/graalvm-integration.adoc
+++ b/docs/src/modules/contribute/pages/graalvm-integration.adoc
@@ -12,7 +12,7 @@ If you simply want to run the native image locally, you can use the following co
 
 [source,sh]
 ----
-sbt "dockerBuildDevMode publishLocal"
+sbt "dockerBuildNativeCore publishLocal"
 ----
 
 This will take 5 or more minutes. Among the output you should see the result of the native image build, for example:
@@ -39,9 +39,9 @@ This will take 5 or more minutes. Among the output you should see the result of 
 [success] Total time: 304 s, completed Aug 6, 2019 4:00:02 PM
 ----
 
-The resulting Docker image is `cloudstate-proxy-dev-mode:latest`.
+The resulting Docker image is `cloudstate-proxy-native-core:latest`.
 
-This image is a dev mode image, it uses an in memory store, and forms a single cluster by itself. You can also run `dockerBuildNoStore` and `dockerBuildInMemory`, `dockerBuildCassandra` to build a production proxy that has no store, an in memory store or Cassandra store respectively. These will attempt the Kubernetes cluster bootstrap process, so can only be used in Kubernetes with appropriate environment variables set to help them discover other pods in the same deployment.
+This image supports running in multiple different nodes, depending on the arguments passed to it - it can be run in dev mode, with an in memory store, or with no configured store, `-Dconfig.resource=dev-mode.conf`, `-Dconfig.resource=in-memory.conf` or `-Dconfig.resource=no-store.conf`, respectively. You can also run `dockerBuildNativePostrges`, `dockerBuildNativeCassandra` and `dockerBuildNativeSpanner` to build a production proxy that has a Postgres, Cassandra and Spanner support respectively. These will attempt the Kubernetes cluster bootstrap process, so can only be used in Kubernetes with appropriate environment variables set to help them discover other pods in the same deployment.
 
 Substituting `publishLocal` for `publish` will push the docker images to a remote Docker registry, to enable this the `-Ddocker.registry` and `-Ddocker.username` flags must be specified to the `sbt` command.
 
@@ -53,7 +53,7 @@ For all other platforms, the simplest way is to run the user function in a docke
 
 [source,sh]
 ----
-docker run -it --rm --name cloudstate -p 9000:9000 cloudstate-proxy-dev-mode
+docker run -it --rm --name cloudstate -p 9000:9000 cloudstate-proxy-core -Dconfig.resource=dev-mode.conf
 docker run -it --rm --network container:cloudstate --name shopping-cart -e "DEBUG=cloudstate*" js-shopping-cart
 ----
 

--- a/docs/src/modules/contribute/pages/graalvm-integration.adoc
+++ b/docs/src/modules/contribute/pages/graalvm-integration.adoc
@@ -41,7 +41,7 @@ This will take 5 or more minutes. Among the output you should see the result of 
 
 The resulting Docker image is `cloudstate-proxy-native-core:latest`.
 
-This image supports running in multiple different nodes, depending on the arguments passed to it - it can be run in dev mode, with an in memory store, or with no configured store, `-Dconfig.resource=dev-mode.conf`, `-Dconfig.resource=in-memory.conf` or `-Dconfig.resource=no-store.conf`, respectively. You can also run `dockerBuildNativePostrges`, `dockerBuildNativeCassandra` and `dockerBuildNativeSpanner` to build a production proxy that has a Postgres, Cassandra and Spanner support respectively. These will attempt the Kubernetes cluster bootstrap process, so can only be used in Kubernetes with appropriate environment variables set to help them discover other pods in the same deployment.
+This image supports running in multiple different modes, depending on the arguments passed to it - it can be run in dev mode, with an in memory store, or with no configured store, `-Dconfig.resource=dev-mode.conf`, `-Dconfig.resource=in-memory.conf` or `-Dconfig.resource=no-store.conf`, respectively. You can also run `dockerBuildNativePostrges`, `dockerBuildNativeCassandra` and `dockerBuildNativeSpanner` to build a production proxy that has a Postgres, Cassandra and Spanner support respectively. These will attempt the Kubernetes cluster bootstrap process, so can only be used in Kubernetes with appropriate environment variables set to help them discover other pods in the same deployment.
 
 Substituting `publishLocal` for `publish` will push the docker images to a remote Docker registry, to enable this the `-Ddocker.registry` and `-Ddocker.username` flags must be specified to the `sbt` command.
 

--- a/tck/src/it/resources/native-image.conf
+++ b/tck/src/it/resources/native-image.conf
@@ -7,7 +7,8 @@ cloudstate-tck.combinations = [{
   }
   proxy {
     port = 9000
-    docker-image = "cloudstateio/cloudstate-proxy-native-dev-mode:latest"
+    docker-image = "cloudstateio/cloudstate-proxy-native-core:latest"
+    docker-args = ["-Dconfig.resource=dev-mode.conf"]
   }
 
   service {
@@ -25,7 +26,8 @@ cloudstate-tck.combinations = [{
   }
   proxy {
     port = 9000
-    docker-image = "cloudstateio/cloudstate-proxy-native-dev-mode:latest"
+    docker-image = "cloudstateio/cloudstate-proxy-native-core:latest"
+    docker-args = ["-Dconfig.resource=dev-mode.conf"]
   }
 
   service {
@@ -46,7 +48,8 @@ cloudstate-tck.combinations = [{
   }
   proxy {
     port = 9000
-    docker-image = "cloudstateio/cloudstate-proxy-native-dev-mode:latest"
+    docker-image = "cloudstateio/cloudstate-proxy-native-core:latest"
+    docker-args = ["-Dconfig.resource=dev-mode.conf"]
   }
 
   service {
@@ -67,7 +70,8 @@ cloudstate-tck.combinations = [{
   }
   proxy {
     port = 9000
-    docker-image = "cloudstateio/cloudstate-proxy-native-dev-mode:latest"
+    docker-image = "cloudstateio/cloudstate-proxy-native-core:latest"
+    docker-args = ["-Dconfig.resource=dev-mode.conf"]
   }
 
   service {

--- a/tck/src/it/resources/reference.conf
+++ b/tck/src/it/resources/reference.conf
@@ -22,6 +22,7 @@ cloudstate-tck {
     # If specified, will start a docker container, with the environment variable USER_FUNCTION_HOST set to the host
     # to connect to, USER_FUNCTION_PORT set to the port to connect to, and HTTP_PORT set to the port above.
     docker-image = ""
+    docker-args = []
   }
 
   service {
@@ -35,5 +36,6 @@ cloudstate-tck {
     }
     # If specified, will start a docker container, with the environment variable PORT set to the port above.
     docker-image = ""
+    docker-args = []
   }
 }

--- a/tck/src/it/scala/io/cloudstate/tck/TckConfiguration.scala
+++ b/tck/src/it/scala/io/cloudstate/tck/TckConfiguration.scala
@@ -28,7 +28,8 @@ final case class TckProcessConfig private (
     command: List[String],
     stopCommand: Option[List[String]],
     envVars: Map[String, String],
-    dockerImage: String
+    dockerImage: String,
+    dockerArgs: List[String],
 ) {
   def validate(): Unit =
     if (dockerImage.nonEmpty) {
@@ -52,7 +53,8 @@ object TckProcessConfig {
       envVars = config.getConfig("env-vars").root.unwrapped.asScala.toMap.map {
         case (key, value: AnyRef) => key -> value.toString
       },
-      dockerImage = config.getString("docker-image")
+      dockerImage = config.getString("docker-image"),
+      dockerArgs = config.getStringList("docker-args").asScala.toList
     )
 }
 

--- a/tck/src/it/scala/io/cloudstate/tck/TckProcesses.scala
+++ b/tck/src/it/scala/io/cloudstate/tck/TckProcesses.scala
@@ -105,8 +105,9 @@ object TckProcesses {
           extraArgs ++
           env.toSeq.flatMap {
             case (key, value) => Seq("-e", s"$key=$value")
-          } :+
-          spec.dockerImage
+          } ++
+          Seq(spec.dockerImage) ++
+          spec.dockerArgs
 
         Process(command).run(logger)
       }


### PR DESCRIPTION
This means we're not building three essentially identical docker images. Instead of changing the entry point in the docker images to include the config resource configuration, pass the resource configuration in the Kubernetes arguments.