### PR TITLE
Add TCK model test for Actions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -646,7 +646,6 @@ lazy val `java-support-tck` = (project in file("java-support/tck"))
     mainClass in Compile := Some("io.cloudstate.javasupport.tck.JavaSupportTck"),
     akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
     PB.protoSources in Compile += (baseDirectory in ThisBuild).value / "protocols" / "tck",
-    PB.targets in Compile := Seq(PB.gens.java -> (sourceManaged in Compile).value),
     javacOptions in Compile ++= Seq("-encoding", "UTF-8", "-source", "11", "-target", "11"),
     assemblySettings("cloudstate-java-tck.jar")
   )

--- a/java-support/src/main/java/io/cloudstate/javasupport/action/ActionReply.java
+++ b/java-support/src/main/java/io/cloudstate/javasupport/action/ActionReply.java
@@ -18,6 +18,7 @@ package io.cloudstate.javasupport.action;
 
 import io.cloudstate.javasupport.Metadata;
 import io.cloudstate.javasupport.ServiceCall;
+import io.cloudstate.javasupport.impl.action.FailureReplyImpl;
 import io.cloudstate.javasupport.impl.action.ForwardReplyImpl;
 import io.cloudstate.javasupport.impl.action.MessageReplyImpl;
 import io.cloudstate.javasupport.impl.action.NoReply;
