### PR TITLE
Fix yaml name for SpannerStore.Project

### DIFF
--- a/cloudstate-operator/config/crd/bases/cloudstate.io_statefulstores.yaml
+++ b/cloudstate-operator/config/crd/bases/cloudstate.io_statefulstores.yaml
@@ -206,6 +206,9 @@ spec:
                   instance:
                     description: Instance is the Spanner instance id.
                     type: string
+                  project:
+                    description: Project is the GCP project to use.
+                    type: string
                   secret:
                     description: Secret the secret to read Spanner credentials from.
                       Must have a key.json file in it.
@@ -215,12 +218,9 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                  string:
-                    description: Project is the GCP project to use.
-                    type: string
                 required:
                 - instance
-                - string
+                - project
                 type: object
             type: object
           status:

--- a/cloudstate-operator/manifests/cloudstate-operator-native.yaml
+++ b/cloudstate-operator/manifests/cloudstate-operator-native.yaml
@@ -1428,6 +1428,9 @@ spec:
                   instance:
                     description: Instance is the Spanner instance id.
                     type: string
+                  project:
+                    description: Project is the GCP project to use.
+                    type: string
                   secret:
                     description: Secret the secret to read Spanner credentials from.
                       Must have a key.json file in it.
@@ -1437,12 +1440,9 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                  string:
-                    description: Project is the GCP project to use.
-                    type: string
                 required:
                 - instance
-                - string
+                - project
                 type: object
             type: object
           status:

--- a/cloudstate-operator/manifests/cloudstate-operator.yaml
+++ b/cloudstate-operator/manifests/cloudstate-operator.yaml
@@ -1428,6 +1428,9 @@ spec:
                   instance:
                     description: Instance is the Spanner instance id.
                     type: string
+                  project:
+                    description: Project is the GCP project to use.
+                    type: string
                   secret:
                     description: Secret the secret to read Spanner credentials from.
                       Must have a key.json file in it.
@@ -1437,12 +1440,9 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                  string:
-                    description: Project is the GCP project to use.
-                    type: string
                 required:
                 - instance
-                - string
+                - project
                 type: object
             type: object
           status:

--- a/cloudstate-operator/manifests/crds.yaml
+++ b/cloudstate-operator/manifests/crds.yaml
@@ -1420,6 +1420,9 @@ spec:
                   instance:
                     description: Instance is the Spanner instance id.
                     type: string
+                  project:
+                    description: Project is the GCP project to use.
+                    type: string
                   secret:
                     description: Secret the secret to read Spanner credentials from.
                       Must have a key.json file in it.
@@ -1429,12 +1432,9 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                  string:
-                    description: Project is the GCP project to use.
-                    type: string
                 required:
                 - instance
-                - string
+                - project
                 type: object
             type: object
           status:

--- a/cloudstate-operator/pkg/apis/v1alpha1/statefulstore_types.go
+++ b/cloudstate-operator/pkg/apis/v1alpha1/statefulstore_types.go
@@ -155,7 +155,7 @@ const (
 // SpannerStore simply indicates the use of a Cloudstate-managed Spanner store.
 type SpannerStore struct {
 	// Project is the GCP project to use.
-	Project string `json:"string"`
+	Project string `json:"project"`
 
 	// Instance is the Spanner instance id.
 	Instance string `json:"instance"`


### PR DESCRIPTION
Don't know if this is worth updating the ApiVersion or not...  e.g. v1alpha1 -> v1alpha2