### PR TITLE
Update javadoc links in java-support docs

### DIFF
--- a/java-support/docs/src/modules/java/pages/crdt.adoc
+++ b/java-support/docs/src/modules/java/pages/crdt.adoc
@@ -13,7 +13,7 @@ include::example$docs/user/crdt/ShoppingCartEntity.java[tag=entity-class]
 
 Each CRDT entity manages one root CRDT. That CRDT will either be supplied to the entity by the proxy when it is started, or, if no CRDT exists for the entity when it is started, it can be created by the entity using a link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CrdtFactory.html[`CrdtFactory`] extending context.
 
-There are multiple ways that a CRDT entity may access its CRDT. It may have the CRDT injected directly into its constructor or a command handler - the value can be wrapped in an `Optional` to distinguish between entities that have been created and CRDTs that have not yet been created. If not wrapped in `Optional`, the CRDT will be created automatically, according to its type. The CRDT can also be read from any link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CrdtContext.html[`CrdtContext`] via the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CrdtContext.html#state-java.lang.Class-[`state`] method.
+There are multiple ways that a CRDT entity may access its CRDT. It may have the CRDT injected directly into its constructor or a command handler - the value can be wrapped in an `Optional` to distinguish between entities that have been created and CRDTs that have not yet been created. If not wrapped in `Optional`, the CRDT will be created automatically, according to its type. The CRDT can also be read from any link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CrdtContext.html[`CrdtContext`] via the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CrdtContext.html#state(java.lang.Class)[`state`] method.
 
 An entity's CRDT can be created from the entity's constructor using the `CrdtFactory` methods on link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CrdtCreationContext.html[`CrdtCreationContext`], or using the same methods in a command handler using the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CommandContext.html[`CommandContext`]. Note that the CRDT may only be created once, and only if it hasn't been provided by the CloudState proxy already. Any attempt to create a CRDT when one already exists will throw an `IllegalStateException`.
 
@@ -56,7 +56,7 @@ include::example$docs/user/crdt/ShoppingCartEntity.java[tag=add-item]
 
 == Deleting a CRDT
 
-A CRDT can be deleted by invoking link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CommandContext.html#delete--[`CommandContext.delete`]. Once a CRDT is deleted, the entity will be shut down, and all subsequent commands for the entity will be rejected.
+A CRDT can be deleted by invoking link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CommandContext.html#delete()[`CommandContext.delete`]. Once a CRDT is deleted, the entity will be shut down, and all subsequent commands for the entity will be rejected.
 
 Caution should be taken when deleting CRDTs - the Reference Implementation of the proxy needs to maintain tombstones for each CRDT deleted, so over time, if many CRDTs are created and deleted, this will result in not just running out of memory, but increased network usage as the tombstones still need to be gossipped through the cluster for replication.
 
@@ -66,7 +66,7 @@ Streamed commands can be used to receive and publish updates to the state. If a 
 
 === Responding to changes
 
-If the command handler wishes to publish changes to the stream it can register a callback with link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/StreamedCommandContext.html#onChange-java.util.function.Function-[`onChange`], which will be invoked every time the CRDT changes.
+If the command handler wishes to publish changes to the stream it can register a callback with link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/StreamedCommandContext.html#onChange(java.util.function.Function)[`onChange`], which will be invoked every time the CRDT changes.
 
 The callback is then able to return a message to be sent to the client (or empty, if it wishes to send no message in response to that particular change). The callback may not modify the CRDT itself, but it may emit effects that may modify the CRDT.
 
@@ -86,11 +86,11 @@ include::example$docs/user/crdt/ShoppingCartEntity.java[tag=watch-cart]
 
 === Ending the stream
 
-The `onChange` callback can end the stream by invoking link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/SubscriptionContext.html#endStream--[`endStream`] on the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/SubscriptionContext.html[`SubscriptionContext`] it is passed. If it does this, it will not receive an `onCancel` callback.
+The `onChange` callback can end the stream by invoking link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/SubscriptionContext.html#endStream()[`endStream`] on the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/SubscriptionContext.html[`SubscriptionContext`] it is passed. If it does this, it will not receive an `onCancel` callback.
 
 === Responding to stream cancellation
 