@@ -27,17 +28,32 @@ import java.util.Collection;
 /**
  * An action reply.
  *
- * <p>Action replies allow returning forwards and attaching effects to messages.
+ * <p>Action replies allow returning forwards or failures, and attaching effects to messages.
  *
  * @param <T> The type of the message that must be returned by this action call.
  */
 public interface ActionReply<T> {
+  /**
+   * Whether this reply is empty: does not have a message, forward, or failure.
+   *
+   * @return Whether the reply is empty.
+   */
+  boolean isEmpty();
+
   /**
    * The effects attached to this reply.
    *
    * @return The effects.
    */
   Collection<Effect> effects();
+
+  /**
+   * Attach the given effects to this reply.
+   *
+   * @param effects The effects to attach.
+   * @return A new reply with the attached effects.
+   */
+  ActionReply<T> withEffects(Collection<Effect> effects);
 
   /**
    * Attach the given effects to this reply.
@@ -79,7 +95,17 @@ public interface ActionReply<T> {
   }
 
   /**
-   * Create a reply that contains neither a message nor a forward.
+   * Create a failure reply.
+   *
+   * @param description The description of the failure.
+   * @return A failure reply.
+   */
+  static <T> FailureReply<T> failure(String description) {
+    return new FailureReplyImpl<>(description);
+  }
+
+  /**
+   * Create a reply that contains neither a message nor a forward nor a failure.
    *
    * <p>This may be useful for emitting effects without sending a message.
    *

--- a/java-support/src/main/java/io/cloudstate/javasupport/action/FailureReply.java
+++ b/java-support/src/main/java/io/cloudstate/javasupport/action/FailureReply.java
@@ -16,21 +16,19 @@
 
 package io.cloudstate.javasupport.action;
 
-import io.cloudstate.javasupport.ServiceCall;
-
 import java.util.Collection;
 
-/** A forward reply. */
-public interface ForwardReply<T> extends ActionReply<T> {
+/** A failure reply. */
+public interface FailureReply<T> extends ActionReply<T> {
 
   /**
-   * The service call that is being forwarded to.
+   * The description of the failure.
    *
-   * @return The service call.
+   * @return The failure description.
    */
-  ServiceCall serviceCall();
+  String description();
 
-  ForwardReply<T> withEffects(Collection<Effect> effects);
+  FailureReply<T> withEffects(Collection<Effect> effects);
 
-  ForwardReply<T> withEffects(Effect... effects);
+  FailureReply<T> withEffects(Effect... effects);
 }

--- a/java-support/src/main/java/io/cloudstate/javasupport/action/MessageReply.java
+++ b/java-support/src/main/java/io/cloudstate/javasupport/action/MessageReply.java
@@ -18,6 +18,8 @@ package io.cloudstate.javasupport.action;
 
 import io.cloudstate.javasupport.Metadata;
 
+import java.util.Collection;
+
 /** A message reply. */
 public interface MessageReply<T> extends ActionReply<T> {
 
@@ -35,5 +37,7 @@ public interface MessageReply<T> extends ActionReply<T> {
    */
   Metadata metadata();
 
-  MessageReply<T> withEffects(Effect... effect);
+  MessageReply<T> withEffects(Collection<Effect> effects);
+
+  MessageReply<T> withEffects(Effect... effects);
 }

--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/action/AnnotationBasedActionSupport.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/action/AnnotationBasedActionSupport.scala
@@ -210,12 +210,14 @@ private object ActionReflection {
           val message = any.asInstanceOf[ActionReply[T]]
           message match {
             case envelope: MessageReply[T] =>
-              ActionReply.message(JavaPbAny
-                                    .newBuilder()
-                                    .setValue(resolvedType.toByteString(envelope.payload))
-                                    .setTypeUrl(resolvedType.typeUrl)
-                                    .build(),
-                                  envelope.metadata)
+              ActionReply
+                .message(JavaPbAny
+                           .newBuilder()
+                           .setValue(resolvedType.toByteString(envelope.payload))
+                           .setTypeUrl(resolvedType.typeUrl)
+                           .build(),
+                         envelope.metadata)
+                .withEffects(envelope.effects)
             case other => other.asInstanceOf[ActionReply[JavaPbAny]]
           }
         })

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/JavaSupportTck.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/JavaSupportTck.java
@@ -18,14 +18,25 @@ package io.cloudstate.javasupport.tck;
 
 import com.example.shoppingcart.Shoppingcart;
 import io.cloudstate.javasupport.CloudState;
+import io.cloudstate.javasupport.tck.model.action.ActionTckModelBehavior;
+import io.cloudstate.javasupport.tck.model.action.ActionTwoBehavior;
 import io.cloudstate.javasupport.tck.model.eventsourced.EventSourcedTckModelEntity;
 import io.cloudstate.javasupport.tck.model.eventsourced.EventSourcedTwoEntity;
 import io.cloudstate.samples.shoppingcart.ShoppingCartEntity;
+import io.cloudstate.tck.model.Action;
 import io.cloudstate.tck.model.Eventsourced;
 
 public final class JavaSupportTck {
   public static final void main(String[] args) throws Exception {
     new CloudState()
+        .registerAction(
+            new ActionTckModelBehavior(),
+            Action.getDescriptor().findServiceByName("ActionTckModel"),
+            Action.getDescriptor())
+        .registerAction(
+            new ActionTwoBehavior(),
+            Action.getDescriptor().findServiceByName("ActionTwo"),
+            Action.getDescriptor())
         .registerEventSourcedEntity(
             EventSourcedTckModelEntity.class,
             Eventsourced.getDescriptor().findServiceByName("EventSourcedTckModel"),

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/action/ActionTckModelBehavior.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/action/ActionTckModelBehavior.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.javasupport.tck.model.action;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import io.cloudstate.javasupport.Context;
+import io.cloudstate.javasupport.ServiceCall;
+import io.cloudstate.javasupport.action.*;
+import io.cloudstate.javasupport.action.Effect;
+import io.cloudstate.tck.model.Action.*;
+import io.cloudstate.tck.model.ActionTwo;
+import java.util.concurrent.CompletionStage;
+
+@Action
+public class ActionTckModelBehavior {
+
+  private final ActorSystem system = ActorSystem.create("ActionTckModel");
+
+  public ActionTckModelBehavior() {}
+
+  @CallHandler
+  public CompletionStage<ActionReply<Response>> processUnary(
+      Request request, ActionContext context) {
+    return Source.single(request).via(responses(context)).runWith(singleResponse(), system);
+  }
+
+  @CallHandler
+  public CompletionStage<ActionReply<Response>> processStreamedIn(
+      Source<Request, NotUsed> requests, ActionContext context) {
+    return requests.via(responses(context)).runWith(singleResponse(), system);
+  }
+
+  @CallHandler
+  public Source<ActionReply<Response>, NotUsed> processStreamedOut(
+      Request request, ActionContext context) {
+    return Source.single(request).via(responses(context));
+  }
+
+  @CallHandler
+  public Source<ActionReply<Response>, NotUsed> processStreamed(
+      Source<Request, NotUsed> requests, ActionContext context) {
+    return requests.via(responses(context));
+  }
+
+  private Flow<Request, ActionReply<Response>, NotUsed> responses(ActionContext context) {
+    return Flow.of(Request.class)
+        .flatMapConcat(request -> Source.from(request.getGroupsList()))
+        .map(group -> response(group, context));
+  }
+
+  private ActionReply<Response> response(ProcessGroup group, ActionContext context) {
+    ActionReply<Response> reply = ActionReply.noReply();
+    for (ProcessStep step : group.getStepsList()) {
+      switch (step.getStepCase()) {
+        case REPLY:
+          reply =
+              ActionReply.message(
+                      Response.newBuilder().setMessage(step.getReply().getMessage()).build())
+                  .withEffects(reply.effects());
+          break;
+        case FORWARD:
+          reply =
+              ActionReply.<Response>forward(serviceTwoRequest(context, step.getForward().getId()))
+                  .withEffects(reply.effects());
+          break;
+        case EFFECT:
+          SideEffect effect = step.getEffect();
+          reply =
+              reply.withEffects(
+                  Effect.of(serviceTwoRequest(context, effect.getId()), effect.getSynchronous()));
+          break;
+        case FAIL:
+          reply =
+              ActionReply.<Response>failure(step.getFail().getMessage())
+                  .withEffects(reply.effects());
+      }
+    }
+    return reply;
+  }
+
+  private Sink<ActionReply<Response>, CompletionStage<ActionReply<Response>>> singleResponse() {
+    return Sink.fold(
+        ActionReply.noReply(),
+        (reply, next) ->
+            next.isEmpty() ? reply.withEffects(next.effects()) : next.withEffects(reply.effects()));
+  }
+
+  private ServiceCall serviceTwoRequest(Context context, String id) {
+    return context
+        .serviceCallFactory()
+        .lookup(ActionTwo.name, "Call", OtherRequest.class)
+        .createCall(OtherRequest.newBuilder().setId(id).build());
+  }
+}

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/action/ActionTwoBehavior.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/action/ActionTwoBehavior.java
@@ -14,23 +14,17 @@
  * limitations under the License.
  */
 
-package io.cloudstate.javasupport.action;
+package io.cloudstate.javasupport.tck.model.action;
 
-import io.cloudstate.javasupport.ServiceCall;
+import io.cloudstate.javasupport.action.*;
+import io.cloudstate.tck.model.Action.*;
 
-import java.util.Collection;
+@Action
+public class ActionTwoBehavior {
+  public ActionTwoBehavior() {}
 
-/** A forward reply. */
-public interface ForwardReply<T> extends ActionReply<T> {
-
-  /**
-   * The service call that is being forwarded to.
-   *
-   * @return The service call.
-   */
-  ServiceCall serviceCall();
-
-  ForwardReply<T> withEffects(Collection<Effect> effects);
-
-  ForwardReply<T> withEffects(Effect... effects);
+  @CallHandler
+  public Response call(OtherRequest request) {
+    return Response.newBuilder().build();
+  }
 }

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/eventsourced/EventSourcedTckModelEntity.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/eventsourced/EventSourcedTckModelEntity.java
@@ -20,6 +20,7 @@ import io.cloudstate.javasupport.Context;
 import io.cloudstate.javasupport.ServiceCall;
 import io.cloudstate.javasupport.ServiceCallRef;
 import io.cloudstate.javasupport.eventsourced.*;
+import io.cloudstate.tck.model.EventSourcedTwo;
 import io.cloudstate.tck.model.Eventsourced.*;
 import java.util.Optional;
 
@@ -32,9 +33,7 @@ public class EventSourcedTckModelEntity {
 
   public EventSourcedTckModelEntity(Context context) {
     serviceTwoCall =
-        context
-            .serviceCallFactory()
-            .lookup("cloudstate.tck.model.EventSourcedTwo", "Call", Request.class);
+        context.serviceCallFactory().lookup(EventSourcedTwo.name, "Call", Request.class);
   }
 
   @Snapshot

--- a/protocols/tck/cloudstate/tck/model/action.proto
+++ b/protocols/tck/cloudstate/tck/model/action.proto
@@ -1,0 +1,134 @@
+// Copyright 2019 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// == Cloudstate TCK model test for actions ==
+//
+
+syntax = "proto3";
+
+package cloudstate.tck.model.action;
+
+option java_package = "io.cloudstate.tck.model";
+option go_package = "github.com/cloudstateio/go-support/tck/action;action";
+
+//
+// The `ActionTckModel` service should be implemented in the following ways:
+//
+// - The `Process` methods receive `Request` messages with steps to take:
+//   - The `ProcessUnary` method receives a single Request and gives a single Response.
+//     Multiple request steps should be combined to give just one response, with subsequent steps taking precedence.
+//   - The `ProcessStreamedIn` method receives a stream of Requests and gives a single Response.
+//     All request steps should be combined to produce a single response after the request stream completes.
+//   - The `ProcessStreamedOut` method receives a single Request and gives a stream of Responses.
+//     The single request may contain multiple grouped steps, each group corresponding to an expected response.
+//   - The `ProcessStreamed` method receives a stream of Requests and gives a stream of Responses.
+//     Each request may contain multiple grouped steps, each group corresponding to an expected response.
+// - Request steps must be processed in order, and can require replying, forwarding, or failing, and side effects.
+// - The Request steps are grouped, for streamed Responses, where each group correlates with a Response.
+// - The `Process` methods must reply with the requested reply message, unless forwarding or failing.
+// - Forwarding and side effects must always be made to the second service `ActionTwo`.
+//
+service ActionTckModel {
+  rpc ProcessUnary(Request) returns (Response);
+  rpc ProcessStreamedIn(stream Request) returns (Response);
+  rpc ProcessStreamedOut(Request) returns (stream Response);
+  rpc ProcessStreamed(stream Request) returns (stream Response);
+}
+
+//
+// The `ActionTwo` service is only for verifying forwards and side effects.
+// The `Call` method is not required to do anything, and may simply return an empty `Response` message.
+//
+service ActionTwo {
+  rpc Call(OtherRequest) returns (Response);
+}
+
+//
+// A `Request` message contains the steps that the entity should process.
+// Steps are grouped for streamed responses. Steps must be processed in order.
+//
+message Request {
+  repeated ProcessGroup groups = 1;
+}
+
+//
+// A `ProcessGroup` contains the steps for one response.
+//
+message ProcessGroup {
+  repeated ProcessStep steps = 1;
+}
+
+//
+// Each `ProcessStep` is one of:
+//
+// - Reply: reply with the given message in a `Response`.
+// - Forward: forward to another service, in place of replying with a `Response`.
+// - Fail: fail the current `Process` command by sending a failure.
+// - SideEffect: add a side effect to the current reply, forward, or failure.
+//
+message ProcessStep {
+  oneof step {
+    Reply reply = 1;
+    Forward forward = 2;
+    Fail fail = 3;
+    SideEffect effect = 4;
+  }
+}
+
+//
+// Reply with a message in the reponse.
+//
+message Reply {
+  string message = 1;
+}
+
+//
+// Replace the response with a forward to `cloudstate.tck.model.ActionTwo/Call`.
+// The payload must be an `OtherRequest` message with the given `id`.
+//
+message Forward {
+  string id = 1;
+}
+
+//
+// Fail the current command with the given description `message`.
+//
+message Fail {
+  string message = 1;
+}
+
+//
+// Add a side effect to the reply, to `cloudstate.tck.model.ActionTwo/Call`.
+// The payload must be an `OtherRequest` message with the given `id`.
+// The side effect should be marked synchronous based on the given `synchronous` value.
+//
+message SideEffect {
+  string id = 1;
+  bool synchronous = 2;
+}
+
+//
+// The `Response` message must contain the message from the corresponding reply step.
+//
+message Response {
+  string message = 1;
+}
+
+//
+// The `OtherRequest` message must contain the id for the forward or side effect.
+//
+message OtherRequest {
+  string id = 1;
+}

--- a/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
+++ b/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
@@ -24,9 +24,10 @@ import com.example.shoppingcart.shoppingcart._
 import com.google.protobuf.DescriptorProtos
 import com.google.protobuf.any.{Any => ScalaPbAny}
 import com.typesafe.config.{Config, ConfigFactory}
-import io.cloudstate.protocol.action.ActionProtocol
+import io.cloudstate.protocol.action._
 import io.cloudstate.protocol.crdt.Crdt
 import io.cloudstate.protocol.event_sourced._
+import io.cloudstate.tck.model.action.{ActionTckModel, ActionTwo}
 import io.cloudstate.testkit.InterceptService.InterceptorSettings
 import io.cloudstate.testkit.eventsourced.{EventSourcedMessages, InterceptEventSourcedService}
 import io.cloudstate.testkit.{InterceptService, ServiceAddress, TestClient, TestProtocol}
@@ -119,6 +120,16 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
 
         serviceNames.size mustBe spec.entities.size
 
+        spec.entities.find(_.serviceName == ActionTckModel.name).foreach { entity =>
+          serviceNames must contain("ActionTckModel")
+          entity.entityType mustBe ActionProtocol.name
+        }
+
+        spec.entities.find(_.serviceName == ActionTwo.name).foreach { entity =>
+          serviceNames must contain("ActionTwo")
+          entity.entityType mustBe ActionProtocol.name
+        }
+
         spec.entities.find(_.serviceName == EventSourcedTckModel.name).foreach { entity =>
           serviceNames must contain("EventSourcedTckModel")
           entity.entityType mustBe EventSourced.name
@@ -137,6 +148,399 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
         }
 
         enabledServices = spec.entities.map(_.serviceName)
+      }
+    }
+
+    "verifying model test: actions" must {
+      import io.cloudstate.protocol.entity
+      import io.cloudstate.tck.model.action._
+      import io.cloudstate.testkit.action.ActionMessages._
+
+      val Service = ActionTckModel.name
+      val ServiceTwo = ActionTwo.name
+
+      def actionTest(test: => Any): Unit =
+        testFor(ActionTckModel, ActionTwo)(test)
+
+      def processUnary(request: Request): ActionCommand =
+        command(Service, "ProcessUnary", request)
+
+      val processStreamedIn: ActionCommand =
+        command(Service, "ProcessStreamedIn")
+
+      def processStreamedOut(request: Request): ActionCommand =
+        command(Service, "ProcessStreamedOut", request)
+
+      val processStreamed: ActionCommand =
+        command(Service, "ProcessStreamed")
+
+      def single(steps: ProcessStep*): Request =
+        request(group(steps: _*))
+
+      def request(groups: ProcessGroup*): Request =
+        Request(groups)
+
+      def group(steps: ProcessStep*): ProcessGroup =
+        ProcessGroup(steps)
+
+      def replyWith(message: String): ProcessStep =
+        ProcessStep(ProcessStep.Step.Reply(Reply(message)))
+
+      def sideEffectTo(id: String, synchronous: Boolean = false): ProcessStep =
+        ProcessStep(ProcessStep.Step.Effect(SideEffect(id, synchronous)))
+
+      def forwardTo(id: String): ProcessStep =
+        ProcessStep(ProcessStep.Step.Forward(Forward(id)))
+
+      def failWith(message: String): ProcessStep =
+        ProcessStep(ProcessStep.Step.Fail(Fail(message)))
+
+      def sideEffects(ids: String*): SideEffects =
+        createSideEffects(synchronous = false, ids)
+
+      def synchronousSideEffects(ids: String*): SideEffects =
+        createSideEffects(synchronous = true, ids)
+
+      def createSideEffects(synchronous: Boolean, ids: Seq[String]): SideEffects =
+        ids.map(id => sideEffect(ServiceTwo, "Call", OtherRequest(id), synchronous))
+
+      def forwarded(id: String, sideEffects: SideEffects = Seq.empty): ActionResponse =
+        forward(ServiceTwo, "Call", OtherRequest(id), sideEffects)
+
+      "verify unary command reply" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(replyWith("one"))))
+          .expect(reply(Response("one")))
+      }
+
+      "verify unary command reply with side effect" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(replyWith("two"), sideEffectTo("other"))))
+          .expect(reply(Response("two"), sideEffects("other")))
+      }
+
+      "verify unary command reply with synchronous side effect" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(replyWith("three"), sideEffectTo("another", synchronous = true))))
+          .expect(reply(Response("three"), synchronousSideEffects("another")))
+      }
+
+      "verify unary command reply with multiple side effects" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(replyWith("four"), sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))))
+          .expect(reply(Response("four"), sideEffects("a", "b", "c")))
+      }
+
+      "verify unary command no reply" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single()))
+          .expect(noReply())
+      }
+
+      "verify unary command no reply with side effect" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(sideEffectTo("other"))))
+          .expect(noReply(sideEffects("other")))
+      }
+
+      "verify unary command no reply with synchronous side effect" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(sideEffectTo("another", synchronous = true))))
+          .expect(noReply(synchronousSideEffects("another")))
+      }
+
+      "verify unary command no reply with multiple side effects" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))))
+          .expect(noReply(sideEffects("a", "b", "c")))
+      }
+
+      "verify unary command forward" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(forwardTo("one"))))
+          .expect(forwarded("one"))
+      }
+
+      "verify unary command forward with side effect" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(forwardTo("two"), sideEffectTo("other"))))
+          .expect(forwarded("two", sideEffects("other")))
+      }
+
+      "verify unary command forward with synchronous side effect" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(forwardTo("three"), sideEffectTo("another", synchronous = true))))
+          .expect(forwarded("three", synchronousSideEffects("another")))
+      }
+
+      "verify unary command forward with multiple side effects" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(forwardTo("four"), sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))))
+          .expect(forwarded("four", sideEffects("a", "b", "c")))
+      }
+
+      "verify unary command failure" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(failWith("one"))))
+          .expect(failure("one"))
+      }
+
+      "verify unary command failure with side effect" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(failWith("two"), sideEffectTo("other"))))
+          .expect(failure("two", sideEffects("other")))
+      }
+
+      "verify unary command failure with synchronous side effect" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(failWith("three"), sideEffectTo("another", synchronous = true))))
+          .expect(failure("three", synchronousSideEffects("another")))
+      }
+
+      "verify unary command failure with multiple side effects" in actionTest {
+        protocol.action.unary
+          .send(processUnary(single(failWith("four"), sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))))
+          .expect(failure("four", sideEffects("a", "b", "c")))
+      }
+
+      "verify streamed-in command reply" in actionTest {
+        protocol.action
+          .connectIn()
+          .send(processStreamedIn)
+          .send(command(single(replyWith("one"))))
+          .complete()
+          .expect(reply(Response("one")))
+      }
+
+      "verify streamed-in command reply with side effects" in actionTest {
+        protocol.action
+          .connectIn()
+          .send(processStreamedIn)
+          .send(command(single(replyWith("two"), sideEffectTo("a"))))
+          .send(command(single(sideEffectTo("b", synchronous = true))))
+          .send(command(single(sideEffectTo("c"), sideEffectTo("d"))))
+          .complete()
+          .expect(reply(Response("two"), sideEffects("a") ++ synchronousSideEffects("b") ++ sideEffects("c", "d")))
+      }
+
+      "verify streamed-in command no reply (no requests)" in actionTest {
+        protocol.action
+          .connectIn()
+          .send(processStreamedIn)
+          .complete()
+          .expect(noReply())
+      }
+
+      "verify streamed-in command no reply" in actionTest {
+        protocol.action
+          .connectIn()
+          .send(processStreamedIn)
+          .send(command(single()))
+          .complete()
+          .expect(noReply())
+      }
+
+      "verify streamed-in command no reply with side effects" in actionTest {
+        protocol.action
+          .connectIn()
+          .send(processStreamedIn)
+          .send(command(single(sideEffectTo("a"))))
+          .send(command(single(sideEffectTo("b", synchronous = true))))
+          .send(command(single(sideEffectTo("c"), sideEffectTo("d"))))
+          .complete()
+          .expect(noReply(sideEffects("a") ++ synchronousSideEffects("b") ++ sideEffects("c", "d")))
+      }
+
+      "verify streamed-in command forward" in actionTest {
+        protocol.action
+          .connectIn()
+          .send(processStreamedIn)
+          .send(command(single(forwardTo("one"))))
+          .complete()
+          .expect(forwarded("one"))
+      }
+
+      "verify streamed-in command forward with side effects" in actionTest {
+        protocol.action
+          .connectIn()
+          .send(processStreamedIn)
+          .send(command(single(forwardTo("two"), sideEffectTo("a"))))
+          .send(command(single(sideEffectTo("b", synchronous = true))))
+          .send(command(single(sideEffectTo("c"), sideEffectTo("d"))))
+          .complete()
+          .expect(forwarded("two", sideEffects("a") ++ synchronousSideEffects("b") ++ sideEffects("c", "d")))
+      }
+
+      "verify streamed-in command failure" in actionTest {
+        protocol.action
+          .connectIn()
+          .send(processStreamedIn)
+          .send(command(single(failWith("one"))))
+          .complete()
+          .expect(failure("one"))
+      }
+
+      "verify streamed-in command failure with side effects" in actionTest {
+        protocol.action
+          .connectIn()
+          .send(processStreamedIn)
+          .send(command(single(failWith("two"), sideEffectTo("a"))))
+          .send(command(single(sideEffectTo("b", synchronous = true))))
+          .send(command(single(sideEffectTo("c"), sideEffectTo("d"))))
+          .complete()
+          .expect(failure("two", sideEffects("a") ++ synchronousSideEffects("b") ++ sideEffects("c", "d")))
+      }
+
+      "verify streamed-out command replies and side effects" in actionTest {
+        protocol.action
+          .connectOut()
+          .send(
+            processStreamedOut(
+              request(
+                group(replyWith("one")),
+                group(replyWith("two"), sideEffectTo("other")),
+                group(replyWith("three"), sideEffectTo("another", synchronous = true)),
+                group(replyWith("four"), sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))
+              )
+            )
+          )
+          .expect(reply(Response("one")))
+          .expect(reply(Response("two"), sideEffects("other")))
+          .expect(reply(Response("three"), synchronousSideEffects("another")))
+          .expect(reply(Response("four"), sideEffects("a", "b", "c")))
+          .expectClosed()
+      }
+
+      "verify streamed-out command no replies and side effects" in actionTest {
+        protocol.action
+          .connectOut()
+          .send(
+            processStreamedOut(
+              request(
+                group(),
+                group(sideEffectTo("other")),
+                group(sideEffectTo("another", synchronous = true)),
+                group(sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))
+              )
+            )
+          )
+          .expect(noReply())
+          .expect(noReply(sideEffects("other")))
+          .expect(noReply(synchronousSideEffects("another")))
+          .expect(noReply(sideEffects("a", "b", "c")))
+          .expectClosed()
+      }
+
+      "verify streamed-out command forwards and side effects" in actionTest {
+        protocol.action
+          .connectOut()
+          .send(
+            processStreamedOut(
+              request(
+                group(forwardTo("one")),
+                group(forwardTo("two"), sideEffectTo("other")),
+                group(forwardTo("three"), sideEffectTo("another", synchronous = true)),
+                group(forwardTo("four"), sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))
+              )
+            )
+          )
+          .expect(forwarded("one"))
+          .expect(forwarded("two", sideEffects("other")))
+          .expect(forwarded("three", synchronousSideEffects("another")))
+          .expect(forwarded("four", sideEffects("a", "b", "c")))
+          .expectClosed()
+      }
+
+      "verify streamed-out command failures and side effects" in actionTest {
+        protocol.action
+          .connectOut()
+          .send(
+            processStreamedOut(
+              request(
+                group(failWith("one")),
+                group(failWith("two"), sideEffectTo("other")),
+                group(failWith("three"), sideEffectTo("another", synchronous = true)),
+                group(failWith("four"), sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))
+              )
+            )
+          )
+          .expect(failure("one"))
+          .expect(failure("two", sideEffects("other")))
+          .expect(failure("three", synchronousSideEffects("another")))
+          .expect(failure("four", sideEffects("a", "b", "c")))
+          .expectClosed()
+      }
+
+      "verify streamed command replies and side effects" in actionTest {
+        protocol.action
+          .connect()
+          .send(processStreamed)
+          .send(command(single(replyWith("one"))))
+          .expect(reply(Response("one")))
+          .send(command(single(replyWith("two"), sideEffectTo("other"))))
+          .expect(reply(Response("two"), sideEffects("other")))
+          .send(command(single(replyWith("three"), sideEffectTo("another", synchronous = true))))
+          .expect(reply(Response("three"), synchronousSideEffects("another")))
+          .send(command(single(replyWith("four"), sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))))
+          .expect(reply(Response("four"), sideEffects("a", "b", "c")))
+          .send(command(request(group(replyWith("five")), group(replyWith("six"), sideEffectTo("other")))))
+          .expect(reply(Response("five")))
+          .expect(reply(Response("six"), sideEffects("other")))
+          .complete()
+      }
+
+      "verify streamed command no replies and side effects" in actionTest {
+        protocol.action
+          .connect()
+          .send(processStreamed)
+          .send(command(single()))
+          .expect(noReply())
+          .send(command(single(sideEffectTo("other"))))
+          .expect(noReply(sideEffects("other")))
+          .send(command(single(sideEffectTo("another", synchronous = true))))
+          .expect(noReply(synchronousSideEffects("another")))
+          .send(command(single(sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))))
+          .expect(noReply(sideEffects("a", "b", "c")))
+          .send(command(request(group(), group(sideEffectTo("other")))))
+          .expect(noReply())
+          .expect(noReply(sideEffects("other")))
+          .complete()
+      }
+
+      "verify streamed command forwards and side effects" in actionTest {
+        protocol.action
+          .connect()
+          .send(processStreamed)
+          .send(command(single(forwardTo("one"))))
+          .expect(forwarded("one"))
+          .send(command(single(forwardTo("two"), sideEffectTo("other"))))
+          .expect(forwarded("two", sideEffects("other")))
+          .send(command(single(forwardTo("three"), sideEffectTo("another", synchronous = true))))
+          .expect(forwarded("three", synchronousSideEffects("another")))
+          .send(command(single(forwardTo("four"), sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))))
+          .expect(forwarded("four", sideEffects("a", "b", "c")))
+          .send(command(request(group(forwardTo("five")), group(forwardTo("six"), sideEffectTo("other")))))
+          .expect(forwarded("five"))
+          .expect(forwarded("six", sideEffects("other")))
+          .complete()
+      }
+
+      "verify streamed command failures and side effects" in actionTest {
+        protocol.action
+          .connect()
+          .send(processStreamed)
+          .send(command(single(failWith("one"))))
+          .expect(failure("one"))
+          .send(command(single(failWith("two"), sideEffectTo("other"))))
+          .expect(failure("two", sideEffects("other")))
+          .send(command(single(failWith("three"), sideEffectTo("another", synchronous = true))))
+          .expect(failure("three", synchronousSideEffects("another")))
+          .send(command(single(failWith("four"), sideEffectTo("a"), sideEffectTo("b"), sideEffectTo("c"))))
+          .expect(failure("four", sideEffects("a", "b", "c")))
+          .send(command(request(group(failWith("five")), group(failWith("six"), sideEffectTo("other")))))
+          .expect(failure("five"))
+          .expect(failure("six", sideEffects("other")))
+          .complete()
       }
     }
 
