### PR TITLE
Fix javadoc search: disable module directories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -581,6 +581,7 @@ lazy val `java-support` = (project in file("java-support"))
     javacOptions in (Compile, doc) ++= Seq(
         "-overview",
         ((javaSource in Compile).value / "overview.html").getAbsolutePath,
+        "--no-module-directories",
         "-notimestamp",
         "-doctitle",
         "Cloudstate Java Support"


### PR DESCRIPTION
Resolves #481 

Disable module directories — javadoc search adds an incorrect `undefined` to links, as we're not using modules.