### PR TITLE
Automate upload of protocols to github release assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ jobs:
     - sbt "set concurrentRestrictions in Global += Tags.limitAll(1)" "dockerBuildAllNonNative publish" operator/docker:publish tck/docker:publish
     - sbt proxy/publish proxy/bintrayRelease proxy/bintraySyncMavenCentral
     - sbt -Duse.native.builds=false operator/compileK8sDescriptors
+    - sbt protocols/package
     - travis/upload-release-assets.sh
     - make -C docs deploy
 

--- a/build.sbt
+++ b/build.sbt
@@ -125,17 +125,18 @@ lazy val root = (project in file("."))
   )
   .settings(common)
 
-val cloudstateProtocolsName = "cloudstate-protocols"
-val cloudstateTCKProtocolsName = "cloudstate-tck-protocols"
-
 lazy val protocols = (project in file("protocols"))
   .enablePlugins(NoPublish)
   .settings(
     name := "protocols",
     packageBin in Compile := {
       val base = baseDirectory.value
-      val cloudstateProtos = base / s"$cloudstateProtocolsName.zip"
-      val cloudstateTCKProtos = base / s"$cloudstateTCKProtocolsName.zip"
+      val targetDir = target.value
+      val releaseVersion = version.value
+      val cloudstateProtocolsName = s"cloudstate-protocols-$releaseVersion"
+      val cloudstateTCKProtocolsName = s"cloudstate-tck-protocols-$releaseVersion"
+      val cloudstateProtocolsZip = targetDir / s"$cloudstateProtocolsName.zip"
+      val cloudstateTCKProtocolsZip = targetDir / s"$cloudstateTCKProtocolsName.zip"
 
       def archiveStructure(topDirName: String, files: PathFinder): Seq[(File, String)] =
         files pair Path.relativeTo(base) map {
@@ -144,21 +145,26 @@ lazy val protocols = (project in file("protocols"))
 
       // Common Language Support Proto Dependencies
       IO.zip(
-        archiveStructure(cloudstateProtocolsName,
-                         (base / "frontend" ** "*.proto" +++
-                         base / "protocol" ** "*.proto")),
-        cloudstateProtos
+        archiveStructure(
+          cloudstateProtocolsName,
+          base / "frontend" ** "*.proto" +++
+          base / "protocol" ** "*.proto"
+        ),
+        cloudstateProtocolsZip
       )
 
       // Common TCK Language Support Proto Dependencies
-      IO.zip(archiveStructure(cloudstateTCKProtocolsName, base / "example" ** "*.proto"), cloudstateTCKProtos)
-
-      cloudstateProtos
-    },
-    cleanFiles ++= Seq(
-        baseDirectory.value / s"$cloudstateProtocolsName.zip",
-        baseDirectory.value / s"$cloudstateTCKProtocolsName.zip"
+      IO.zip(
+        archiveStructure(
+          cloudstateTCKProtocolsName,
+          base / "example" ** "*.proto" +++
+          base / "tck" ** "*.proto"
+        ),
+        cloudstateTCKProtocolsZip
       )
+
+      cloudstateProtocolsZip
+    }
   )
 
 lazy val proxyDockerBuild = settingKey[Option[String]](

--- a/docs/src/modules/contribute/pages/language-support.adoc
+++ b/docs/src/modules/contribute/pages/language-support.adoc
@@ -1,5 +1,7 @@
 = Language support
 
+include::ROOT:partial$attributes.adoc[]
+
 Cloudstate is a polyglot platform for developers.
 This is achieved by having a gRPC based protocol between the Proxy and the User function. Since every language wants to be able to offer a language-idiomatic Application Programming Interface (API) Cloudstate offers Support Libraries for the following languages:
 
@@ -15,12 +17,10 @@ This is achieved by having a gRPC based protocol between the Proxy and the User 
 
 In order to implement a support library for a language, the Cloudstate protocol needs to be implemented as a gRPC server which is started when a Stateful Service is started. This gRPC server will then relay state and commands to the underlying User function.
 
-To obtain the necessary Cloudstate Protobuf descriptors that need to be implemented, your build can be set up to fetch the following compressed archives and extract the contents. The archives are available from version `v0.6.0` and forwards.
+To obtain the necessary Cloudstate Protobuf descriptors that need to be implemented, your build can be set up to fetch the following compressed archives and extract the contents. The archives are available from version `v0.5.1` and forwards.
 
-* The Cloudstate protocols
-** `https://raw.githubusercontent.com/cloudstateio/cloudstate/<VERSION_TAG>/protocols/cloudstate-protocols.zip`
-* The Cloudstate TCK protocols
-**  `https://raw.githubusercontent.com/cloudstateio/cloudstate/<VERSION_TAG>/protocols/cloudstate-tck-protocols.zip`
+* https://github.com/cloudstateio/cloudstate/releases/download/v{cloudstate-version}/cloudstate-protocols-{cloudstate-version}.zip[The Cloudstate protocols] (version {cloudstate-version})
+* https://github.com/cloudstateio/cloudstate/releases/download/v{cloudstate-version}/cloudstate-tck-protocols-{cloudstate-version}.zip[The Cloudstate TCK protocols] (version {cloudstate-version})
 
 It is also possible to take a look at the various protobuf messages available in the https://github.com/cloudstateio/cloudstate/tree/master/protocols[project's `protocols` folder]. In this folder, you will see four sub-folders divided as follows:
 
@@ -67,7 +67,6 @@ rpc SeenPing(PingSent) returns (google.protobuf.Empty) {
 ****
 
 * `protocol` is the protocol between the xref:concepts:glossary.adoc#proxy[proxy] and what we call language support, i.e. a bridge library which speaks with the proxy and exposes a native API for some programming language.
-* `proxy` contains the protocols which the xref:concepts:glossary.adoc#proxy[proxy] itself speaks with the outside world.
 
 When implementing a xref:concepts:glossary.adoc#support-library[Support Library], the implementation can be verified using the TCK. In order to run the TCK, one must create an implementation of the Shopping Cart application using the newly created support library to be verified.
 

--- a/travis/upload-release-assets.sh
+++ b/travis/upload-release-assets.sh
@@ -16,14 +16,19 @@ readonly base_dir="$(cd "$script_dir/.." && pwd)"
 
 readonly owner="cloudstateio"
 readonly repo="cloudstate"
-
 readonly version="${tag:1}"
-readonly asset="$base_dir/operator/cloudstate-$version.yaml"
 
 readonly release_url="https://api.github.com/repos/$owner/$repo/releases/tags/$tag"
 readonly release_id=$(curl -s $release_url | jq -r .id)
-
 readonly auth_header="Authorization: token $token"
-readonly asset_url="https://uploads.github.com/repos/$owner/$repo/releases/$release_id/assets?name=$(basename $asset)"
 
-curl -H "$auth_header" -H "Content-Type: application/octet-stream" --data-binary @"$asset" $asset_url
+readonly -a assets=(
+  "$base_dir/operator/cloudstate-$version.yaml"
+  "$base_dir/protocols/target/cloudstate-protocols-$version.zip"
+  "$base_dir/protocols/target/cloudstate-tck-protocols-$version.zip"
+)
+
+for asset in "${assets[@]}"; do
+  asset_url="https://uploads.github.com/repos/$owner/$repo/releases/$release_id/assets?name=$(basename $asset)"
+  curl -H "$auth_header" -H "Content-Type: application/octet-stream" --data-binary @"$asset" $asset_url
+done


### PR DESCRIPTION
Noticed that the protocol zips were not being published anywhere. Looks like they were intended to be committed directly. They're now uploaded under github release assets on tagged releases. Updated the links in the docs.

I've retro-published the `0.5.1` protocols as well: https://github.com/cloudstateio/cloudstate/releases/tag/v0.5.1

@jroper, when looking at this, noticed that the old operator yaml is still being uploaded and referenced in the docs.