@@ -180,7 +584,13 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
         events(eventValues: _*).withSnapshot(persisted(snapshotValue))
 
       def sideEffects(ids: String*): Effects =
-        ids.foldLeft(Effects.empty) { case (e, id) => e.withSideEffect(ServiceTwo, "Call", Request(id)) }
+        createSideEffects(synchronous = false, ids)
+
+      def synchronousSideEffects(ids: String*): Effects =
+        createSideEffects(synchronous = true, ids)
+
+      def createSideEffects(synchronous: Boolean, ids: Seq[String]): Effects =
+        ids.foldLeft(Effects.empty) { case (e, id) => e.withSideEffect(ServiceTwo, "Call", Request(id), synchronous) }
 
       "verify initial empty state" in eventSourcedTest { id =>
         protocol.eventSourced
@@ -315,7 +725,7 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, Seq(sideEffectTo(id)))))
-          .expect(reply(1, Response(), sideEffect(EventSourcedTwo.name, "Call", Request(id))))
+          .expect(reply(1, Response(), sideEffects(id)))
           .passivate()
       }
 
@@ -324,7 +734,7 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, Seq(sideEffectTo(id, synchronous = true)))))
-          .expect(reply(1, Response(), sideEffect(EventSourcedTwo.name, "Call", Request(id), synchronous = true)))
+          .expect(reply(1, Response(), synchronousSideEffects(id)))
           .passivate()
       }
 