-A streamed command handler may also register an link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/StreamedCommandContext.html#onCancel-java.util.function.Consumer-[`onCancel`] callback to be notified when the stream is cancelled. The cancellation callback handler may update the CRDT. This is useful if the CRDT is being used to track connections, for example, when using link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html[`Vote`] CRDTs to track a user's online status.
+A streamed command handler may also register an link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/StreamedCommandContext.html#onCancel(java.util.function.Consumer)[`onCancel`] callback to be notified when the stream is cancelled. The cancellation callback handler may update the CRDT. This is useful if the CRDT is being used to track connections, for example, when using link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html[`Vote`] CRDTs to track a user's online status.
 
 == Types of CRDTs
 
@@ -102,17 +102,17 @@ link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/GCounter.html[`GCounter
 
 === Vote
 
-link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html[`Vote`] is available for the Vote CRDT. The Vote CRDT allows updating the current node's vote using the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#vote-boolean-[`vote`] method, the current nodes vote can be queried using the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#getSelfVote--[`getSelfVote`] method.
+link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html[`Vote`] is available for the Vote CRDT. The Vote CRDT allows updating the current node's vote using the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#vote(boolean)[`vote`] method, the current nodes vote can be queried using the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#getSelfVote()[`getSelfVote`] method.
 
-For determining the result of a vote, link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#getVoters--[`getVoters`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#getVotesFor--[`getVotesFor`] can be used to check the total number of nodes, and the number of nodes that have voted for the condition, respectively. In addition, convenience methods are provided for common vote decision approaches, link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#isAtLeastOne--[`isAtLeastOne`] returns true if there is at least one voter for the condition, link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#isMajority--[`isMajority`] returns true if the number of votes for is more than half the number of voters, and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#isUnanimous--[`isUnanimous`] returns true if the number of votes for equals the number of voters.
+For determining the result of a vote, link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#getVoters()[`getVoters`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#getVotesFor()[`getVotesFor`] can be used to check the total number of nodes, and the number of nodes that have voted for the condition, respectively. In addition, convenience methods are provided for common vote decision approaches, link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#isAtLeastOne()[`isAtLeastOne`] returns true if there is at least one voter for the condition, link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#isMajority()[`isMajority`] returns true if the number of votes for is more than half the number of voters, and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/Vote.html#isUnanimous()[`isUnanimous`] returns true if the number of votes for equals the number of voters.
 
 === Registers
 
-link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html[`LWWRegister`] provides the LWWRegister CRDT. It can be interacted with using the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html#set-T-[`set`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html#get--[`get`] methods. If you wish to use a custom clock, you can use the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html#set-T-io.cloudstate.javasupport.crdt.LWWRegister.Clock-long-[`set`] overload that allows passing a custom clock and custom clock value.
+link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html[`LWWRegister`] provides the LWWRegister CRDT. It can be interacted with using the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html#set(T)[`set`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html#get()[`get`] methods. If you wish to use a custom clock, you can use the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html#set(T,io.cloudstate.javasupport.crdt.LWWRegister.Clock,long)[`set`] overload that allows passing a custom clock and custom clock value.
 
 [IMPORTANT]
 ====
-Direct mutations to link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html[`LWWRegister`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegisterMap.html[`LWWRegisterMap`] values will not be replicated to other nodes, only mutations triggered through using the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html#set-T-[`set`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegisterMap.html#put-K-V-[`put`] methods will be replicated. Hence, the following update will not be replicated:
+Direct mutations to link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html[`LWWRegister`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegisterMap.html[`LWWRegisterMap`] values will not be replicated to other nodes, only mutations triggered through using the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegister.html#set(T)[`set`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegisterMap.html#put(K,V)[`put`] methods will be replicated. Hence, the following update will not be replicated:
 
 [source,java]
 ----
@@ -135,7 +135,7 @@ In general, we recommend that these values be immutable, as this will prevent ac
 
 Cloudstate Java support provides link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/GSet.html[`GSet`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/ORSet.html[`ORSet`] that implement the `java.util.Set` interface, and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/ORMap.html[`ORMap`] that implements the `java.util.Map`. However, not all operations are implemented - `GSet` doesn't support any removal operations, and `ORMap` does not support any operations that would replace an existing value in the map.
 
-To insert a value into an `ORMap`, you should use the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/ORMap.html#getOrCreate-K-java.util.function.Function-[`getOrCreate`] method. The passed in callback will give you a link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CrdtFactory.html[`CrdtFactory`] that you can use to create the CRDT value that you wish to use.
+To insert a value into an `ORMap`, you should use the link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/ORMap.html#getOrCreate(K,java.util.function.Function)[`getOrCreate`] method. The passed in callback will give you a link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/CrdtFactory.html[`CrdtFactory`] that you can use to create the CRDT value that you wish to use.
 
 [IMPORTANT]
 ====
@@ -154,7 +154,7 @@ link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/LWWRegisterMap.html[`LW
 A map of LWWRegister values. This exposes the LWWRegister values as values directly in the map.
 
 link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/PNCounterMap.html[`PNCounterMap`]::
-A map of PNCounter values. This exposes the current value of the PNCounters directly as values in the map, and offers link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/PNCounterMap.html#increment-java.lang.Object-long-[`increment`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/PNCounterMap.html#decrement-java.lang.Object-long-[`decrement`] methods to update the values.
+A map of PNCounter values. This exposes the current value of the PNCounters directly as values in the map, and offers link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/PNCounterMap.html#increment(java.lang.Object,long)[`increment`] and link:{attachmentsdir}/api/io/cloudstate/javasupport/crdt/PNCounterMap.html#decrement(java.lang.Object,long)[`decrement`] methods to update the values.
 
 == Registering the entity
 

--- a/java-support/docs/src/modules/java/pages/effects.adoc
+++ b/java-support/docs/src/modules/java/pages/effects.adoc
@@ -4,7 +4,7 @@ This page documents how to use Cloudstate effects and forwarding in Java. For hi
 
 == Looking up service call references
 
-To forward a command or emit an effect, a reference to the service call that will be invoked needs to be looked up. This can be done using the link:{attachmentsdir}/api/io/cloudstate/javasupport/ServiceCallFactory.html[ServiceCallFactory] interface, which is accessible on any context object via the link:{attachmentsdir}/api/io/cloudstate/javasupport/Context.html#serviceCallFactory--[`serviceCallFactory()`] method.
+To forward a command or emit an effect, a reference to the service call that will be invoked needs to be looked up. This can be done using the link:{attachmentsdir}/api/io/cloudstate/javasupport/ServiceCallFactory.html[ServiceCallFactory] interface, which is accessible on any context object via the link:{attachmentsdir}/api/io/cloudstate/javasupport/Context.html#serviceCallFactory()[`serviceCallFactory()`] method.
 
 For example, if a user function serves two entity types, a shopping cart, and a CRDT that tracks which items are currently in hot demand, it might want to invoke the `ItemAddedToCart` command on `example.shoppingcart.HotItems` as a side effect of the `AddItem` shopping cart command. This reference can be looked up like so:
 
@@ -17,7 +17,7 @@ This could be looked up in the constructor of the entity, for later use, so it d
 
 == Forwarding command
 
-The `CommandContext` for each entity type implements `ClientActionContext` to allow forwarding a command by invoking link:{attachmentsdir}/api/io/cloudstate/javasupport/ClientActionContext.html#forward-io.cloudstate.javasupport.ServiceCall-[`ClientActionContext.forward()`]. For example, if the item being processed in the `addItem` command is a "hot" item, we can make the `HotItems` entity aware of that item by forwarding a command:
+The `CommandContext` for each entity type implements `ClientActionContext` to allow forwarding a command by invoking link:{attachmentsdir}/api/io/cloudstate/javasupport/ClientActionContext.html#forward(io.cloudstate.javasupport.ServiceCall)[`ClientActionContext.forward()`]. For example, if the item being processed in the `addItem` command is a "hot" item, we can make the `HotItems` entity aware of that item by forwarding a command:
 
 [source,java]
 ----
@@ -26,7 +26,7 @@ include::example$docs/user/effects/ShoppingCartEntity.java[tag=forward]
 
 == Emitting an effect
 
-The `CommandContext` for each entity type implements `EffectContext` to allow emitting an effect by invoking link:{attachmentsdir}/api/io/cloudstate/javasupport/EffectContext.html#effect-io.cloudstate.javasupport.ServiceCall-boolean-[`EffectContext.effect()`]. For example, upon successful completion of the `addItem` command by `ShoppingCartEntity`, if we also want to emit an effect on the `HotItems` entity, we would invoke the effectful service call as:
+The `CommandContext` for each entity type implements `EffectContext` to allow emitting an effect by invoking link:{attachmentsdir}/api/io/cloudstate/javasupport/EffectContext.html#effect(io.cloudstate.javasupport.ServiceCall,boolean)[`EffectContext.effect()`]. For example, upon successful completion of the `addItem` command by `ShoppingCartEntity`, if we also want to emit an effect on the `HotItems` entity, we would invoke the effectful service call as:
 
 [source,java]
 ----


### PR DESCRIPTION
Follow up to #469. Update the javadoc links to Java 11 style.