### PR TITLE
Retry Spanner schema creation and shutdown on ultimate failure

### DIFF
--- a/proxy/spanner/src/main/resources/application.conf
+++ b/proxy/spanner/src/main/resources/application.conf
@@ -51,6 +51,8 @@ cloudstate {
       snapshots-table = "snapshots"${?SPANNER_TABLE_SUFFIX}
       operation-await-delay = 500ms
       operation-await-max-duration = 30s
+      number-of-retries = 3
+      retry-delay = 60s
     }
   }
 }

--- a/proxy/spanner/src/main/scala/io/cloudstate/proxy/spanner/Schema.scala
+++ b/proxy/spanner/src/main/scala/io/cloudstate/proxy/spanner/Schema.scala
@@ -31,7 +31,8 @@ object Schema {
         |  ser_manifest STRING(MAX) NOT NULL,
         |  write_time TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
         |  writer_uuid STRING(MAX) NOT NULL,
-        |) PRIMARY KEY (persistence_id, sequence_nr)""".stripMargin
+        |) PRIMARY KEY (persistence_id, sequence_nr);
+        |""".stripMargin
 
   def createTagsTableDdl(table: String, journalTable: String): String =
     s"""|CREATE TABLE $table (
@@ -40,7 +41,8 @@ object Schema {
         |  tag STRING(MAX) NOT NULL,
         |  write_time TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
         |) PRIMARY KEY (persistence_id, sequence_nr, tag),
-        |INTERLEAVE IN PARENT $journalTable ON DELETE CASCADE""".stripMargin
+        |INTERLEAVE IN PARENT $journalTable ON DELETE CASCADE;
+        |""".stripMargin
 
   def createTagsIndexDdl(table: String): String = {
     val name = tagsIndexName(table)
@@ -48,17 +50,16 @@ object Schema {
         |ON $table (
         |  tag,
         |  write_time
-        |)""".stripMargin
+        |);
+        |""".stripMargin
   }
 
   def createDeletionsTableDdl(table: String): String =
     s"""|CREATE TABLE $table (
         |  persistence_id STRING(MAX) NOT NULL,
         |  deleted_to INT64 NOT NULL,
-        |) PRIMARY KEY (persistence_id)""".stripMargin
-
-  def tagsIndexName(table: String): String =
-    s"${table}_tag_and_offset"
+        |) PRIMARY KEY (persistence_id);
+        |""".stripMargin
 
   def createSnapshotsTableDdl(table: String): String =
     s"""|CREATE TABLE $table (
@@ -68,5 +69,9 @@ object Schema {
         |  ser_id INT64 NOT NULL,
         |  ser_manifest STRING(MAX) NOT NULL,
         |  snapshot BYTES(MAX)
-        |) PRIMARY KEY (persistence_id, sequence_nr)""".stripMargin
+        |) PRIMARY KEY (persistence_id, sequence_nr);
+        |""".stripMargin
+
+  private def tagsIndexName(table: String) =
+    s"${table}_tag_and_offset"
 }

--- a/proxy/spanner/src/main/scala/io/cloudstate/proxy/spanner/SchemaCheck.scala
+++ b/proxy/spanner/src/main/scala/io/cloudstate/proxy/spanner/SchemaCheck.scala
@@ -17,17 +17,16 @@
 package io.cloudstate.proxy.spanner
 
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.adapter.TypedSchedulerOps
 import akka.Done
 import akka.actor.typed.Behavior
-import akka.actor.Scheduler
+import akka.actor.typed.scaladsl.adapter.TypedSchedulerOps
+import akka.pattern.after
 import com.google.longrunning.{GetOperationRequest, Operation, OperationsClient}
 import com.google.spanner.admin.database.v1.{DatabaseAdminClient, UpdateDatabaseDdlRequest}
 import io.grpc.{Status, StatusRuntimeException}
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.{Failure, Success, Try}
-import akka.pattern.after
+import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success}
 
 /**
  * This actor checks that the database schema for akka-persistence-spanner is created. It therefore
@@ -36,10 +35,17 @@ import scala.concurrent.duration.FiniteDuration
  */
 object SchemaCheck {
 
+  sealed trait Command
+  private final case class HandleFailure(cause: Throwable) extends Command
+  private final case object HandleSuccess extends Command
+  private final case object TryCreateSchema extends Command
+
   final class ReadinessCheck extends (() => Future[Boolean]) {
     override def apply(): Future[Boolean] =
       ready.future
   }
+
+  private val ready = Promise[Boolean]()
 
   def apply(databaseName: String,
             journalTable: String,
@@ -49,32 +55,88 @@ object SchemaCheck {
             operationAwaitDelay: FiniteDuration,
             operationAwaitMaxDuration: FiniteDuration,
             adminClient: DatabaseAdminClient,
-            operationsClient: OperationsClient): Behavior[Try[Done]] =
+            operationsClient: OperationsClient,
+            numberOfRetries: Int,
+            retryDelay: FiniteDuration): Behavior[Command] =
     Behaviors.setup { context =>
       import context.executionContext
 
-      val scheduler = context.system.scheduler.toClassic
-      val self = context.self
+      def tryCreateSchema() = {
+        def tryCreate(ddl: String) =
+          adminClient
+            .updateDatabaseDdl(UpdateDatabaseDdlRequest(databaseName, List(ddl)))
+            .transform {
+              case Success(o) =>
+                Success(o)
+              case Failure(t) if alreadyExists(t) =>
+                Success(Operation(done = true, result = Operation.Result.Empty))
+              case other =>
+                other
+            }
 
-      tryCreateSchema(
-        databaseName,
-        journalTable,
-        tagsTable,
-        deletionsTable,
-        snapshotsTable,
-        operationAwaitDelay,
-        operationAwaitMaxDuration,
-        adminClient,
-        operationsClient,
-        scheduler
-      ).onComplete(self ! _)
+        def await(operation: Operation): Future[Done] = {
+          val deadline = operationAwaitMaxDuration.fromNow
+          def loop(o: Operation): Future[Done] =
+            if (deadline.hasTimeLeft())
+              operationsClient
+                .getOperation(GetOperationRequest(o.name))
+                .flatMap { o =>
+                  if (o.done)
+                    Future.successful(Done)
+                  else
+                    after(operationAwaitDelay, context.system.scheduler.toClassic)(loop(o))
+                } else
+              Future.failed(
+                new IllegalStateException(s"Operation ${operation.name} not done after $operationAwaitMaxDuration!")
+              )
+          if (operation.done)
+            Future.successful(Done)
+          else
+            loop(operation)
+        }
+
+        val ddl =
+          List(
+            Schema.createJournalTableDdl(journalTable),
+            Schema.createTagsTableDdl(tagsTable, journalTable),
+            Schema.createDeletionsTableDdl(deletionsTable),
+            Schema.createTagsIndexDdl(tagsTable),
+            Schema.createSnapshotsTableDdl(snapshotsTable)
+          ).mkString
+
+        tryCreate(ddl).flatMap(await)
+      }
 
       Behaviors.receiveMessage {
-        case Failure(t) =>
+        case TryCreateSchema =>
+          context.pipeToSelf(tryCreateSchema()) {
+            case Failure(cause) => HandleFailure(cause)
+            case _ => HandleSuccess
+          }
+          Behaviors.same
+
+        case HandleFailure(t) if numberOfRetries <= 0 =>
           context.log.error("Cannot create schema!", t)
           Behaviors.stopped
 
-        case Success(_) =>
+        case HandleFailure(t) =>
+          context.log.warn("Scheduling retry to create schema!", t)
+          context.scheduleOnce(retryDelay, context.self, TryCreateSchema)
+          SchemaCheck(
+            databaseName,
+            journalTable,
+            tagsTable,
+            deletionsTable,
+            snapshotsTable,
+            operationAwaitDelay,
+            operationAwaitMaxDuration,
+            adminClient,
+            operationsClient,
+            numberOfRetries - 1,
+            retryDelay
+          )
+
+        case HandleSuccess =>
           context.log.info("Schema already existed or successfully created")
           ready.success(true)
           adminClient.close()
@@ -82,67 +144,6 @@ object SchemaCheck {
           Behaviors.stopped
       }
     }
-
-  private val ready = Promise[Boolean]()
-
-  private def tryCreateSchema(databaseName: String,
-                              journalTable: String,
-                              tagsTable: String,
-                              deletionsTable: String,
-                              snapshotTable: String,
-                              operationAwaitDelay: FiniteDuration,
-                              operationAwaitMaxDuration: FiniteDuration,
-                              adminClient: DatabaseAdminClient,
-                              operationsClient: OperationsClient,
-                              scheduler: Scheduler)(
-      implicit ec: ExecutionContext
-  ) = {
-    def tryCreate(ddl: String) =
-      adminClient
-        .updateDatabaseDdl(UpdateDatabaseDdlRequest(databaseName, List(ddl)))
-        .transform {
-          case Success(o) =>
-            Success(o)
-          case Failure(t) if alreadyExists(t) =>
-            Success(Operation(done = true, result = Operation.Result.Empty))
-          case other =>
-            other
-        }
-
-    def await(operation: Operation)(implicit ec: ExecutionContext): Future[Done] = {
-      val deadline = operationAwaitMaxDuration.fromNow
-
-      def loop(o: Operation): Future[Done] =
-        if (deadline.hasTimeLeft())
-          operationsClient
-            .getOperation(GetOperationRequest(o.name))
-            .flatMap { o =>
-              if (o.done)
-                Future.successful(Done)
-              else
-                after(operationAwaitDelay, scheduler)(loop(o))
-            } else
-          Future.failed(
-            new IllegalStateException(s"Operation ${operation.name} not done after $operationAwaitMaxDuration!")
-          )
-
-      if (operation.done)
-        Future.successful(Done)
-      else
-        loop(operation)
-    }
-
-    val ddl =
-      List(
-        Schema.createJournalTableDdl(journalTable),
-        Schema.createTagsTableDdl(tagsTable, journalTable),
-        Schema.createDeletionsTableDdl(deletionsTable),
-        Schema.createTagsIndexDdl(tagsTable),
-        Schema.createSnapshotsTableDdl(snapshotTable)
-      ).mkString
-
-    tryCreate(ddl).flatMap(await)
-  }
 
   private def alreadyExists(t: Throwable) =
     t match {


### PR DESCRIPTION
See https://github.com/lightbend/cloudstatemachine/issues/2083.

This PR improves on the so far very naive approach to check and create the database schema for Google Cloud Spanner:
- Several admin calls are unified into single a one
- Schema check/creation is retried a configurable number of times after a configurable delay
- After ultimate failure the actor system is shutdown (for k8s to react upon)