@@ -333,7 +743,7 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .connect()
           .send(init(EventSourcedTckModel.name, id))
           .send(command(1, id, "Process", Request(id, Seq(sideEffectTo(id), forwardTo(id)))))
-          .expect(forward(1, ServiceTwo, "Call", Request(id), sideEffect(ServiceTwo, "Call", Request(id))))
+          .expect(forward(1, ServiceTwo, "Call", Request(id), sideEffects(id)))
           .passivate()
       }
 

--- a/testkit/src/main/scala/io/cloudstate/testkit/TestProtocol.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/TestProtocol.scala
@@ -20,6 +20,7 @@ import akka.actor.ActorSystem
 import akka.grpc.GrpcClientSettings
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
+import io.cloudstate.testkit.action.TestActionProtocol
 import io.cloudstate.testkit.eventsourced.TestEventSourcedProtocol
 
 final class TestProtocol(host: String, port: Int) {
@@ -27,11 +28,13 @@ final class TestProtocol(host: String, port: Int) {
 
   val context = new TestProtocolContext(host, port)
 
+  val action = new TestActionProtocol(context)
   val eventSourced = new TestEventSourcedProtocol(context)
 
   def settings: GrpcClientSettings = context.clientSettings
 
   def terminate(): Unit = {
+    action.terminate()
     eventSourced.terminate()
     context.terminate()
   }

--- a/testkit/src/main/scala/io/cloudstate/testkit/action/ActionMessages.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/action/ActionMessages.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.action
+
+import com.google.protobuf.any.{Any => ScalaPbAny}
+import com.google.protobuf.{Message => JavaPbMessage}
+import io.cloudstate.protocol.action.{ActionCommand, ActionResponse}
+import io.cloudstate.protocol.entity.{Failure, Forward, Reply, SideEffect}
+import io.cloudstate.testkit.entity.EntityMessages
+import scalapb.{GeneratedMessage => ScalaPbMessage}
+
+object ActionMessages extends EntityMessages {
+  type SideEffects = Seq[SideEffect]
+
+  def command(service: String, name: String, payload: JavaPbMessage): ActionCommand =
+    command(service, name, messagePayload(payload))
+
+  def command(service: String, name: String, payload: ScalaPbMessage): ActionCommand =
+    command(service, name, messagePayload(payload))
+
+  def command(service: String, name: String, payload: Option[ScalaPbAny]): ActionCommand =
+    ActionCommand(service, name, payload)
+
+  def command(service: String, name: String): ActionCommand =
+    ActionCommand(service, name)
+
+  def command(payload: JavaPbMessage): ActionCommand =
+    command(messagePayload(payload))
+
+  def command(payload: ScalaPbMessage): ActionCommand =
+    command(messagePayload(payload))
+
+  def command(payload: Option[ScalaPbAny]): ActionCommand =
+    ActionCommand(payload = payload)
+
+  def reply(payload: JavaPbMessage): ActionResponse =
+    reply(payload, Seq.empty)
+
+  def reply(payload: JavaPbMessage, sideEffects: SideEffects): ActionResponse =
+    reply(messagePayload(payload), sideEffects)
+
+  def reply(payload: ScalaPbMessage): ActionResponse =
+    reply(payload, Seq.empty)
+
+  def reply(payload: ScalaPbMessage, sideEffects: SideEffects): ActionResponse =
+    reply(messagePayload(payload), sideEffects)
+
+  def reply(payload: Option[ScalaPbAny], sideEffects: SideEffects): ActionResponse =
+    ActionResponse(ActionResponse.Response.Reply(Reply(payload)), sideEffects)
+
+  def noReply(): ActionResponse =
+    ActionResponse()
+
+  def noReply(sideEffects: SideEffects): ActionResponse =
+    ActionResponse(sideEffects = sideEffects)
+
+  def forward(service: String, command: String, payload: JavaPbMessage): ActionResponse =
+    forward(service, command, payload, Seq.empty)
+
+  def forward(service: String, command: String, payload: JavaPbMessage, sideEffects: SideEffects): ActionResponse =
+    forward(service, command, messagePayload(payload), sideEffects)
+
+  def forward(service: String, command: String, payload: ScalaPbMessage): ActionResponse =
+    forward(service, command, payload, Seq.empty)
+
+  def forward(service: String, command: String, payload: ScalaPbMessage, sideEffects: SideEffects): ActionResponse =
+    forward(service, command, messagePayload(payload), sideEffects)
+
+  def forward(service: String, command: String, payload: Option[ScalaPbAny], sideEffects: SideEffects): ActionResponse =
+    ActionResponse(ActionResponse.Response.Forward(Forward(service, command, payload)), sideEffects)
+
+  def failure(description: String): ActionResponse =
+    failure(description, Seq.empty)
+
+  def failure(description: String, sideEffects: SideEffects): ActionResponse =
+    ActionResponse(ActionResponse.Response.Failure(Failure(description = description)), sideEffects)
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/action/TestActionProtocol.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/action/TestActionProtocol.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.action
+
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestProbe
+import io.cloudstate.protocol.action._
+import io.cloudstate.testkit.TestProtocol.TestProtocolContext
+import scala.util.{Failure, Success}
+
+final class TestActionProtocol(context: TestProtocolContext) {
+  private val client = ActionProtocolClient(context.clientSettings)(context.system)
+
+  val unary: TestActionProtocol.Unary =
+    new TestActionProtocol.Unary(client, context)
+
+  def connectIn(): TestActionProtocol.InConnection =
+    new TestActionProtocol.InConnection(client, context)
+
+  def connectOut(): TestActionProtocol.OutConnecting =
+    new TestActionProtocol.OutConnecting(client, context)
+
+  def connect(): TestActionProtocol.BidirectionalConnection =
+    new TestActionProtocol.BidirectionalConnection(client, context)
+
+  def terminate(): Unit = client.close()
+}
+
+object TestActionProtocol {
+  final class Unary(client: ActionProtocolClient, context: TestProtocolContext) {
+    private val out = TestProbe("UnaryOutProbe")(context.system)
+
+    def send(command: ActionCommand): Unary = {
+      client.handleUnary(command).onComplete(out.ref.!)(context.system.dispatcher)
+      this
+    }
+
+    def expect(response: ActionResponse): Unit =
+      out.expectMsg(Success(response))
+
+    def expectError(throwable: Throwable): Unit =
+      out.expectMsg(Failure(throwable))
+  }
+
+  final class InConnection(client: ActionProtocolClient, context: TestProtocolContext) {
+    import context.system
+    import context.system.dispatcher
+
+    private val in = TestPublisher.probe[ActionCommand]()
+    private val out = TestProbe("InConnectionOutProbe")(context.system)
+
+    client.handleStreamedIn(Source.fromPublisher(in)).onComplete(out.ref.!)
+
+    def send(command: ActionCommand): InConnection = {
+      in.sendNext(command)
+      this
+    }
+
+    def complete(): InConnection = {
+      in.sendComplete()
+      this
+    }
+
+    def expect(response: ActionResponse): Unit =
+      out.expectMsg(Success(response))
+
+    def expectError(throwable: Throwable): Unit =
+      out.expectMsg(Failure(throwable))
+  }
+
+  final class OutConnecting(client: ActionProtocolClient, context: TestProtocolContext) {
+    def send(command: ActionCommand): OutConnection = new OutConnection(client, context, command)
+  }
+
+  final class OutConnection(client: ActionProtocolClient, context: TestProtocolContext, command: ActionCommand) {
+    import context.system
+
+    private val out = client.handleStreamedOut(command).runWith(TestSink.probe[ActionResponse])
+
+    out.ensureSubscription()
+
+    def expect(response: ActionResponse): OutConnection = {
+      out.request(1).expectNext(response)
+      this
+    }
+
+    def expectClosed(): Unit =
+      out.expectComplete()
+  }
+
+  final class BidirectionalConnection(client: ActionProtocolClient, context: TestProtocolContext) {
+    import context.system
+
+    private val in = TestPublisher.probe[ActionCommand]()
+    private val out = client.handleStreamed(Source.fromPublisher(in)).runWith(TestSink.probe[ActionResponse])
+
+    out.ensureSubscription()
+
+    def send(command: ActionCommand): BidirectionalConnection = {
+      in.sendNext(command)
+      this
+    }
+
+    def expect(response: ActionResponse): BidirectionalConnection = {
+      out.request(1).expectNext(response)
+      this
+    }
+
+    def expectClosed(): Unit = {
+      out.expectComplete()
+      in.expectCancellation()
+    }
+
+    def complete(): Unit = {
+      in.sendComplete()
+      out.expectComplete()
+    }
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/entity/EntityMessages.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/entity/EntityMessages.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.entity
+
+import com.google.protobuf.any.{Any => ScalaPbAny}
+import com.google.protobuf.empty.{Empty => ScalaPbEmpty}
+import com.google.protobuf.{StringValue, Any => JavaPbAny, Empty => JavaPbEmpty, Message => JavaPbMessage}
+import io.cloudstate.protocol.entity._
+import scalapb.{GeneratedMessage => ScalaPbMessage}
+
+object EntityMessages extends EntityMessages
+
+trait EntityMessages {
+  val EmptyJavaMessage: JavaPbMessage = JavaPbEmpty.getDefaultInstance
+  val EmptyScalaMessage: ScalaPbMessage = ScalaPbEmpty.defaultInstance
+
+  def clientActionReply(payload: Option[ScalaPbAny]): Option[ClientAction] =
+    Some(ClientAction(ClientAction.Action.Reply(Reply(payload))))
+
+  def clientActionForward(service: String, command: String, payload: Option[ScalaPbAny]): Option[ClientAction] =
+    Some(ClientAction(ClientAction.Action.Forward(Forward(service, command, payload))))
+
+  def clientActionFailure(description: String): Option[ClientAction] =
+    clientActionFailure(id = 0, description)
+
+  def clientActionFailure(id: Long, description: String): Option[ClientAction] =
+    clientActionFailure(id, description, restart = false)
+
+  def clientActionFailure(id: Long, description: String, restart: Boolean): Option[ClientAction] =
+    Some(ClientAction(ClientAction.Action.Failure(Failure(id, description, restart))))
+
+  def sideEffect(service: String, command: String, payload: JavaPbMessage): SideEffect =
+    sideEffect(service, command, messagePayload(payload), synchronous = false)
+
+  def sideEffect(service: String, command: String, payload: JavaPbMessage, synchronous: Boolean): SideEffect =
+    sideEffect(service, command, messagePayload(payload), synchronous)
+
+  def sideEffect(service: String, command: String, payload: ScalaPbMessage): SideEffect =
+    sideEffect(service, command, messagePayload(payload), synchronous = false)
+
+  def sideEffect(service: String, command: String, payload: ScalaPbMessage, synchronous: Boolean): SideEffect =
+    sideEffect(service, command, messagePayload(payload), synchronous)
+
+  def sideEffect(service: String, command: String, payload: Option[ScalaPbAny], synchronous: Boolean): SideEffect =
+    SideEffect(service, command, payload, synchronous)
+
+  def messagePayload(message: JavaPbMessage): Option[ScalaPbAny] =
+    Option(message).map(protobufAny)
+
+  def messagePayload(message: ScalaPbMessage): Option[ScalaPbAny] =
+    Option(message).map(protobufAny)
+
+  def protobufAny(message: JavaPbMessage): ScalaPbAny = message match {
+    case javaPbAny: JavaPbAny => ScalaPbAny.fromJavaProto(javaPbAny)
+    case _ => ScalaPbAny("type.googleapis.com/" + message.getDescriptorForType.getFullName, message.toByteString)
+  }
+
+  def protobufAny(message: ScalaPbMessage): ScalaPbAny = message match {
+    case scalaPbAny: ScalaPbAny => scalaPbAny
+    case _ => ScalaPbAny("type.googleapis.com/" + message.companion.scalaDescriptor.fullName, message.toByteString)
+  }
+
+  def primitiveString(value: String): ScalaPbAny =
+    ScalaPbAny("p.cloudstate.io/string", StringValue.of(value).toByteString)
+}


### PR DESCRIPTION
More on evolving the TCK: #316. Add simple TCK model tests for Actions.

Currently only implemented for java-support, which is set up for TCK model tests. This did uncover a couple of things in the java-support implementation: side effects were not being returned to the proxy, and there was no support for failure replies.