### PR TITLE
Add TCK model test for CRDT entities

### DIFF
--- a/java-support/src/main/java/io/cloudstate/javasupport/crdt/CrdtContext.java
+++ b/java-support/src/main/java/io/cloudstate/javasupport/crdt/CrdtContext.java
@@ -31,4 +31,18 @@ public interface CrdtContext extends EntityContext {
    *     </code> type.
    */
   <T extends Crdt> Optional<T> state(Class<T> crdtClass) throws IllegalStateException;
+
+  /**
+   * Get the current write consistency setting for replication of CRDT state.
+   *
+   * @return the current write consistency
+   */
+  WriteConsistency getWriteConsistency();
+
+  /**
+   * Set the write consistency setting for replication of CRDT state.
+   *
+   * @param writeConsistency the new write consistency to use
+   */
+  void setWriteConsistency(WriteConsistency writeConsistency);
 }

--- a/java-support/src/main/java/io/cloudstate/javasupport/crdt/WriteConsistency.java
+++ b/java-support/src/main/java/io/cloudstate/javasupport/crdt/WriteConsistency.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.javasupport.crdt;
+
+/** Write consistency setting for replication of state updates for CRDTs. */
+public enum WriteConsistency {
+  /**
+   * Updates will only be written to the local replica immediately, and then asynchronously
+   * distributed to other replicas in the background.
+   */
+  LOCAL,
+
+  /**
+   * Updates will be written immediately to a majority of replicas, and then asynchronously
+   * distributed to remaining replicas in the background.
+   */
+  MAJORITY,
+
+  /** Updates will be written immediately to all replicas. */
+  ALL
+}

--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/crdt/AnnotationBasedCrdtSupport.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/crdt/AnnotationBasedCrdtSupport.scala
@@ -45,7 +45,8 @@ import io.cloudstate.javasupport.crdt.{
   StreamCancelledContext,
   StreamedCommandContext,
   SubscriptionContext,
-  Vote
+  Vote,
+  WriteConsistency
 }
 import io.cloudstate.javasupport.impl.ReflectionHelper.{
   CommandHandlerInvoker,
@@ -288,6 +289,9 @@ private final class AdaptedStreamedCommandContext(val delegate: StreamedCommandC
   override def newLWWRegister[T](value: T): LWWRegister[T] = delegate.newLWWRegister(value)
   override def newORMap[K, V <: Crdt](): ORMap[K, V] = delegate.newORMap()
   override def newVote(): Vote = delegate.newVote()
+
+  override def getWriteConsistency: WriteConsistency = delegate.getWriteConsistency
+  override def setWriteConsistency(consistency: WriteConsistency): Unit = delegate.setWriteConsistency(consistency)
 }
 
 private final class EntityConstructorInvoker(constructor: Constructor[_]) extends (CrdtCreationContext => AnyRef) {

--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/crdt/CrdtImpl.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/crdt/CrdtImpl.scala
@@ -31,7 +31,8 @@ import io.cloudstate.javasupport.crdt.{
   CrdtEntityFactory,
   StreamCancelledContext,
   StreamedCommandContext,
-  SubscriptionContext
+  SubscriptionContext,
+  WriteConsistency
 }
 import io.cloudstate.javasupport.impl.{
   AbstractClientActionContext,
@@ -139,7 +140,9 @@ class CrdtImpl(system: ActorSystem, services: Map[String, CrdtStatefulService], 
         ctx.deactivate()
       }
     }
-    verifyNoDelta("creation")
+    // Doesn't make sense to verify that there's no delta here.
+    // LWWRegister can have its value set on creation, so there may be a delta.
+    // verifyNoDelta("creation")
 
     private def verifyNoDelta(scope: String): Unit =
       crdt match {
@@ -399,6 +402,19 @@ class CrdtImpl(system: ActorSystem, services: Map[String, CrdtStatefulService], 
       override final def entityId(): String = EntityRunner.this.entityId
 
       override def serviceCallFactory(): ServiceCallFactory = rootContext.serviceCallFactory()
+
+      private var writeConsistency = WriteConsistency.LOCAL
+
+      override final def getWriteConsistency: WriteConsistency = writeConsistency
+
+      override final def setWriteConsistency(writeConsistency: WriteConsistency): Unit =
+        this.writeConsistency = writeConsistency
+
+      def crdtWriteConsistency: CrdtWriteConsistency = writeConsistency match {
+        case WriteConsistency.LOCAL => CrdtWriteConsistency.LOCAL
+        case WriteConsistency.MAJORITY => CrdtWriteConsistency.MAJORITY
+        case WriteConsistency.ALL => CrdtWriteConsistency.ALL
+      }
     }
 
     trait CapturingCrdtFactory extends AbstractCrdtFactory with AbstractCrdtContext {
@@ -430,11 +446,11 @@ class CrdtImpl(system: ActorSystem, services: Map[String, CrdtStatefulService], 
       final def createCrdtAction(): Option[CrdtStateAction] = crdt match {
         case Some(c) =>
           if (deleted) {
-            Some(CrdtStateAction(action = CrdtStateAction.Action.Delete(CrdtDelete())))
+            Some(CrdtStateAction(action = CrdtStateAction.Action.Delete(CrdtDelete()), crdtWriteConsistency))
           } else if (c.hasDelta) {
             val delta = c.delta
             c.resetDelta()
-            Some(CrdtStateAction(action = CrdtStateAction.Action.Update(CrdtDelta(delta))))
+            Some(CrdtStateAction(action = CrdtStateAction.Action.Update(CrdtDelta(delta)), crdtWriteConsistency))
           } else {
             None
           }

--- a/java-support/src/main/scala/io/cloudstate/javasupport/impl/crdt/LWWRegisterImpl.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/impl/crdt/LWWRegisterImpl.scala
@@ -33,9 +33,11 @@ private[crdt] final class LWWRegisterImpl[T](anySupport: AnySupport) extends Int
   override def set(value: T, clock: LWWRegister.Clock, customClockValue: Long): T = {
     Objects.requireNonNull(value)
     val old = this.value
-    if (this.value != value) {
+    if (this.value != value || this.clock != clock || this.customClockValue != customClockValue) {
       deltaValue = Some(anySupport.encodeScala(value))
       this.value = value
+      this.clock = clock
+      this.customClockValue = customClockValue
     }
     old
   }
@@ -55,6 +57,7 @@ private[crdt] final class LWWRegisterImpl[T](anySupport: AnySupport) extends Int
 
   override val applyDelta = {
     case CrdtDelta.Delta.Lwwregister(LWWRegisterDelta(Some(any), _, _, _)) =>
+      resetDelta()
       this.value = anySupport.decode(any).asInstanceOf[T]
   }
 

--- a/java-support/src/test/scala/io/cloudstate/javasupport/impl/crdt/AnnotationBasedCrdtSupportSpec.scala
+++ b/java-support/src/test/scala/io/cloudstate/javasupport/impl/crdt/AnnotationBasedCrdtSupportSpec.scala
@@ -23,7 +23,7 @@ import com.google.protobuf.any.{Any => ScalaPbAny}
 import com.google.protobuf.{ByteString, Any => JavaPbAny}
 import io.cloudstate.javasupport.impl.{AnySupport, ResolvedServiceMethod, ResolvedType}
 import io.cloudstate.javasupport._
-import io.cloudstate.javasupport.crdt.{Crdt, CrdtContext, CrdtCreationContext, CrdtEntity, Vote}
+import io.cloudstate.javasupport.crdt.{Crdt, CrdtContext, CrdtCreationContext, CrdtEntity, Vote, WriteConsistency}
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.compat.java8.OptionConverters._
@@ -58,6 +58,8 @@ class AnnotationBasedCrdtSupportSpec extends WordSpec with Matchers {
           s"The current ${wrongType} CRDT state doesn't match requested type of ${crdtType.getSimpleName}"
         )
     }
+    override def getWriteConsistency: WriteConsistency = WriteConsistency.LOCAL
+    override def setWriteConsistency(writeConsistency: WriteConsistency): Unit = ()
   }
 
   object WrappedResolvedType extends ResolvedType[Wrapped] {

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/JavaSupportTck.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/JavaSupportTck.java
@@ -22,10 +22,13 @@ import io.cloudstate.javasupport.tck.model.valuebased.ValueEntityTckModelEntity;
 import io.cloudstate.javasupport.tck.model.valuebased.ValueEntityTwoEntity;
 import io.cloudstate.javasupport.tck.model.action.ActionTckModelBehavior;
 import io.cloudstate.javasupport.tck.model.action.ActionTwoBehavior;
+import io.cloudstate.javasupport.tck.model.crdt.CrdtTckModelEntity;
+import io.cloudstate.javasupport.tck.model.crdt.CrdtTwoEntity;
 import io.cloudstate.javasupport.tck.model.eventsourced.EventSourcedTckModelEntity;
 import io.cloudstate.javasupport.tck.model.eventsourced.EventSourcedTwoEntity;
 import io.cloudstate.samples.shoppingcart.ShoppingCartEntity;
 import io.cloudstate.tck.model.Action;
+import io.cloudstate.tck.model.Crdt;
 import io.cloudstate.tck.model.Eventsourced;
 import io.cloudstate.tck.model.valueentity.Valueentity;
 
@@ -51,6 +54,11 @@ public final class JavaSupportTck {
             ShoppingCartEntity.class,
             Shoppingcart.getDescriptor().findServiceByName("ShoppingCart"),
             com.example.valueentity.shoppingcart.persistence.Domain.getDescriptor())
+        .registerCrdtEntity(
+            CrdtTckModelEntity.class,
+            Crdt.getDescriptor().findServiceByName("CrdtTckModel"),
+            Crdt.getDescriptor())
+        .registerCrdtEntity(CrdtTwoEntity.class, Crdt.getDescriptor().findServiceByName("CrdtTwo"))
         .registerEventSourcedEntity(
             EventSourcedTckModelEntity.class,
             Eventsourced.getDescriptor().findServiceByName("EventSourcedTckModel"),

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/crdt/CrdtTckModelEntity.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/crdt/CrdtTckModelEntity.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.javasupport.tck.model.crdt;
+
+import io.cloudstate.javasupport.ServiceCall;
+import io.cloudstate.javasupport.ServiceCallRef;
+import io.cloudstate.javasupport.crdt.*;
+import io.cloudstate.tck.model.Crdt.*;
+
+import java.util.*;
+
+@CrdtEntity
+public class CrdtTckModelEntity {
+
+  private final Crdt crdt;
+
+  private final ServiceCallRef<Request> serviceTwo;
+
+  public CrdtTckModelEntity(CrdtCreationContext context) {
+    @SuppressWarnings("unchecked")
+    Optional<Crdt> initialised = (Optional<Crdt>) initialCrdt(context.entityId(), context);
+    crdt = initialised.orElseGet(() -> createCrdt(context.entityId(), context));
+    serviceTwo =
+        context
+            .serviceCallFactory()
+            .lookup("cloudstate.tck.model.crdt.CrdtTwo", "Call", Request.class);
+  }
+
+  private static String crdtType(String name) {
+    return name.split("-")[0];
+  }
+
+  private static Optional<? extends Crdt> initialCrdt(String name, CrdtContext context) {
+    String crdtType = crdtType(name);
+    switch (crdtType) {
+      case "GCounter":
+        return context.state(GCounter.class);
+      case "PNCounter":
+        return context.state(PNCounter.class);
+      case "GSet":
+        return context.state(GSet.class);
+      case "ORSet":
+        return context.state(ORSet.class);
+      case "LWWRegister":
+        return context.state(LWWRegister.class);
+      case "Flag":
+        return context.state(Flag.class);
+      case "ORMap":
+        return context.state(ORMap.class);
+      case "Vote":
+        return context.state(Vote.class);
+      default:
+        throw new IllegalArgumentException("Unknown CRDT type: " + crdtType);
+    }
+  }
+
+  private static Crdt createCrdt(String name, CrdtFactory factory) {
+    String crdtType = crdtType(name);
+    switch (crdtType) {
+      case "GCounter":
+        return factory.newGCounter();
+      case "PNCounter":
+        return factory.newPNCounter();
+      case "GSet":
+        return factory.<String>newGSet();
+      case "ORSet":
+        return factory.<String>newORSet();
+      case "LWWRegister":
+        return factory.newLWWRegister("");
+      case "Flag":
+        return factory.newFlag();
+      case "ORMap":
+        return factory.<String, Crdt>newORMap();
+      case "Vote":
+        return factory.newVote();
+      default:
+        throw new IllegalArgumentException("Unknown CRDT type: " + crdtType);
+    }
+  }
+
+  @CommandHandler
+  public Optional<Response> process(Request request, CommandContext context) {
+    boolean forwarding = false;
+    for (RequestAction action : request.getActionsList()) {
+      switch (action.getActionCase()) {
+        case UPDATE:
+          applyUpdate(crdt, action.getUpdate());
+          switch (action.getUpdate().getWriteConsistency()) {
+            case LOCAL:
+              context.setWriteConsistency(WriteConsistency.LOCAL);
+              break;
+            case MAJORITY:
+              context.setWriteConsistency(WriteConsistency.MAJORITY);
+              break;
+            case ALL:
+              context.setWriteConsistency(WriteConsistency.ALL);
+              break;
+          }
+          break;
+        case DELETE:
+          context.delete();
+          break;
+        case FORWARD:
+          forwarding = true;
+          context.forward(serviceTwoRequest(action.getForward().getId()));
+          break;
+        case EFFECT:
+          Effect effect = action.getEffect();
+          context.effect(serviceTwoRequest(effect.getId()), effect.getSynchronous());
+          break;
+        case FAIL:
+          context.fail(action.getFail().getMessage());
+          break;
+      }
+    }
+    return forwarding ? Optional.empty() : Optional.of(responseValue());
+  }
+
+  @CommandHandler
+  public Response processStreamed(
+      StreamedRequest request, StreamedCommandContext<Response> context) {
+    if (context.isStreamed()) {
+      context.onChange(
+          subscription -> {
+            for (Effect effect : request.getEffectsList())
+              subscription.effect(serviceTwoRequest(effect.getId()), effect.getSynchronous());
+            if (request.hasEndState() && crdtState(crdt).equals(request.getEndState()))
+              subscription.endStream();
+            return Optional.of(responseValue());
+          });
+      if (request.hasCancelUpdate())
+        context.onCancel(cancelled -> applyUpdate(crdt, request.getCancelUpdate()));
+    }
+    return responseValue();
+  }
+
+  private void applyUpdate(Crdt crdt, Update update) {
+    switch (update.getUpdateCase()) {
+      case GCOUNTER:
+        ((GCounter) crdt).increment(update.getGcounter().getIncrement());
+        break;
+      case PNCOUNTER:
+        ((PNCounter) crdt).increment(update.getPncounter().getChange());
+        break;
+      case GSET:
+        @SuppressWarnings("unchecked")
+        GSet<String> gset = (GSet<String>) crdt;
+        gset.add(update.getGset().getAdd());
+        break;
+      case ORSET:
+        @SuppressWarnings("unchecked")
+        ORSet<String> orset = (ORSet<String>) crdt;
+        switch (update.getOrset().getActionCase()) {
+          case ADD:
+            orset.add(update.getOrset().getAdd());
+            break;
+          case REMOVE:
+            orset.remove(update.getOrset().getRemove());
+            break;
+          case CLEAR:
+            if (update.getOrset().getClear()) orset.clear();
+            break;
+        }
+        break;
+      case LWWREGISTER:
+        @SuppressWarnings("unchecked")
+        LWWRegister<String> lwwRegister = (LWWRegister<String>) crdt;
+        String newValue = update.getLwwregister().getValue();
+        if (update.getLwwregister().hasClock()) {
+          LWWRegisterClock clock = update.getLwwregister().getClock();
+          switch (clock.getClockType()) {
+            case DEFAULT:
+              lwwRegister.set(newValue);
+              break;
+            case REVERSE:
+              lwwRegister.set(newValue, LWWRegister.Clock.REVERSE, 0);
+              break;
+            case CUSTOM:
+              lwwRegister.set(newValue, LWWRegister.Clock.CUSTOM, clock.getCustomClockValue());
+              break;
+            case CUSTOM_AUTO_INCREMENT:
+              lwwRegister.set(
+                  newValue, LWWRegister.Clock.CUSTOM_AUTO_INCREMENT, clock.getCustomClockValue());
+              break;
+          }
+        } else {
+          lwwRegister.set(newValue);
+        }
+        break;
+      case FLAG:
+        ((Flag) crdt).enable();
+        break;
+      case ORMAP:
+        @SuppressWarnings("unchecked")
+        ORMap<String, Crdt> ormap = (ORMap<String, Crdt>) crdt;
+        switch (update.getOrmap().getActionCase()) {
+          case ADD:
+            String addKey = update.getOrmap().getAdd();
+            ormap.getOrCreate(addKey, factory -> createCrdt(addKey, factory));
+            break;
+          case UPDATE:
+            String updateKey = update.getOrmap().getUpdate().getKey();
+            Update entryUpdate = update.getOrmap().getUpdate().getUpdate();
+            Crdt crdtValue =
+                ormap.getOrCreate(updateKey, factory -> createCrdt(updateKey, factory));
+            applyUpdate(crdtValue, entryUpdate);
+            break;
+          case REMOVE:
+            String removeKey = update.getOrmap().getRemove();
+            ormap.remove(removeKey);
+            break;
+          case CLEAR:
+            ormap.clear();
+            break;
+        }
+        break;
+      case VOTE:
+        ((Vote) crdt).vote(update.getVote().getSelfVote());
+        break;
+    }
+  }
+
+  private Response responseValue() {
+    return Response.newBuilder().setState(crdtState(crdt)).build();
+  }
+
+  private State crdtState(Crdt crdt) {
+    State.Builder builder = State.newBuilder();
+    if (crdt instanceof GCounter) {
+      GCounter gcounter = (GCounter) crdt;
+      builder.setGcounter(GCounterValue.newBuilder().setValue(gcounter.getValue()));
+    } else if (crdt instanceof PNCounter) {
+      PNCounter pncounter = (PNCounter) crdt;
+      builder.setPncounter(PNCounterValue.newBuilder().setValue(pncounter.getValue()));
+    } else if (crdt instanceof GSet) {
+      @SuppressWarnings("unchecked")
+      GSet<String> gset = (GSet<String>) crdt;
+      List<String> elements = new ArrayList<>(gset);
+      Collections.sort(elements);
+      builder.setGset(GSetValue.newBuilder().addAllElements(elements));
+    } else if (crdt instanceof ORSet) {
+      @SuppressWarnings("unchecked")
+      ORSet<String> orset = (ORSet<String>) crdt;
+      List<String> elements = new ArrayList<>(orset);
+      Collections.sort(elements);
+      builder.setOrset(ORSetValue.newBuilder().addAllElements(elements));
+    } else if (crdt instanceof LWWRegister) {
+      @SuppressWarnings("unchecked")
+      LWWRegister<String> lwwRegister = (LWWRegister<String>) crdt;
+      builder.setLwwregister(LWWRegisterValue.newBuilder().setValue(lwwRegister.get()));
+    } else if (crdt instanceof Flag) {
+      builder.setFlag(FlagValue.newBuilder().setValue(((Flag) crdt).isEnabled()));
+    } else if (crdt instanceof ORMap) {
+      @SuppressWarnings("unchecked")
+      ORMap<String, Crdt> ormap = (ORMap<String, Crdt>) crdt;
+      List<ORMapEntryValue> entries = new ArrayList<>();
+      for (Map.Entry<String, Crdt> entry : ormap.entrySet()) {
+        entries.add(
+            ORMapEntryValue.newBuilder()
+                .setKey(entry.getKey())
+                .setValue(crdtState(entry.getValue()))
+                .build());
+      }
+      entries.sort(Comparator.comparing(ORMapEntryValue::getKey));
+      builder.setOrmap(ORMapValue.newBuilder().addAllEntries(entries));
+    } else if (crdt instanceof Vote) {
+      Vote vote = (Vote) crdt;
+      builder.setVote(
+          VoteValue.newBuilder()
+              .setSelfVote(vote.getSelfVote())
+              .setVotesFor(vote.getVotesFor())
+              .setTotalVoters(vote.getVoters()));
+    }
+    return builder.build();
+  }
+
+  private ServiceCall serviceTwoRequest(String id) {
+    return serviceTwo.createCall(Request.newBuilder().setId(id).build());
+  }
+}

--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/crdt/CrdtTwoEntity.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/crdt/CrdtTwoEntity.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.javasupport.tck.model.crdt;
+
+import io.cloudstate.javasupport.crdt.*;
+import io.cloudstate.tck.model.Crdt.*;
+
+@CrdtEntity
+public class CrdtTwoEntity {
+  public CrdtTwoEntity() {}
+
+  @CommandHandler
+  public Response call(Request request) {
+    return Response.newBuilder().build();
+  }
+}

--- a/protocols/tck/cloudstate/tck/model/crdt.proto
+++ b/protocols/tck/cloudstate/tck/model/crdt.proto
@@ -1,0 +1,337 @@
+// Copyright 2019 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// == Cloudstate TCK model test for CRDT entites ==
+//
+
+syntax = "proto3";
+
+package cloudstate.tck.model.crdt;
+
+import "cloudstate/entity_key.proto";
+
+option java_package = "io.cloudstate.tck.model";
+option go_package = "github.com/cloudstateio/go-support/tck/crdt;crdt";
+
+//
+// The `CrdtTckModel` service should be implemented in the following ways:
+//
+// - The type of CRDT is determined by the prefix of the entity id, separated with a hyphen, which will be one of:
+//     `GCounter`, `PNCounter`, `GSet`, `ORSet`, `LWWRegister`, `Flag`, `ORMap`, or `Vote`.
+// - For GSet, ORSet, or LWWRegister CRDTs, the values are expected to be strings.
+// - For ORMap CRDTs, the keys are expected to be strings, and the values are based on the key.
+//   The type of CRDT for ORMap values is determined by the prefix of the key, in the same way as with entity ids,
+//   so that processing for ORMaps is effectively a nested version of the processing for other CRDT types.
+// - The `Process` method receives a `Request` message with actions to take.
+// - Request actions must be processed in order, and can require updating state, forwarding, side effects, or failing.
+// - The `Process` method must return the updated state in a `Response`, unless forwarding or failing.
+// - Forwarding and side effects must always be made to the second service `CrdtTwo`.
+// - The `ProcessStreamed` method receives a `StreamedRequest` message with streaming actions to take.
+// - The `ProcessStreamed` method must stream the current state in a `Response`, on any changes.
+// - A `StreamedRequest` message may have an end state, an update to apply on stream cancellation, or side effects.
+service CrdtTckModel {
+  rpc Process(Request) returns (Response);
+  rpc ProcessStreamed(StreamedRequest) returns (stream Response);
+}
+
+//
+// The `CrdtTwo` service is only for verifying forwards and side effects.
+// The `Call` method is not required to do anything, and may simply return an empty `Response` message.
+//
+service CrdtTwo {
+  rpc Call(Request) returns (Response);
+}
+
+//
+// A `Request` message contains any actions that the entity should process.
+// Actions must be processed in order. Any actions after a `Fail` may be ignored.
+//
+message Request {
+  string id = 1 [(.cloudstate.entity_key) = true];
+  repeated RequestAction actions = 2;
+}
+
+//
+// A `StreamedRequest` message contains actions for streamed responses.
+// If `end_state` is set, it specifies a target state for ending the stream.
+// If `cancel_update` is set, it specifies an update to apply when the stream is cancelled.
+// If `effects` is set, it specifies side effects to return with every streamed response.
+//
+message StreamedRequest {
+  string id = 1 [(.cloudstate.entity_key) = true];
+  State end_state = 2;
+  Update cancel_update = 3;
+  repeated Effect effects = 4;
+}
+
+//
+// Each `RequestAction` is one of:
+//
+// - Update: update the CRDT and return the updated state in the `Response`.
+// - Forward: forward to another service, in place of replying with a `Response`.
+// - Fail: fail the current `Process` command by sending a failure.
+// - Effect: add a side effect to the current reply, forward, or failure.
+// - Delete: request for the CRDT to be deleted.
+//
+message RequestAction {
+  oneof action {
+    Update update = 1;
+    Delete delete = 2;
+    Forward forward = 3;
+    Fail fail = 4;
+    Effect effect = 5;
+  }
+}
+
+//
+// Update the CRDT, with specific update values for particular CRDT types.
+//
+message Update {
+  oneof update {
+    GCounterUpdate gcounter = 1;
+    PNCounterUpdate pncounter = 2;
+    GSetUpdate gset = 3;
+    ORSetUpdate orset = 4;
+    LWWRegisterUpdate lwwregister = 5;
+    FlagUpdate flag = 6;
+    ORMapUpdate ormap = 7;
+    VoteUpdate vote = 8;
+  }
+
+  UpdateWriteConsistency write_consistency = 9;
+}
+
+//
+// Update a GCounter CRDT with an increment.
+//
+message GCounterUpdate {
+  uint64 increment = 1;
+}
+
+//
+// Update a PNCounter CRDT with a change.
+//
+message PNCounterUpdate {
+  sint64 change = 1;
+}
+
+//
+// Update a GSet CRDT with an additional element.
+//
+message GSetUpdate {
+  string add = 1;
+}
+
+//
+// Update an ORSet CRDT by adding or removing elements, or clearing the set.
+//
+message ORSetUpdate {
+  oneof action {
+    string add = 1;
+    string remove = 2;
+    bool clear = 3;
+  }
+}
+
+//
+// Update an LWWRegister CRDT with a new value.
+//
+message LWWRegisterUpdate {
+  string value = 1;
+  LWWRegisterClock clock = 2;
+}
+
+//
+// Clock for LWWRegister updates.
+//
+message LWWRegisterClock {
+  LWWRegisterClockType clockType = 1;
+  int64 customClockValue = 2;
+}
+
+//
+// Type of clock for LWWRegister updates.
+//
+enum LWWRegisterClockType {
+  DEFAULT = 0;
+  REVERSE = 1;
+  CUSTOM = 2;
+  CUSTOM_AUTO_INCREMENT = 3;
+}
+
+//
+// Update a Flag CRDT by enabling it.
+//
+message FlagUpdate {}
+
+//
+// Update an ORMap CRDT by adding, updating, or removing entries, or clearing the map.
+// Value types are determined by the prefix of the key.
+//
+message ORMapUpdate {
+  oneof action {
+    string add = 1;
+    ORMapEntryUpdate update = 2;
+    string remove = 3;
+    bool clear = 4;
+  }
+}
+
+//
+// Update for an ORMap entry.
+//
+message ORMapEntryUpdate {
+  string key = 1;
+  Update update = 2;
+}
+
+//
+// Update a Vote CRDT's self vote.
+//
+message VoteUpdate {
+  bool self_vote = 1;
+}
+
+//
+// The CRDT write consistency setting to use for updates.
+//
+enum UpdateWriteConsistency {
+  LOCAL = 0;
+  MAJORITY = 1;
+  ALL = 2;
+}
+
+//
+// Delete the CRDT.
+//
+message Delete {}
+
+//
+// Replace the response with a forward to `cloudstate.tck.model.CrdtTwo/Call`.
+// The payload must be an `OtherRequest` message with the given `id`.
+//
+message Forward {
+  string id = 1;
+}
+
+//
+// Fail the current command with the given description `message`.
+//
+message Fail {
+  string message = 1;
+}
+
+//
+// Add a side effect to the reply, to `cloudstate.tck.model.CrdtTwo/Call`.
+// The payload must be an `OtherRequest` message with the given `id`.
+// The side effect should be marked synchronous based on the given `synchronous` value.
+//
+message Effect {
+  string id = 1;
+  bool synchronous = 2;
+}
+
+//
+// The `Response` message must contain the updated state of the CRDT.
+//
+message Response {
+  State state = 1;
+}
+
+//
+// Current state of a CRDT, with specific values for particular CRDT types.
+//
+message State {
+  oneof value {
+    GCounterValue gcounter = 1;
+    PNCounterValue pncounter = 2;
+    GSetValue gset = 3;
+    ORSetValue orset = 4;
+    LWWRegisterValue lwwregister = 5;
+    FlagValue flag = 6;
+    ORMapValue ormap = 7;
+    VoteValue vote = 8;
+  }
+}
+
+//
+// The current state of a GCounter CRDT.
+//
+message GCounterValue {
+  uint64 value = 1;
+}
+
+//
+// The current state of a PNCounter CRDT.
+//
+message PNCounterValue {
+  int64 value = 1;
+}
+
+//
+// The current state of a GSet CRDT.
+// Elements should be sorted, for testing of responses.
+//
+message GSetValue {
+  repeated string elements = 1;
+}
+
+//
+// The current state of an ORSet CRDT.
+// Elements should be sorted, for testing of responses.
+//
+message ORSetValue {
+  repeated string elements = 1;
+}
+
+//
+// The current state of an LWWRegister CRDT.
+// Always a string in the TCK model tests.
+//
+message LWWRegisterValue {
+  string value = 1;
+}
+
+//
+// The current state of a Flag CRDT.
+//
+message FlagValue {
+  bool value = 1;
+}
+
+//
+// The current state of an ORMap CRDT.
+// Entries should be sorted by key, for testing of responses.
+//
+message ORMapValue {
+  repeated ORMapEntryValue entries = 1;
+}
+
+//
+// The current state of an ORMap entry.
+//
+message ORMapEntryValue {
+  string key = 1;
+  State value = 2;
+}
+
+//
+// The current state of a Vote CRDT.
+//
+message VoteValue {
+    bool self_vote = 1;
+    int32 votes_for = 2;
+    int32 total_voters = 3;
+}

--- a/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
+++ b/tck/src/main/scala/io/cloudstate/tck/CloudStateTCK.scala
@@ -31,11 +31,12 @@ import com.google.protobuf.DescriptorProtos
 import com.google.protobuf.any.{Any => ScalaPbAny}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.cloudstate.protocol.action._
-import io.cloudstate.protocol.crdt.Crdt
+import io.cloudstate.protocol.crdt._
 import io.cloudstate.protocol.value_entity.ValueEntity
 import io.cloudstate.protocol.event_sourced._
 import io.cloudstate.tck.model.valueentity.valueentity.{ValueEntityTckModel, ValueEntityTwo}
 import io.cloudstate.tck.model.action.{ActionTckModel, ActionTwo}
+import io.cloudstate.tck.model.crdt.{CrdtTckModel, CrdtTwo}
 import io.cloudstate.testkit.InterceptService.InterceptorSettings
 import io.cloudstate.testkit.eventsourced.EventSourcedMessages
 import io.cloudstate.testkit.{InterceptService, ServiceAddress, TestClient, TestProtocol}
@@ -142,6 +143,16 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           entity.entityType mustBe ActionProtocol.name
         }
 
+        spec.entities.find(_.serviceName == CrdtTckModel.name).foreach { entity =>
+          serviceNames must contain("CrdtTckModel")
+          entity.entityType mustBe Crdt.name
+        }
+
+        spec.entities.find(_.serviceName == CrdtTwo.name).foreach { entity =>
+          serviceNames must contain("CrdtTwo")
+          entity.entityType mustBe Crdt.name
+        }
+
         spec.entities.find(_.serviceName == EventSourcedTckModel.name).foreach { entity =>
           serviceNames must contain("EventSourcedTckModel")
           entity.entityType mustBe EventSourced.name
@@ -182,7 +193,6 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
     }
 
     "verifying model test: actions" must {
-      import io.cloudstate.protocol.entity
       import io.cloudstate.tck.model.action._
       import io.cloudstate.testkit.action.ActionMessages._
 
@@ -571,6 +581,1716 @@ class CloudStateTCK(description: String, settings: CloudStateTCK.Settings)
           .expect(failure("five"))
           .expect(failure("six", sideEffects("other")))
           .complete()
+      }
+    }
+
+    "verifying model test: CRDT entities" must {
+      import io.cloudstate.tck.model.crdt._
+      import io.cloudstate.testkit.crdt.CrdtMessages._
+
+      val ServiceTwo = CrdtTwo.name
+
+      var entityId: Int = 0
+
+      def nextEntityId(crdtType: String): String = {
+        entityId += 1; s"$crdtType-$entityId"
+      }
+
+      def crdtTest(crdtType: String)(test: String => Any): Unit =
+        testFor(CrdtTckModel, CrdtTwo)(test(nextEntityId(crdtType)))
+
+      def requestUpdate(update: Update): RequestAction =
+        RequestAction(RequestAction.Action.Update(update))
+
+      val requestDelete: RequestAction =
+        RequestAction(RequestAction.Action.Delete(Delete()))
+
+      val deleteCrdt: Effects =
+        Effects(stateAction = crdtDelete)
+
+      def forwardTo(id: String): RequestAction =
+        RequestAction(RequestAction.Action.Forward(Forward(id)))
+
+      def sideEffectTo(id: String, synchronous: Boolean = false): RequestAction =
+        RequestAction(RequestAction.Action.Effect(Effect(id, synchronous)))
+
+      def sideEffectsTo(ids: String*): Seq[RequestAction] =
+        ids.map(id => sideEffectTo(id, synchronous = false))
+
+      def sideEffects(ids: String*): Effects =
+        createSideEffects(synchronous = false, ids)
+
+      def synchronousSideEffects(ids: String*): Effects =
+        createSideEffects(synchronous = true, ids)
+
+      def createSideEffects(synchronous: Boolean, ids: Seq[String]): Effects =
+        ids.foldLeft(Effects.empty) { case (e, id) => e.withSideEffect(ServiceTwo, "Call", Request(id), synchronous) }
+
+      def forwarded(id: Long, entityId: String, effects: Effects = Effects.empty) =
+        forward(id, ServiceTwo, "Call", Request(entityId), effects)
+
+      def failWith(message: String): RequestAction =
+        RequestAction(RequestAction.Action.Fail(Fail(message)))
+
+      // Sort sequences in received Deltas (using ScalaPB Lens support) for comparing easily
+      object Delta {
+        def sorted(out: CrdtStreamOut): CrdtStreamOut =
+          out.update(_.reply.stateAction.update.modify(Delta.sort))
+
+        def sort(delta: CrdtDelta): CrdtDelta =
+          if (delta.delta.isGset)
+            delta.update(
+              _.gset.added.modify(_.sortBy(readPrimitiveString))
+            )
+          else if (delta.delta.isOrset)
+            delta.update(
+              _.orset.update(
+                _.removed.modify(_.sortBy(readPrimitiveString)),
+                _.added.modify(_.sortBy(readPrimitiveString))
+              )
+            )
+          else if (delta.delta.isOrmap)
+            delta.update(
+              _.ormap.update(
+                _.removed.modify(_.sortBy(readPrimitiveString)),
+                _.updated.modify(_.map(_.update(_.delta.modify(Delta.sort))).sortBy(_.key.map(readPrimitiveString))),
+                _.added.modify(_.map(_.update(_.delta.modify(Delta.sort))).sortBy(_.key.map(readPrimitiveString)))
+              )
+            )
+          else delta
+      }
+
+      // GCounter tests
+
+      object GCounter {
+        def state(value: Long): Response =
+          Response(Some(State(State.Value.Gcounter(GCounterValue(value)))))
+
+        def incrementBy(increments: Long*): Seq[RequestAction] =
+          increments.map(increment => requestUpdate(updateWith(increment)))
+
+        def updateWith(increment: Long): Update =
+          Update(Update.Update.Gcounter(GCounterUpdate(increment)))
+
+        def update(value: Long): Effects =
+          Effects(stateAction = crdtUpdate(delta(value)))
+
+        def delta(value: Long): CrdtDelta.Delta.Gcounter = deltaGCounter(value)
+
+        def test(run: String => Any): Unit = crdtTest("GCounter")(run)
+      }
+
+      "verify GCounter initial empty state" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, GCounter.state(0)))
+          .passivate()
+      }
+
+      "verify GCounter state changes" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, GCounter.incrementBy(42))))
+          .expect(reply(1, GCounter.state(42), GCounter.update(42)))
+          .send(command(2, id, "Process", Request(id, GCounter.incrementBy(1, 2, 3))))
+          .expect(reply(2, GCounter.state(48), GCounter.update(6)))
+          .passivate()
+      }
+
+      "verify GCounter initial delta in init" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, GCounter.delta(42)))
+          .send(command(1, id, "Process", Request(id, GCounter.incrementBy(123))))
+          .expect(reply(1, GCounter.state(165), GCounter.update(123)))
+          .passivate()
+      }
+
+      "verify GCounter initial empty state with replicated initial delta" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(GCounter.delta(42)))
+          .send(command(1, id, "Process", Request(id, GCounter.incrementBy(123))))
+          .expect(reply(1, GCounter.state(165), GCounter.update(123)))
+          .passivate()
+      }
+
+      "verify GCounter mix of local and replicated state changes" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, GCounter.incrementBy(1))))
+          .expect(reply(1, GCounter.state(1), GCounter.update(1)))
+          .send(delta(GCounter.delta(2)))
+          .send(delta(GCounter.delta(3)))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, GCounter.state(6)))
+          .send(command(3, id, "Process", Request(id, GCounter.incrementBy(4))))
+          .expect(reply(3, GCounter.state(10), GCounter.update(4)))
+          .send(delta(GCounter.delta(5)))
+          .send(command(4, id, "Process", Request(id, GCounter.incrementBy(6))))
+          .expect(reply(4, GCounter.state(21), GCounter.update(6)))
+          .passivate()
+      }
+
+      "verify GCounter rehydration after passivation" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, GCounter.incrementBy(1))))
+          .expect(reply(1, GCounter.state(1), GCounter.update(1)))
+          .send(delta(GCounter.delta(2)))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, GCounter.state(3)))
+          .send(command(3, id, "Process", Request(id, GCounter.incrementBy(3))))
+          .expect(reply(3, GCounter.state(6), GCounter.update(3)))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, GCounter.delta(6)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, GCounter.state(6)))
+          .send(delta(GCounter.delta(4)))
+          .send(command(2, id, "Process", Request(id, GCounter.incrementBy(5))))
+          .expect(reply(2, GCounter.state(15), GCounter.update(5)))
+          .passivate()
+      }
+
+      "verify GCounter delete action received from entity" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, GCounter.incrementBy(42))))
+          .expect(reply(1, GCounter.state(42), GCounter.update(42)))
+          .send(command(2, id, "Process", Request(id, Seq(requestDelete))))
+          .expect(reply(2, GCounter.state(42), deleteCrdt))
+          .passivate()
+      }
+
+      "verify GCounter delete action sent to entity" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delete)
+          .passivate()
+      }
+
+      // PNCounter tests
+
+      object PNCounter {
+        def state(value: Long): Response =
+          Response(Some(State(State.Value.Pncounter(PNCounterValue(value)))))
+
+        def changeBy(changes: Long*): Seq[RequestAction] =
+          changes.map(change => requestUpdate(updateWith(change)))
+
+        def updateWith(change: Long): Update =
+          Update(Update.Update.Pncounter(PNCounterUpdate(change)))
+
+        def update(value: Long): Effects =
+          Effects(stateAction = crdtUpdate(delta(value)))
+
+        def delta(value: Long): CrdtDelta.Delta.Pncounter = deltaPNCounter(value)
+
+        def test(run: String => Any): Unit = crdtTest("PNCounter")(run)
+      }
+
+      "verify PNCounter initial empty state" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, PNCounter.state(0)))
+          .passivate()
+      }
+
+      "verify PNCounter state changes" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, PNCounter.changeBy(+1, -2, +3))))
+          .expect(reply(1, PNCounter.state(+2), PNCounter.update(+2)))
+          .send(command(2, id, "Process", Request(id, PNCounter.changeBy(-4, +5, -6))))
+          .expect(reply(2, PNCounter.state(-3), PNCounter.update(-5)))
+          .passivate()
+      }
+
+      "verify PNCounter initial delta in init" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, PNCounter.delta(42)))
+          .send(command(1, id, "Process", Request(id, PNCounter.changeBy(-123))))
+          .expect(reply(1, PNCounter.state(-81), PNCounter.update(-123)))
+          .passivate()
+      }
+
+      "verify PNCounter initial empty state with replicated initial delta" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(PNCounter.delta(-42)))
+          .send(command(1, id, "Process", Request(id, PNCounter.changeBy(+123))))
+          .expect(reply(1, PNCounter.state(81), PNCounter.update(+123)))
+          .passivate()
+      }
+
+      "verify PNCounter mix of local and replicated state changes" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, PNCounter.changeBy(+1))))
+          .expect(reply(1, PNCounter.state(+1), PNCounter.update(+1)))
+          .send(delta(PNCounter.delta(-2)))
+          .send(delta(PNCounter.delta(+3)))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, PNCounter.state(+2)))
+          .send(command(3, id, "Process", Request(id, PNCounter.changeBy(-4))))
+          .expect(reply(3, PNCounter.state(-2), PNCounter.update(-4)))
+          .send(delta(PNCounter.delta(+5)))
+          .send(command(4, id, "Process", Request(id, PNCounter.changeBy(-6))))
+          .expect(reply(4, PNCounter.state(-3), PNCounter.update(-6)))
+          .passivate()
+      }
+
+      "verify PNCounter rehydration after passivation" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, PNCounter.changeBy(+1))))
+          .expect(reply(1, PNCounter.state(+1), PNCounter.update(+1)))
+          .send(delta(PNCounter.delta(-2)))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, PNCounter.state(-1)))
+          .send(command(3, id, "Process", Request(id, PNCounter.changeBy(+3))))
+          .expect(reply(3, PNCounter.state(+2), PNCounter.update(+3)))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, PNCounter.delta(+2)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, PNCounter.state(+2)))
+          .send(delta(PNCounter.delta(-4)))
+          .send(command(2, id, "Process", Request(id, PNCounter.changeBy(+5))))
+          .expect(reply(2, PNCounter.state(+3), PNCounter.update(+5)))
+          .passivate()
+      }
+
+      "verify PNCounter delete action received from entity" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, PNCounter.changeBy(+42))))
+          .expect(reply(1, PNCounter.state(+42), PNCounter.update(+42)))
+          .send(command(2, id, "Process", Request(id, Seq(requestDelete))))
+          .expect(reply(2, PNCounter.state(+42), deleteCrdt))
+          .passivate()
+      }
+
+      "verify PNCounter delete action sent to entity" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delete)
+          .passivate()
+      }
+
+      // GSet tests
+
+      object GSet {
+        def state(elements: String*): Response =
+          Response(Some(State(State.Value.Gset(GSetValue(elements)))))
+
+        def add(elements: String*): Seq[RequestAction] =
+          elements.map(element => requestUpdate(updateWith(element)))
+
+        def updateWith(element: String): Update =
+          Update(Update.Update.Gset(GSetUpdate(element)))
+
+        def update(added: String*): Effects =
+          Effects(stateAction = crdtUpdate(delta(added: _*)))
+
+        def delta(added: String*): CrdtDelta.Delta.Gset = deltaGSet(added.map(primitiveString))
+
+        def test(run: String => Any): Unit = crdtTest("GSet")(run)
+      }
+
+      "verify GSet initial empty state" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, GSet.state()))
+          .passivate()
+      }
+
+      "verify GSet state changes" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, GSet.add("a", "b"))))
+          .expect(reply(1, GSet.state("a", "b"), GSet.update("a", "b")), Delta.sorted)
+          .send(command(2, id, "Process", Request(id, GSet.add("b", "c"))))
+          .expect(reply(2, GSet.state("a", "b", "c"), GSet.update("c")))
+          .send(command(3, id, "Process", Request(id, GSet.add("c", "a"))))
+          .expect(reply(3, GSet.state("a", "b", "c")))
+          .passivate()
+      }
+
+      "verify GSet initial delta in init" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, GSet.delta("a", "b", "c")))
+          .send(command(1, id, "Process", Request(id, GSet.add("c", "d", "e"))))
+          .expect(reply(1, GSet.state("a", "b", "c", "d", "e"), GSet.update("d", "e")), Delta.sorted)
+          .passivate()
+      }
+
+      "verify GSet initial empty state with replicated initial delta" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(GSet.delta("x", "y")))
+          .send(command(1, id, "Process", Request(id, GSet.add("z"))))
+          .expect(reply(1, GSet.state("x", "y", "z"), GSet.update("z")))
+          .passivate()
+      }
+
+      "verify GSet mix of local and replicated state changes" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, GSet.add("a"))))
+          .expect(reply(1, GSet.state("a"), GSet.update("a")))
+          .send(delta(GSet.delta("a")))
+          .send(delta(GSet.delta("b")))
+          .send(delta(GSet.delta("c")))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, GSet.state("a", "b", "c")))
+          .send(command(3, id, "Process", Request(id, GSet.add("c", "d", "e"))))
+          .expect(reply(3, GSet.state("a", "b", "c", "d", "e"), GSet.update("d", "e")), Delta.sorted)
+          .send(delta(GSet.delta("f")))
+          .send(command(4, id, "Process", Request(id, GSet.add("g", "d", "b"))))
+          .expect(reply(4, GSet.state("a", "b", "c", "d", "e", "f", "g"), GSet.update("g")))
+          .passivate()
+      }
+
+      "verify GSet rehydration after passivation" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, GSet.add("a"))))
+          .expect(reply(1, GSet.state("a"), GSet.update("a")))
+          .send(delta(GSet.delta("b")))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, GSet.state("a", "b")))
+          .send(command(3, id, "Process", Request(id, GSet.add("c"))))
+          .expect(reply(3, GSet.state("a", "b", "c"), GSet.update("c")))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, GSet.delta("a", "b", "c")))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, GSet.state("a", "b", "c")))
+          .send(delta(GSet.delta("d")))
+          .send(command(2, id, "Process", Request(id, GSet.add("e"))))
+          .expect(reply(2, GSet.state("a", "b", "c", "d", "e"), GSet.update("e")))
+          .passivate()
+      }
+
+      "verify GSet delete action received from entity" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, GSet.add("x"))))
+          .expect(reply(1, GSet.state("x"), GSet.update("x")))
+          .send(command(2, id, "Process", Request(id, Seq(requestDelete))))
+          .expect(reply(2, GSet.state("x"), deleteCrdt))
+          .passivate()
+      }
+
+      "verify GSet delete action sent to entity" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delete)
+          .passivate()
+      }
+
+      // ORSet tests
+
+      object ORSet {
+        def state(elements: String*): Response =
+          Response(Some(State(State.Value.Orset(ORSetValue(elements)))))
+
+        def add(elements: String*): Seq[RequestAction] =
+          elements.map(element => action(ORSetUpdate.Action.Add(element)))
+
+        def remove(elements: String*): Seq[RequestAction] =
+          elements.map(element => action(ORSetUpdate.Action.Remove(element)))
+
+        def clear(value: Boolean = true): Seq[RequestAction] =
+          Seq(action(ORSetUpdate.Action.Clear(value)))
+
+        def action(updateAction: ORSetUpdate.Action): RequestAction =
+          requestUpdate(Update(Update.Update.Orset(ORSetUpdate(updateAction))))
+
+        def update(cleared: Boolean = false,
+                   removed: Seq[String] = Seq.empty,
+                   added: Seq[String] = Seq.empty): Effects =
+          Effects(stateAction = crdtUpdate(delta(cleared, removed, added)))
+
+        def delta(cleared: Boolean = false,
+                  removed: Seq[String] = Seq.empty,
+                  added: Seq[String] = Seq.empty): CrdtDelta.Delta.Orset =
+          CrdtDelta.Delta.Orset(ORSetDelta(cleared, removed.map(primitiveString), added.map(primitiveString)))
+
+        def test(run: String => Any): Unit = crdtTest("ORSet")(run)
+      }
+
+      "verify ORSet initial empty state" in ORSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, ORSet.state()))
+          .passivate()
+      }
+
+      "verify ORSet state changes" in ORSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, ORSet.add("a", "b"))))
+          .expect(reply(1, ORSet.state("a", "b"), ORSet.update(added = Seq("a", "b"))), Delta.sorted)
+          .send(command(2, id, "Process", Request(id, ORSet.add("b", "c"))))
+          .expect(reply(2, ORSet.state("a", "b", "c"), ORSet.update(added = Seq("c"))))
+          .send(command(3, id, "Process", Request(id, ORSet.add("c", "a"))))
+          .expect(reply(3, ORSet.state("a", "b", "c")))
+          .send(command(4, id, "Process", Request(id, ORSet.remove("b", "d"))))
+          .expect(reply(4, ORSet.state("a", "c"), ORSet.update(removed = Seq("b"))))
+          .send(command(5, id, "Process", Request(id, ORSet.remove("c", "d") ++ ORSet.add("b", "c"))))
+          .expect(reply(5, ORSet.state("a", "b", "c"), ORSet.update(added = Seq("b"))))
+          .send(command(6, id, "Process", Request(id, ORSet.clear())))
+          .expect(reply(6, ORSet.state(), ORSet.update(cleared = true)))
+          .send(command(7, id, "Process", Request(id, ORSet.add("a") ++ ORSet.clear() ++ ORSet.add("x"))))
+          .expect(reply(7, ORSet.state("x"), ORSet.update(cleared = true, added = Seq("x"))))
+          .passivate()
+      }
+
+      "verify ORSet initial delta in init" in ORSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, ORSet.delta(added = Seq("a", "b", "c"))))
+          .send(command(1, id, "Process", Request(id, ORSet.remove("c") ++ ORSet.add("d"))))
+          .expect(reply(1, ORSet.state("a", "b", "d"), ORSet.update(removed = Seq("c"), added = Seq("d"))))
+          .passivate()
+      }
+
+      "verify ORSet initial empty state with replicated initial delta" in ORSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(ORSet.delta(added = Seq("x", "y"))))
+          .send(command(1, id, "Process", Request(id, ORSet.remove("x") ++ ORSet.add("z"))))
+          .expect(reply(1, ORSet.state("y", "z"), ORSet.update(removed = Seq("x"), added = Seq("z"))))
+          .passivate()
+      }
+
+      "verify ORSet mix of local and replicated state changes" in ORSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, ORSet.add("a"))))
+          .expect(reply(1, ORSet.state("a"), ORSet.update(added = Seq("a"))))
+          .send(delta(ORSet.delta(added = Seq("a", "b"))))
+          .send(delta(ORSet.delta(added = Seq("c", "d"))))
+          .send(delta(ORSet.delta(removed = Seq("b", "d"))))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, ORSet.state("a", "c")))
+          .send(command(3, id, "Process", Request(id, ORSet.add("c", "d", "e"))))
+          .expect(reply(3, ORSet.state("a", "c", "d", "e"), ORSet.update(added = Seq("d", "e"))), Delta.sorted)
+          .send(delta(ORSet.delta(removed = Seq("a", "c"), added = Seq("f"))))
+          .send(command(4, id, "Process", Request(id, ORSet.add("g") ++ ORSet.remove("a", "d"))))
+          .expect(reply(4, ORSet.state("e", "f", "g"), ORSet.update(removed = Seq("d"), added = Seq("g"))))
+          .send(delta(ORSet.delta(cleared = true, added = Seq("x", "y", "z"))))
+          .send(command(5, id, "Process", Request(id, ORSet.add("q", "x") ++ ORSet.remove("z"))))
+          .expect(reply(5, ORSet.state("q", "x", "y"), ORSet.update(removed = Seq("z"), added = Seq("q"))))
+          .send(delta(ORSet.delta(removed = Seq("x", "y"), added = Seq("r", "p"))))
+          .send(command(6, id, "Process", Request(id, ORSet.add("s"))))
+          .expect(reply(6, ORSet.state("p", "q", "r", "s"), ORSet.update(added = Seq("s"))))
+          .send(delta(ORSet.delta(added = Seq("a", "b", "c"))))
+          .send(command(7, id, "Process", Request(id, ORSet.clear() ++ ORSet.add("abc"))))
+          .expect(reply(7, ORSet.state("abc"), ORSet.update(cleared = true, added = Seq("abc"))))
+          .passivate()
+      }
+
+      "verify ORSet rehydration after passivation" in ORSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, ORSet.add("a"))))
+          .expect(reply(1, ORSet.state("a"), ORSet.update(added = Seq("a"))))
+          .send(delta(ORSet.delta(removed = Seq("a"), added = Seq("b"))))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, ORSet.state("b")))
+          .send(command(3, id, "Process", Request(id, ORSet.add("c"))))
+          .expect(reply(3, ORSet.state("b", "c"), ORSet.update(added = Seq("c"))))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, ORSet.delta(added = Seq("b", "c"))))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, ORSet.state("b", "c")))
+          .send(delta(ORSet.delta(cleared = true, added = Seq("p", "q"))))
+          .send(command(2, id, "Process", Request(id, ORSet.add("x", "y") ++ ORSet.remove("x"))))
+          .expect(reply(2, ORSet.state("p", "q", "y"), ORSet.update(added = Seq("y"))))
+          .passivate()
+      }
+
+      "verify ORSet delete action received from entity" in ORSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, ORSet.add("x"))))
+          .expect(reply(1, ORSet.state("x"), ORSet.update(added = Seq("x"))))
+          .send(command(2, id, "Process", Request(id, Seq(requestDelete))))
+          .expect(reply(2, ORSet.state("x"), deleteCrdt))
+          .passivate()
+      }
+
+      "verify ORSet delete action sent to entity" in ORSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delete)
+          .passivate()
+      }
+
+      // LWWRegister tests
+
+      object LWWRegister {
+        val DefaultClock: LWWRegisterClockType = LWWRegisterClockType.DEFAULT
+        val ReverseClock: LWWRegisterClockType = LWWRegisterClockType.REVERSE
+        val CustomClock: LWWRegisterClockType = LWWRegisterClockType.CUSTOM
+        val CustomAutoIncClock: LWWRegisterClockType = LWWRegisterClockType.CUSTOM_AUTO_INCREMENT
+
+        def state(value: String): Response =
+          Response(Some(State(State.Value.Lwwregister(LWWRegisterValue(value)))))
+
+        def setTo(value: String,
+                  clockType: LWWRegisterClockType = DefaultClock,
+                  customClockValue: Long = 0L): Seq[RequestAction] =
+          updateWith(LWWRegisterUpdate(value, Some(LWWRegisterClock(clockType, customClockValue))))
+
+        def updateWith(update: LWWRegisterUpdate): Seq[RequestAction] =
+          Seq(requestUpdate(Update(Update.Update.Lwwregister(update))))
+
+        def update(value: String, clock: CrdtClock = CrdtClock.DEFAULT, customClockValue: Long = 0L): Effects =
+          Effects(stateAction = crdtUpdate(delta(value, clock, customClockValue)))
+
+        def delta(value: String,
+                  clock: CrdtClock = CrdtClock.DEFAULT,
+                  customClockValue: Long = 0L): CrdtDelta.Delta.Lwwregister =
+          deltaLWWRegister(Some(primitiveString(value)), clock, customClockValue)
+
+        def test(run: String => Any): Unit = crdtTest("LWWRegister")(run)
+      }
+
+      "verify LWWRegister initial empty state" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, LWWRegister.state(""), LWWRegister.update("")))
+          .passivate()
+      }
+
+      "verify LWWRegister state changes" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, LWWRegister.setTo("one"))))
+          .expect(reply(1, LWWRegister.state("one"), LWWRegister.update("one")))
+          .send(command(2, id, "Process", Request(id, LWWRegister.setTo("two"))))
+          .expect(reply(2, LWWRegister.state("two"), LWWRegister.update("two")))
+          .passivate()
+      }
+
+      "verify LWWRegister initial delta in init" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, LWWRegister.delta("one")))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, LWWRegister.state("one")))
+          .passivate()
+      }
+
+      "verify LWWRegister initial empty state with replicated initial delta" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(LWWRegister.delta("one")))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, LWWRegister.state("one")))
+          .passivate()
+      }
+
+      "verify LWWRegister mix of local and replicated state changes" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, LWWRegister.setTo("A"))))
+          .expect(reply(1, LWWRegister.state("A"), LWWRegister.update("A")))
+          .send(delta(LWWRegister.delta("B")))
+          .send(delta(LWWRegister.delta("C")))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, LWWRegister.state("C")))
+          .send(command(3, id, "Process", Request(id, LWWRegister.setTo("D"))))
+          .expect(reply(3, LWWRegister.state("D"), LWWRegister.update("D")))
+          .send(delta(LWWRegister.delta("D")))
+          .send(command(4, id, "Process", Request(id, LWWRegister.setTo("E"))))
+          .expect(reply(4, LWWRegister.state("E"), LWWRegister.update("E")))
+          .passivate()
+      }
+
+      "verify LWWRegister state changes with clock settings" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, LWWRegister.setTo("A", LWWRegister.ReverseClock))))
+          .expect(reply(1, LWWRegister.state("A"), LWWRegister.update("A", CrdtClock.REVERSE)))
+          .send(command(2, id, "Process", Request(id, LWWRegister.setTo("A", LWWRegister.CustomClock, 123L))))
+          .expect(reply(2, LWWRegister.state("A"), LWWRegister.update("A", CrdtClock.CUSTOM, 123L)))
+          .send(command(2, id, "Process", Request(id, LWWRegister.setTo("A", LWWRegister.CustomAutoIncClock, 456L))))
+          .expect(reply(2, LWWRegister.state("A"), LWWRegister.update("A", CrdtClock.CUSTOM_AUTO_INCREMENT, 456L)))
+          .passivate()
+      }
+
+      "verify LWWRegister rehydration after passivation" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, LWWRegister.setTo("A"))))
+          .expect(reply(1, LWWRegister.state("A"), LWWRegister.update("A")))
+          .send(delta(LWWRegister.delta("B")))
+          .send(command(2, id, "Process", Request(id)))
+          .expect(reply(2, LWWRegister.state("B")))
+          .send(command(3, id, "Process", Request(id, LWWRegister.setTo("C"))))
+          .expect(reply(3, LWWRegister.state("C"), LWWRegister.update("C")))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, LWWRegister.delta("C")))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, LWWRegister.state("C")))
+          .send(delta(LWWRegister.delta("D")))
+          .send(command(2, id, "Process", Request(id, LWWRegister.setTo("E"))))
+          .expect(reply(2, LWWRegister.state("E"), LWWRegister.update("E")))
+          .passivate()
+      }
+
+      "verify LWWRegister delete action received from entity" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, LWWRegister.setTo("one"))))
+          .expect(reply(1, LWWRegister.state("one"), LWWRegister.update("one")))
+          .send(command(2, id, "Process", Request(id, Seq(requestDelete))))
+          .expect(reply(2, LWWRegister.state("one"), deleteCrdt))
+          .passivate()
+      }
+
+      "verify LWWRegister delete action sent to entity" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delete)
+          .passivate()
+      }
+
+      // Flag tests
+
+      object Flag {
+        def state(value: Boolean): Response =
+          Response(Some(State(State.Value.Flag(FlagValue(value)))))
+
+        def enable(): Seq[RequestAction] =
+          Seq(requestUpdate(Update(Update.Update.Flag(FlagUpdate()))))
+
+        def update(value: Boolean): Effects =
+          Effects(stateAction = crdtUpdate(delta(value)))
+
+        def delta(value: Boolean): CrdtDelta.Delta.Flag = deltaFlag(value)
+
+        def test(run: String => Any): Unit = crdtTest("Flag")(run)
+      }
+
+      "verify Flag initial empty state" in Flag.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Flag.state(false)))
+          .passivate()
+      }
+
+      "verify Flag state changes" in Flag.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, Flag.enable())))
+          .expect(reply(1, Flag.state(true), Flag.update(true)))
+          .passivate()
+      }
+
+      "verify Flag initial delta in init" in Flag.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, Flag.delta(false)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Flag.state(false)))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, Flag.delta(true)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Flag.state(true)))
+          .passivate()
+      }
+
+      "verify Flag initial empty state with replicated initial delta" in Flag.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(Flag.delta(false)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Flag.state(false)))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(Flag.delta(true)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Flag.state(true)))
+          .passivate()
+      }
+
+      "verify Flag mix of local and replicated state changes" in Flag.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(Flag.delta(false)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Flag.state(false)))
+          .send(command(2, id, "Process", Request(id, Flag.enable())))
+          .expect(reply(2, Flag.state(true), Flag.update(true)))
+          .send(delta(Flag.delta(true)))
+          .send(delta(Flag.delta(false)))
+          .send(command(3, id, "Process", Request(id)))
+          .expect(reply(3, Flag.state(true)))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(Flag.delta(true)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Flag.state(true)))
+          .send(command(2, id, "Process", Request(id, Flag.enable())))
+          .expect(reply(2, Flag.state(true)))
+          .send(delta(Flag.delta(true)))
+          .send(delta(Flag.delta(false)))
+          .send(command(3, id, "Process", Request(id)))
+          .expect(reply(3, Flag.state(true)))
+          .passivate()
+      }
+
+      "verify Flag rehydration after passivation" in Flag.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Flag.state(false)))
+          .send(command(2, id, "Process", Request(id, Flag.enable())))
+          .expect(reply(2, Flag.state(true), Flag.update(true)))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, Flag.delta(true)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Flag.state(true)))
+          .passivate()
+      }
+
+      "verify Flag delete action received from entity" in Flag.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, Flag.enable())))
+          .expect(reply(1, Flag.state(true), Flag.update(true)))
+          .send(command(2, id, "Process", Request(id, Seq(requestDelete))))
+          .expect(reply(2, Flag.state(true), deleteCrdt))
+          .passivate()
+      }
+
+      "verify Flag delete action sent to entity" in Flag.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delete)
+          .passivate()
+      }
+
+      // ORMap tests
+
+      object ORMap {
+        def state(entries: (String, Response)*): Response =
+          Response(
+            Some(State(State.Value.Ormap(ORMapValue(entries.map {
+              case (key, value) => ORMapEntryValue(key, value.state)
+            }))))
+          )
+
+        def add(keys: String*): Seq[RequestAction] =
+          keys.map(key => action(ORMapUpdate.Action.Add(key)))
+
+        def updateWith(entries: (String, Seq[RequestAction])*): Seq[RequestAction] =
+          entries flatMap {
+            case (key, actions) =>
+              actions map { a =>
+                action(ORMapUpdate.Action.Update(ORMapEntryUpdate(key, Option(a.getUpdate))))
+              }
+          }
+
+        def remove(keys: String*): Seq[RequestAction] =
+          keys.map(key => action(ORMapUpdate.Action.Remove(key)))
+
+        def clear(value: Boolean = true): Seq[RequestAction] =
+          Seq(action(ORMapUpdate.Action.Clear(value)))
+
+        def action(updateAction: ORMapUpdate.Action): RequestAction =
+          requestUpdate(Update(Update.Update.Ormap(ORMapUpdate(updateAction))))
+
+        def update(cleared: Boolean = false,
+                   removed: Seq[String] = Seq.empty,
+                   updated: Seq[(String, Effects)] = Seq.empty,
+                   added: Seq[(String, Effects)] = Seq.empty): Effects =
+          Effects(
+            stateAction = crdtUpdate(
+              delta(
+                cleared,
+                removed,
+                updated map { case (key, effects) => key -> effects.stateAction.get.getUpdate.delta },
+                added map { case (key, effects) => key -> effects.stateAction.get.getUpdate.delta }
+              )
+            )
+          )
+
+        def delta(cleared: Boolean = false,
+                  removed: Seq[String] = Seq.empty,
+                  updated: Seq[(String, CrdtDelta.Delta)] = Seq.empty,
+                  added: Seq[(String, CrdtDelta.Delta)] = Seq.empty): CrdtDelta.Delta.Ormap =
+          CrdtDelta.Delta.Ormap(
+            ORMapDelta(
+              cleared,
+              removed.map(primitiveString),
+              updated map { case (key, delta) => ORMapEntryDelta(Some(primitiveString(key)), Some(CrdtDelta(delta))) },
+              added map { case (key, delta) => ORMapEntryDelta(Some(primitiveString(key)), Some(CrdtDelta(delta))) }
+            )
+          )
+
+        def test(run: String => Any): Unit = crdtTest("ORMap")(run)
+      }
+
+      "verify ORMap initial empty state" in ORMap.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, ORMap.state()))
+          .passivate()
+      }
+
+      "verify ORMap state changes" in ORMap.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, ORMap.add("PNCounter-1", "ORSet-1"))))
+          .expect(
+            reply(
+              1,
+              ORMap.state(
+                "ORSet-1" -> ORSet.state(),
+                "PNCounter-1" -> PNCounter.state(0)
+              ),
+              ORMap.update(
+                added = Seq(
+                  "ORSet-1" -> ORSet.update(),
+                  "PNCounter-1" -> PNCounter.update(0)
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(
+            command(2,
+                    id,
+                    "Process",
+                    Request(id,
+                            ORMap.add("ORSet-1") ++ ORMap.updateWith(
+                              "LWWRegister-1" -> LWWRegister.setTo("zero")
+                            )))
+          )
+          .expect(
+            reply(
+              2,
+              ORMap.state(
+                "LWWRegister-1" -> LWWRegister.state("zero"),
+                "ORSet-1" -> ORSet.state(),
+                "PNCounter-1" -> PNCounter.state(0)
+              ),
+              ORMap.update(
+                added = Seq(
+                  "LWWRegister-1" -> LWWRegister.update("zero")
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(
+            command(3,
+                    id,
+                    "Process",
+                    Request(id,
+                            ORMap.updateWith(
+                              "PNCounter-1" -> PNCounter.changeBy(+42),
+                              "LWWRegister-1" -> LWWRegister.setTo("one")
+                            )))
+          )
+          .expect(
+            reply(
+              3,
+              ORMap.state(
+                "LWWRegister-1" -> LWWRegister.state("one"),
+                "ORSet-1" -> ORSet.state(),
+                "PNCounter-1" -> PNCounter.state(+42)
+              ),
+              ORMap.update(
+                updated = Seq(
+                  "LWWRegister-1" -> LWWRegister.update("one"),
+                  "PNCounter-1" -> PNCounter.update(+42)
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(command(4, id, "Process", Request(id, ORMap.updateWith("ORSet-1" -> ORSet.add("a", "b", "c")))))
+          .expect(
+            reply(
+              4,
+              ORMap.state(
+                "LWWRegister-1" -> LWWRegister.state("one"),
+                "ORSet-1" -> ORSet.state("a", "b", "c"),
+                "PNCounter-1" -> PNCounter.state(+42)
+              ),
+              ORMap.update(
+                updated = Seq(
+                  "ORSet-1" -> ORSet.update(added = Seq("a", "b", "c"))
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(
+            command(
+              5,
+              id,
+              "Process",
+              Request(id,
+                      ORMap.updateWith(
+                        "ORSet-1" -> (ORSet.remove("b") ++ ORSet.add("d")),
+                        "PNCounter-1" -> PNCounter.changeBy(-123),
+                        "LWWRegister-1" -> LWWRegister.setTo("two")
+                      ))
+            )
+          )
+          .expect(
+            reply(
+              5,
+              ORMap.state(
+                "LWWRegister-1" -> LWWRegister.state("two"),
+                "ORSet-1" -> ORSet.state("a", "c", "d"),
+                "PNCounter-1" -> PNCounter.state(-81)
+              ),
+              ORMap.update(
+                updated = Seq(
+                  "LWWRegister-1" -> LWWRegister.update("two"),
+                  "ORSet-1" -> ORSet.update(removed = Seq("b"), added = Seq("d")),
+                  "PNCounter-1" -> PNCounter.update(-123)
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(command(6, id, "Process", Request(id, ORMap.remove("ORSet-1"))))
+          .expect(
+            reply(
+              6,
+              ORMap.state(
+                "LWWRegister-1" -> LWWRegister.state("two"),
+                "PNCounter-1" -> PNCounter.state(-81)
+              ),
+              ORMap.update(removed = Seq("ORSet-1"))
+            ),
+            Delta.sorted
+          )
+          .send(
+            command(7,
+                    id,
+                    "Process",
+                    Request(id, ORMap.remove("LWWRegister-1") ++ ORMap.updateWith("Flag-1" -> Flag.enable())))
+          )
+          .expect(
+            reply(
+              7,
+              ORMap.state(
+                "Flag-1" -> Flag.state(true),
+                "PNCounter-1" -> PNCounter.state(-81)
+              ),
+              ORMap.update(removed = Seq("LWWRegister-1"), added = Seq("Flag-1" -> Flag.update(true)))
+            ),
+            Delta.sorted
+          )
+          .send(command(8, id, "Process", Request(id, ORMap.clear())))
+          .expect(reply(8, ORMap.state(), ORMap.update(cleared = true)))
+          .send(
+            command(
+              9,
+              id,
+              "Process",
+              Request(id,
+                      ORMap.add("PNCounter-2") ++ ORMap.clear() ++ ORMap.updateWith(
+                        "GCounter-1" -> GCounter.incrementBy(123)
+                      ))
+            )
+          )
+          .expect(
+            reply(9,
+                  ORMap.state("GCounter-1" -> GCounter.state(123)),
+                  ORMap.update(cleared = true, added = Seq("GCounter-1" -> GCounter.update(123)))),
+            Delta.sorted
+          )
+          .passivate()
+      }
+
+      "verify ORMap initial delta in init" in ORMap.test { id =>
+        protocol.crdt
+          .connect()
+          .send(
+            init(
+              CrdtTckModel.name,
+              id,
+              ORMap.delta(
+                added = Seq("PNCounter-1" -> PNCounter.delta(+123),
+                            "LWWRegister-1" -> LWWRegister.delta("one"),
+                            "GSet-1" -> GSet.delta("a", "b", "c"))
+              )
+            )
+          )
+          .send(command(1, id, "Process", Request(id)))
+          .expect(
+            reply(1,
+                  ORMap.state("GSet-1" -> GSet.state("a", "b", "c"),
+                              "LWWRegister-1" -> LWWRegister.state("one"),
+                              "PNCounter-1" -> PNCounter.state(+123)))
+          )
+          .send(
+            command(
+              2,
+              id,
+              "Process",
+              Request(id, ORMap.remove("LWWRegister-1") ++ ORMap.updateWith("PNCounter-1" -> PNCounter.changeBy(-42)))
+            )
+          )
+          .expect(
+            reply(
+              2,
+              ORMap.state("GSet-1" -> GSet.state("a", "b", "c"), "PNCounter-1" -> PNCounter.state(+81)),
+              ORMap.update(removed = Seq("LWWRegister-1"), updated = Seq("PNCounter-1" -> PNCounter.update(-42)))
+            ),
+            Delta.sorted
+          )
+          .passivate()
+      }
+
+      "verify ORMap initial empty state with replicated initial delta" in ORMap.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(
+            delta(
+              ORMap.delta(
+                added = Seq("GCounter-1" -> GCounter.delta(42),
+                            "ORSet-1" -> ORSet.delta(added = Seq("a", "b", "c")),
+                            "Flag-1" -> Flag.delta(false))
+              )
+            )
+          )
+          .send(command(1, id, "Process", Request(id)))
+          .expect(
+            reply(1,
+                  ORMap.state("Flag-1" -> Flag.state(false),
+                              "GCounter-1" -> GCounter.state(42),
+                              "ORSet-1" -> ORSet.state("a", "b", "c")))
+          )
+          .passivate()
+      }
+
+      "verify ORMap mix of local and replicated state changes" in ORMap.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, ORMap.add("PNCounter-1"))))
+          .expect(
+            reply(
+              1,
+              ORMap.state(
+                "PNCounter-1" -> PNCounter.state(0)
+              ),
+              ORMap.update(
+                added = Seq(
+                  "PNCounter-1" -> PNCounter.update(0)
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(delta(ORMap.delta(added = Seq("ORSet-1" -> ORSet.delta(added = Seq("x"))))))
+          .send(
+            delta(
+              ORMap.delta(added = Seq("LWWRegister-1" -> LWWRegister.delta("one")),
+                          updated = Seq("ORSet-1" -> ORSet.delta(added = Seq("y", "z"))))
+            )
+          )
+          .send(
+            command(2,
+                    id,
+                    "Process",
+                    Request(id,
+                            ORMap.add("ORSet-2") ++ ORMap.updateWith(
+                              "LWWRegister-2" -> LWWRegister.setTo("two")
+                            )))
+          )
+          .expect(
+            reply(
+              2,
+              ORMap.state(
+                "LWWRegister-1" -> LWWRegister.state("one"),
+                "LWWRegister-2" -> LWWRegister.state("two"),
+                "ORSet-1" -> ORSet.state("x", "y", "z"),
+                "ORSet-2" -> ORSet.state(),
+                "PNCounter-1" -> PNCounter.state(0)
+              ),
+              ORMap.update(
+                added = Seq(
+                  "LWWRegister-2" -> LWWRegister.update("two"),
+                  "ORSet-2" -> ORSet.update()
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(
+            command(3,
+                    id,
+                    "Process",
+                    Request(id,
+                            ORMap.updateWith(
+                              "PNCounter-1" -> PNCounter.changeBy(+42),
+                              "LWWRegister-1" -> LWWRegister.setTo("ONE")
+                            )))
+          )
+          .expect(
+            reply(
+              3,
+              ORMap.state(
+                "LWWRegister-1" -> LWWRegister.state("ONE"),
+                "LWWRegister-2" -> LWWRegister.state("two"),
+                "ORSet-1" -> ORSet.state("x", "y", "z"),
+                "ORSet-2" -> ORSet.state(),
+                "PNCounter-1" -> PNCounter.state(+42)
+              ),
+              ORMap.update(
+                updated = Seq(
+                  "LWWRegister-1" -> LWWRegister.update("ONE"),
+                  "PNCounter-1" -> PNCounter.update(+42)
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(
+            delta(
+              ORMap.delta(removed = Seq("LWWRegister-2"),
+                          added = Seq("ORMap-1" -> ORMap.delta(added = Seq("PNCounter-1" -> PNCounter.delta(+123)))))
+            )
+          )
+          .send(
+            delta(
+              ORMap.delta(
+                removed = Seq("ORSet-1"),
+                updated = Seq("ORSet-2" -> ORSet.delta(added = Seq("a", "b", "c")),
+                              "ORMap-1" -> ORMap.delta(added = Seq("LWWRegister-1" -> LWWRegister.delta("ABC"))))
+              )
+            )
+          )
+          .send(
+            command(4,
+                    id,
+                    "Process",
+                    Request(id,
+                            ORMap.updateWith("ORMap-1" -> ORMap.updateWith("PNCounter-1" -> PNCounter.changeBy(-456)))))
+          )
+          .expect(
+            reply(
+              4,
+              ORMap.state(
+                "LWWRegister-1" -> LWWRegister.state("ONE"),
+                "ORMap-1" -> ORMap.state("LWWRegister-1" -> LWWRegister.state("ABC"),
+                                         "PNCounter-1" -> PNCounter.state(-333)),
+                "ORSet-2" -> ORSet.state("a", "b", "c"),
+                "PNCounter-1" -> PNCounter.state(+42)
+              ),
+              ORMap.update(
+                updated = Seq(
+                  "ORMap-1" -> ORMap.update(updated = Seq("PNCounter-1" -> PNCounter.update(-456)))
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(delta(ORMap.delta(cleared = true, added = Seq("GSet-1" -> GSet.delta("1", "2", "3")))))
+          .send(
+            command(
+              5,
+              id,
+              "Process",
+              Request(id,
+                      ORMap.remove("PNCounter-1", "LWWRegister-1") ++
+                      ORMap.updateWith("GSet-1" -> GSet.add("2", "4", "6")))
+            )
+          )
+          .expect(
+            reply(
+              5,
+              ORMap.state(
+                "GSet-1" -> GSet.state("1", "2", "3", "4", "6")
+              ),
+              ORMap.update(
+                updated = Seq(
+                  "GSet-1" -> GSet.update("4", "6")
+                )
+              )
+            ),
+            Delta.sorted
+          )
+          .send(command(6, id, "Process", Request(id, ORMap.clear() ++ ORMap.add("GCounter-1"))))
+          .expect(
+            reply(6,
+                  ORMap.state("GCounter-1" -> GCounter.state(0)),
+                  ORMap.update(cleared = true, added = Seq("GCounter-1" -> GCounter.update(0))))
+          )
+          .send(delta(ORMap.delta(removed = Seq("GSet-1"), added = Seq("GCounter-1" -> GCounter.delta(42)))))
+          .send(command(7, id, "Process", Request(id, ORMap.updateWith("GCounter-1" -> GCounter.incrementBy(7)))))
+          .expect(
+            reply(7,
+                  ORMap.state("GCounter-1" -> GCounter.state(49)),
+                  ORMap.update(updated = Seq("GCounter-1" -> GCounter.update(7))))
+          )
+          .passivate()
+      }
+      "verify ORMap rehydration after passivation" in ORMap.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(ORMap.delta(added = Seq("PNCounter-1" -> PNCounter.delta(+123)))))
+          .send(command(1, id, "Process", Request(id, ORMap.updateWith("PNCounter-1" -> PNCounter.changeBy(+321)))))
+          .expect(
+            reply(1,
+                  ORMap.state("PNCounter-1" -> PNCounter.state(+444)),
+                  ORMap.update(updated = Seq("PNCounter-1" -> PNCounter.update(+321))))
+          )
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, ORMap.delta(added = Seq("PNCounter-1" -> PNCounter.delta(+444)))))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, ORMap.state("PNCounter-1" -> PNCounter.state(+444))))
+          .send(delta(ORMap.delta(updated = Seq("PNCounter-1" -> PNCounter.delta(-42)))))
+          .send(command(2, id, "Process", Request(id, ORMap.updateWith("PNCounter-1" -> PNCounter.changeBy(-360)))))
+          .expect(
+            reply(2,
+                  ORMap.state("PNCounter-1" -> PNCounter.state(+42)),
+                  ORMap.update(updated = Seq("PNCounter-1" -> PNCounter.update(-360))))
+          )
+          .passivate()
+      }
+
+      "verify ORMap delete action received from entity" in ORMap.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, ORMap.add("Flag-1"))))
+          .expect(
+            reply(1,
+                  ORMap.state("Flag-1" -> Flag.state(false)),
+                  ORMap.update(added = Seq("Flag-1" -> Flag.update(false))))
+          )
+          .send(command(2, id, "Process", Request(id, ORMap.updateWith("Flag-1" -> Flag.enable()) :+ requestDelete)))
+          .expect(reply(2, ORMap.state("Flag-1" -> Flag.state(true)), deleteCrdt))
+          .passivate()
+      }
+
+      "verify ORMap delete action sent to entity" in ORMap.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delete)
+          .passivate()
+      }
+
+      // Vote tests
+
+      object Vote {
+        def state(selfVote: Boolean, votesFor: Int, totalVoters: Int): Response =
+          Response(Some(State(State.Value.Vote(VoteValue(selfVote, votesFor, totalVoters)))))
+
+        def self(vote: Boolean): Seq[RequestAction] =
+          Seq(requestUpdate(Update(Update.Update.Vote(VoteUpdate(vote)))))
+
+        def update(selfVote: Boolean): Effects =
+          Effects(stateAction = crdtUpdate(delta(selfVote)))
+
+        def delta(selfVote: Boolean, votesFor: Int = 0, totalVoters: Int = 0): CrdtDelta.Delta.Vote =
+          deltaVote(selfVote, votesFor, totalVoters)
+
+        def test(run: String => Any): Unit = crdtTest("Vote")(run)
+      }
+
+      "verify Vote initial empty state" in Vote.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Vote.state(selfVote = false, votesFor = 0, totalVoters = 1)))
+          .passivate()
+      }
+
+      "verify Vote state changes" in Vote.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, Vote.self(true))))
+          .expect(reply(1, Vote.state(selfVote = true, votesFor = 1, totalVoters = 1), Vote.update(true)))
+          .send(command(2, id, "Process", Request(id, Vote.self(true))))
+          .expect(reply(2, Vote.state(selfVote = true, votesFor = 1, totalVoters = 1)))
+          .send(command(3, id, "Process", Request(id, Vote.self(false))))
+          .expect(reply(3, Vote.state(selfVote = false, votesFor = 0, totalVoters = 1), Vote.update(false)))
+          .send(command(4, id, "Process", Request(id, Vote.self(false))))
+          .expect(reply(4, Vote.state(selfVote = false, votesFor = 0, totalVoters = 1)))
+          .passivate()
+      }
+
+      "verify Vote initial delta in init" in Vote.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, Vote.delta(selfVote = true, votesFor = 2, totalVoters = 3)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Vote.state(selfVote = true, votesFor = 2, totalVoters = 3)))
+          .send(command(2, id, "Process", Request(id, Vote.self(false))))
+          .expect(reply(2, Vote.state(selfVote = false, votesFor = 1, totalVoters = 3), Vote.update(false)))
+          .passivate()
+      }
+
+      "verify Vote initial empty state with replicated initial delta" in Vote.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(Vote.delta(selfVote = false, votesFor = 3, totalVoters = 5)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Vote.state(selfVote = false, votesFor = 3, totalVoters = 5)))
+          .send(command(2, id, "Process", Request(id, Vote.self(true))))
+          .expect(reply(2, Vote.state(selfVote = true, votesFor = 4, totalVoters = 5), Vote.update(true)))
+          .passivate()
+      }
+
+      "verify Vote mix of local and replicated state changes" in Vote.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delta(Vote.delta(selfVote = false, votesFor = 2, totalVoters = 4)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Vote.state(selfVote = false, votesFor = 2, totalVoters = 4)))
+          .send(command(2, id, "Process", Request(id, Vote.self(true))))
+          .expect(reply(2, Vote.state(selfVote = true, votesFor = 3, totalVoters = 4), Vote.update(true)))
+          .send(delta(Vote.delta(selfVote = true, votesFor = 5, totalVoters = 7)))
+          .send(delta(Vote.delta(selfVote = true, votesFor = 4, totalVoters = 6)))
+          .send(command(3, id, "Process", Request(id, Vote.self(false))))
+          .expect(reply(3, Vote.state(selfVote = false, votesFor = 3, totalVoters = 6), Vote.update(false)))
+          .passivate()
+      }
+
+      "verify Vote rehydration after passivation" in Vote.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Vote.state(selfVote = false, votesFor = 0, totalVoters = 1)))
+          .send(delta(Vote.delta(selfVote = false, votesFor = 2, totalVoters = 5)))
+          .send(command(2, id, "Process", Request(id, Vote.self(true))))
+          .expect(reply(2, Vote.state(selfVote = true, votesFor = 3, totalVoters = 5), Vote.update(true)))
+          .passivate()
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id, Vote.delta(selfVote = true, votesFor = 3, totalVoters = 5)))
+          .send(command(1, id, "Process", Request(id)))
+          .expect(reply(1, Vote.state(selfVote = true, votesFor = 3, totalVoters = 5)))
+          .send(command(2, id, "Process", Request(id, Vote.self(false))))
+          .expect(reply(2, Vote.state(selfVote = false, votesFor = 2, totalVoters = 5), Vote.update(false)))
+          .passivate()
+      }
+
+      "verify Vote delete action received from entity" in Vote.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, Vote.self(true))))
+          .expect(reply(1, Vote.state(selfVote = true, votesFor = 1, totalVoters = 1), Vote.update(true)))
+          .send(command(2, id, "Process", Request(id, Seq(requestDelete))))
+          .expect(reply(2, Vote.state(selfVote = true, votesFor = 1, totalVoters = 1), deleteCrdt))
+          .passivate()
+      }
+
+      "verify Vote delete action sent to entity" in Vote.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(delete)
+          .passivate()
+      }
+
+      // forward and side effect tests
+
+      "verify forward to second service" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, Seq(forwardTo(s"X-$id")))))
+          .expect(forwarded(1, s"X-$id"))
+          .passivate()
+      }
+
+      "verify forward with state changes" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, PNCounter.changeBy(-42) :+ forwardTo(s"X-$id"))))
+          .expect(forwarded(1, s"X-$id", PNCounter.update(-42)))
+          .passivate()
+      }
+
+      "verify reply with side effect to second service" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, Seq(sideEffectTo(s"X-$id")))))
+          .expect(reply(1, GSet.state(), sideEffects(s"X-$id")))
+          .passivate()
+      }
+
+      "verify synchronous side effect to second service" in ORSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, Seq(sideEffectTo(s"X-$id", synchronous = true)))))
+          .expect(reply(1, ORSet.state(), synchronousSideEffects(s"X-$id")))
+          .passivate()
+      }
+
+      "verify forward and side effect to second service" in LWWRegister.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, Seq(sideEffectTo(s"B-$id"), forwardTo(s"A-$id")))))
+          .expect(forwarded(1, s"A-$id", LWWRegister.update("") ++ sideEffects(s"B-$id")))
+          .passivate()
+      }
+
+      "verify reply with multiple side effects" in Flag.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, sideEffectsTo("1", "2", "3"))))
+          .expect(reply(1, Flag.state(false), sideEffects("1", "2", "3")))
+          .passivate()
+      }
+
+      "verify reply with multiple side effects and state changes" in ORMap.test { id =>
+        val crdtActions = ORMap.add("PNCounter-1") ++ ORMap.updateWith("GSet-1" -> GSet.add("a", "b", "c"))
+        val actions = crdtActions ++ sideEffectsTo("1", "2", "3")
+        val expectedState = ORMap.state("GSet-1" -> GSet.state("a", "b", "c"), "PNCounter-1" -> PNCounter.state(0))
+        val crdtUpdates = ORMap.update(
+          added = Seq(
+            "GSet-1" -> GSet.update("a", "b", "c"),
+            "PNCounter-1" -> PNCounter.update(0)
+          )
+        )
+        val effects = crdtUpdates ++ sideEffects("1", "2", "3")
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, actions)))
+          .expect(reply(1, expectedState, effects), Delta.sorted)
+          .passivate()
+      }
+
+      // failure tests
+
+      "verify failure action" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, Seq(failWith("expected failure")))))
+          .expect(failure(1, "expected failure"))
+          .passivate()
+      }
+
+      "verify connection after failure action" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, PNCounter.changeBy(+42))))
+          .expect(reply(1, PNCounter.state(+42), PNCounter.update(+42)))
+          .send(command(2, id, "Process", Request(id, Seq(failWith("expected failure")))))
+          .expect(failure(2, "expected failure"))
+          .send(command(3, id, "Process", Request(id)))
+          .expect(reply(3, PNCounter.state(+42)))
+          .passivate()
+      }
+
+      // streamed response tests
+
+      "verify streamed responses" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "ProcessStreamed", StreamedRequest(id), streamed = true))
+          .expect(reply(1, GCounter.state(0), Effects(streamed = true)))
+          .send(command(2, id, "Process", Request(id, GCounter.incrementBy(1))))
+          .expect(reply(2, GCounter.state(1), GCounter.update(1)))
+          .expect(streamed(1, GCounter.state(1)))
+          .send(command(3, id, "Process", Request(id, GCounter.incrementBy(2))))
+          .expect(reply(3, GCounter.state(3), GCounter.update(2)))
+          .expect(streamed(1, GCounter.state(3)))
+          .send(command(4, id, "Process", Request(id, GCounter.incrementBy(3))))
+          .expect(reply(4, GCounter.state(6), GCounter.update(3)))
+          .expect(streamed(1, GCounter.state(6)))
+          .passivate()
+      }
+
+      "verify streamed responses with stream ending action" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(
+            command(1, id, "ProcessStreamed", StreamedRequest(id, endState = GCounter.state(3).state), streamed = true)
+          )
+          .expect(reply(1, GCounter.state(0), Effects(streamed = true)))
+          .send(command(2, id, "Process", Request(id, GCounter.incrementBy(1))))
+          .expect(reply(2, GCounter.state(1), GCounter.update(1)))
+          .expect(streamed(1, GCounter.state(1)))
+          .send(command(3, id, "Process", Request(id, GCounter.incrementBy(2))))
+          .expect(reply(3, GCounter.state(3), GCounter.update(2)))
+          .expect(streamed(1, GCounter.state(3), Effects(endStream = true)))
+          .send(command(4, id, "Process", Request(id, GCounter.incrementBy(3))))
+          .expect(reply(4, GCounter.state(6), GCounter.update(3)))
+          .passivate()
+      }
+
+      "verify streamed responses with cancellation" in PNCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(
+            command(
+              1,
+              id,
+              "ProcessStreamed",
+              StreamedRequest(id, cancelUpdate = Some(PNCounter.updateWith(-42))),
+              streamed = true
+            )
+          )
+          .expect(reply(1, PNCounter.state(0), Effects(streamed = true)))
+          .send(command(2, id, "Process", Request(id, PNCounter.changeBy(+10))))
+          .expect(reply(2, PNCounter.state(+10), PNCounter.update(+10)))
+          .expect(streamed(1, PNCounter.state(+10)))
+          .send(command(3, id, "Process", Request(id, PNCounter.changeBy(+20))))
+          .expect(reply(3, PNCounter.state(+30), PNCounter.update(+20)))
+          .expect(streamed(1, PNCounter.state(+30)))
+          .send(crdtStreamCancelled(1, id))
+          .expect(streamCancelledResponse(1, PNCounter.update(-42)))
+          .send(command(4, id, "Process", Request(id)))
+          .expect(reply(4, PNCounter.state(-12)))
+          .send(command(5, id, "Process", Request(id, PNCounter.changeBy(+30))))
+          .expect(reply(5, PNCounter.state(+18), PNCounter.update(+30)))
+          .passivate()
+      }
+
+      "verify streamed responses with side effects" in GSet.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(
+            command(
+              1,
+              id,
+              "ProcessStreamed",
+              StreamedRequest(id, effects = Seq(Effect("one"), Effect("two", synchronous = true))),
+              streamed = true
+            )
+          )
+          .expect(reply(1, GSet.state(), Effects(streamed = true)))
+          .send(command(2, id, "Process", Request(id, GSet.add("a"))))
+          .expect(reply(2, GSet.state("a"), GSet.update("a")))
+          .expect(streamed(1, GSet.state("a"), sideEffects("one") ++ synchronousSideEffects("two")))
+          .send(command(3, id, "Process", Request(id, GSet.add("b"))))
+          .expect(reply(3, GSet.state("a", "b"), GSet.update("b")))
+          .expect(streamed(1, GSet.state("a", "b"), sideEffects("one") ++ synchronousSideEffects("two")))
+          .passivate()
+      }
+
+      // write consistency tests
+
+      def incrementWith(increment: Long, writeConsistency: UpdateWriteConsistency): Seq[RequestAction] =
+        Seq(requestUpdate(GCounter.updateWith(increment).withWriteConsistency(writeConsistency)))
+
+      def updateWith(value: Long, writeConsistency: CrdtWriteConsistency): Effects =
+        Effects(stateAction = crdtUpdate(GCounter.delta(value), writeConsistency))
+
+      "verify write consistency can be configured" in GCounter.test { id =>
+        protocol.crdt
+          .connect()
+          .send(init(CrdtTckModel.name, id))
+          .send(command(1, id, "Process", Request(id, incrementWith(1, UpdateWriteConsistency.LOCAL))))
+          .expect(reply(1, GCounter.state(1), updateWith(1, CrdtWriteConsistency.LOCAL)))
+          .send(command(2, id, "Process", Request(id, incrementWith(2, UpdateWriteConsistency.MAJORITY))))
+          .expect(reply(2, GCounter.state(3), updateWith(2, CrdtWriteConsistency.MAJORITY)))
+          .send(command(3, id, "Process", Request(id, incrementWith(3, UpdateWriteConsistency.ALL))))
+          .expect(reply(3, GCounter.state(6), updateWith(3, CrdtWriteConsistency.ALL)))
+          .passivate()
       }
     }
 

--- a/testkit/src/main/scala/io/cloudstate/testkit/TestProtocol.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/TestProtocol.scala
@@ -21,6 +21,7 @@ import akka.grpc.GrpcClientSettings
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
 import io.cloudstate.testkit.action.TestActionProtocol
+import io.cloudstate.testkit.crdt.TestCrdtProtocol
 import io.cloudstate.testkit.eventsourced.TestEventSourcedProtocol
 import io.cloudstate.testkit.valueentity.TestValueEntityProtocol
 
@@ -30,6 +31,7 @@ final class TestProtocol(host: String, port: Int) {
   val context = new TestProtocolContext(host, port)
 
   val action = new TestActionProtocol(context)
+  val crdt = new TestCrdtProtocol(context)
   val eventSourced = new TestEventSourcedProtocol(context)
   val valueEntity = new TestValueEntityProtocol(context)
 
@@ -37,6 +39,7 @@ final class TestProtocol(host: String, port: Int) {
 
   def terminate(): Unit = {
     action.terminate()
+    crdt.terminate()
     eventSourced.terminate()
     valueEntity.terminate()
     context.terminate()

--- a/testkit/src/main/scala/io/cloudstate/testkit/crdt/CrdtMessages.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/crdt/CrdtMessages.scala
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.crdt
+
+import com.google.protobuf.any.{Any => ScalaPbAny}
+import com.google.protobuf.{Message => JavaPbMessage}
+import io.cloudstate.protocol.crdt._
+import io.cloudstate.protocol.entity.{ClientAction, Command, SideEffect}
+import io.cloudstate.testkit.entity.EntityMessages
+import io.cloudstate.testkit.eventsourced.EventSourcedMessages.Effects
+import scalapb.{GeneratedMessage => ScalaPbMessage}
+
+object CrdtMessages extends EntityMessages {
+  import CrdtStreamIn.{Message => InMessage}
+  import CrdtStreamOut.{Message => OutMessage}
+
+  case class Effects(
+      stateAction: Option[CrdtStateAction] = None,
+      sideEffects: Seq[SideEffect] = Seq.empty,
+      streamed: Boolean = false,
+      endStream: Boolean = false
+  ) {
+    def withSideEffect(service: String, command: String, message: JavaPbMessage): Effects =
+      withSideEffect(service, command, messagePayload(message), synchronous = false)
+
+    def withSideEffect(service: String, command: String, message: JavaPbMessage, synchronous: Boolean): Effects =
+      withSideEffect(service, command, messagePayload(message), synchronous)
+
+    def withSideEffect(service: String, command: String, message: ScalaPbMessage): Effects =
+      withSideEffect(service, command, messagePayload(message), synchronous = false)
+
+    def withSideEffect(service: String, command: String, message: ScalaPbMessage, synchronous: Boolean): Effects =
+      withSideEffect(service, command, messagePayload(message), synchronous)
+
+    def withSideEffect(service: String, command: String, payload: Option[ScalaPbAny], synchronous: Boolean): Effects =
+      copy(sideEffects = sideEffects :+ SideEffect(service, command, payload, synchronous))
+
+    def ++(other: Effects): Effects =
+      Effects(stateAction.orElse(other.stateAction),
+              sideEffects ++ other.sideEffects,
+              streamed || other.streamed,
+              endStream || other.endStream)
+  }
+
+  object Effects {
+    val empty: Effects = Effects()
+  }
+
+  def init(serviceName: String, entityId: String): InMessage =
+    init(serviceName, entityId, None)
+
+  def init(serviceName: String, entityId: String, delta: CrdtDelta.Delta): InMessage =
+    InMessage.Init(CrdtInit(serviceName, entityId, Option(CrdtDelta(delta))))
+
+  def init(serviceName: String, entityId: String, delta: Option[CrdtDelta]): InMessage =
+    InMessage.Init(CrdtInit(serviceName, entityId, delta))
+
+  def delta(delta: CrdtDelta.Delta): InMessage =
+    InMessage.Delta(CrdtDelta(delta))
+
+  val delete: InMessage =
+    InMessage.Delete(CrdtDelete())
+
+  def command(id: Long, entityId: String, name: String): InMessage =
+    command(id, entityId, name, streamed = false)
+
+  def command(id: Long, entityId: String, name: String, streamed: Boolean): InMessage =
+    command(id, entityId, name, EmptyJavaMessage, streamed)
+
+  def command(id: Long, entityId: String, name: String, payload: JavaPbMessage): InMessage =
+    command(id, entityId, name, payload, streamed = false)
+
+  def command(id: Long, entityId: String, name: String, payload: JavaPbMessage, streamed: Boolean): InMessage =
+    command(id, entityId, name, messagePayload(payload), streamed)
+
+  def command(id: Long, entityId: String, name: String, payload: ScalaPbMessage): InMessage =
+    command(id, entityId, name, payload, streamed = false)
+
+  def command(id: Long, entityId: String, name: String, payload: ScalaPbMessage, streamed: Boolean): InMessage =
+    command(id, entityId, name, messagePayload(payload), streamed)
+
+  def command(id: Long, entityId: String, name: String, payload: Option[ScalaPbAny]): InMessage =
+    command(id, entityId, name, payload, streamed = false)
+
+  def command(id: Long, entityId: String, name: String, payload: Option[ScalaPbAny], streamed: Boolean): InMessage =
+    InMessage.Command(Command(entityId, id, name, payload, streamed))
+
+  def crdtStreamCancelled(id: Long, entityId: String): InMessage =
+    InMessage.StreamCancelled(streamCancelled(id, entityId))
+
+  def reply(id: Long, payload: JavaPbMessage): OutMessage =
+    reply(id, payload, Effects.empty)
+
+  def reply(id: Long, payload: JavaPbMessage, effects: Effects): OutMessage =
+    reply(id, messagePayload(payload), effects)
+
+  def reply(id: Long, payload: ScalaPbMessage): OutMessage =
+    reply(id, payload, Effects.empty)
+
+  def reply(id: Long, payload: ScalaPbMessage, effects: Effects): OutMessage =
+    reply(id, messagePayload(payload), effects)
+
+  def reply(id: Long, payload: Option[ScalaPbAny], effects: Effects): OutMessage =
+    crdtReply(id, clientActionReply(payload), effects)
+
+  def forward(id: Long, service: String, command: String, payload: JavaPbMessage): OutMessage =
+    forward(id, service, command, payload, Effects.empty)
+
+  def forward(id: Long, service: String, command: String, payload: JavaPbMessage, effects: Effects): OutMessage =
+    forward(id, service, command, messagePayload(payload), effects)
+
+  def forward(id: Long, service: String, command: String, payload: ScalaPbMessage): OutMessage =
+    forward(id, service, command, payload, Effects.empty)
+
+  def forward(id: Long, service: String, command: String, payload: ScalaPbMessage, effects: Effects): OutMessage =
+    forward(id, service, command, messagePayload(payload), effects)
+
+  def forward(id: Long, service: String, command: String, payload: Option[ScalaPbAny], effects: Effects): OutMessage =
+    crdtReply(id, clientActionForward(service, command, payload), effects)
+
+  def failure(id: Long, description: String): OutMessage =
+    crdtReply(id, clientActionFailure(id, description), Effects.empty)
+
+  def crdtReply(id: Long, clientAction: Option[ClientAction], effects: Effects): OutMessage =
+    OutMessage.Reply(CrdtReply(id, clientAction, effects.sideEffects, effects.stateAction, effects.streamed))
+
+  def streamed(id: Long, payload: JavaPbMessage): OutMessage =
+    streamed(id, payload, Effects.empty)
+
+  def streamed(id: Long, payload: JavaPbMessage, effects: Effects): OutMessage =
+    streamed(id, messagePayload(payload), effects)
+
+  def streamed(id: Long, payload: ScalaPbMessage): OutMessage =
+    streamed(id, payload, Effects.empty)
+
+  def streamed(id: Long, payload: ScalaPbMessage, effects: Effects): OutMessage =
+    streamed(id, messagePayload(payload), effects)
+
+  def streamed(id: Long, payload: Option[ScalaPbAny], effects: Effects): OutMessage =
+    crdtStreamedMessage(id, clientActionReply(payload), effects)
+
+  def crdtStreamedMessage(id: Long, clientAction: Option[ClientAction], effects: Effects): OutMessage =
+    OutMessage.StreamedMessage(CrdtStreamedMessage(id, clientAction, effects.sideEffects, effects.endStream))
+
+  def streamCancelledResponse(id: Long, effects: Effects): OutMessage =
+    OutMessage.StreamCancelledResponse(CrdtStreamCancelledResponse(id, effects.sideEffects, effects.stateAction))
+
+  def crdtUpdate(delta: CrdtDelta.Delta): Option[CrdtStateAction] =
+    Some(CrdtStateAction(CrdtStateAction.Action.Update(CrdtDelta(delta))))
+
+  def crdtUpdate(delta: CrdtDelta.Delta, writeConsistency: CrdtWriteConsistency): Option[CrdtStateAction] =
+    Some(CrdtStateAction(CrdtStateAction.Action.Update(CrdtDelta(delta)), writeConsistency))
+
+  def deltaGCounter(value: Long): CrdtDelta.Delta.Gcounter =
+    CrdtDelta.Delta.Gcounter(GCounterDelta(value))
+
+  def deltaPNCounter(value: Long): CrdtDelta.Delta.Pncounter =
+    CrdtDelta.Delta.Pncounter(PNCounterDelta(value))
+
+  def deltaGSet(): CrdtDelta.Delta.Gset =
+    deltaGSet(Seq.empty)
+
+  def deltaGSet(element: String, elements: String*): CrdtDelta.Delta.Gset =
+    deltaGSet(primitiveString(element), elements.map(primitiveString): _*)
+
+  def deltaGSet(element: JavaPbMessage, elements: JavaPbMessage*): CrdtDelta.Delta.Gset =
+    deltaGSet(protobufAny(element), elements.map(protobufAny): _*)
+
+  def deltaGSet(element: ScalaPbMessage, elements: ScalaPbMessage*): CrdtDelta.Delta.Gset =
+    deltaGSet(protobufAny(element), elements.map(protobufAny): _*)
+
+  def deltaGSet(element: ScalaPbAny, elements: ScalaPbAny*): CrdtDelta.Delta.Gset =
+    deltaGSet(element +: elements)
+
+  def deltaGSet(added: Seq[ScalaPbAny]): CrdtDelta.Delta.Gset =
+    CrdtDelta.Delta.Gset(GSetDelta(added))
+
+  case class DeltaORSet(cleared: Boolean = false,
+                        removed: Seq[ScalaPbAny] = Seq.empty,
+                        added: Seq[ScalaPbAny] = Seq.empty) {
+
+    def add(element: JavaPbMessage, elements: JavaPbMessage*): DeltaORSet =
+      add(protobufAny(element), elements.map(protobufAny): _*)
+
+    def add(element: ScalaPbMessage, elements: ScalaPbMessage*): DeltaORSet =
+      add(protobufAny(element), elements.map(protobufAny): _*)
+
+    def add(element: ScalaPbAny, elements: ScalaPbAny*): DeltaORSet =
+      add(element +: elements)
+
+    def add(elements: Seq[ScalaPbAny]): DeltaORSet =
+      copy(added = added ++ elements)
+
+    def remove(element: JavaPbMessage, elements: JavaPbMessage*): DeltaORSet =
+      remove(protobufAny(element), elements.map(protobufAny): _*)
+
+    def remove(element: ScalaPbMessage, elements: ScalaPbMessage*): DeltaORSet =
+      remove(protobufAny(element), elements.map(protobufAny): _*)
+
+    def remove(element: ScalaPbAny, elements: ScalaPbAny*): DeltaORSet =
+      remove(element +: elements)
+
+    def remove(elements: Seq[ScalaPbAny]): DeltaORSet =
+      copy(removed = removed ++ elements)
+
+    def clear(cleared: Boolean = true): DeltaORSet =
+      copy(cleared = cleared)
+
+    def crdtDelta(): CrdtDelta.Delta.Orset =
+      CrdtDelta.Delta.Orset(ORSetDelta(cleared, removed, added))
+  }
+
+  object DeltaORSet {
+    val empty: DeltaORSet = DeltaORSet()
+  }
+
+  def deltaLWWRegister(value: JavaPbMessage): CrdtDelta.Delta.Lwwregister =
+    deltaLWWRegister(value, CrdtClock.DEFAULT)
+
+  def deltaLWWRegister(value: JavaPbMessage, clock: CrdtClock): CrdtDelta.Delta.Lwwregister =
+    deltaLWWRegister(value, clock, customClock = 0L)
+
+  def deltaLWWRegister(value: JavaPbMessage, clock: CrdtClock, customClock: Long): CrdtDelta.Delta.Lwwregister =
+    deltaLWWRegister(messagePayload(value), clock, customClock)
+
+  def deltaLWWRegister(value: ScalaPbMessage): CrdtDelta.Delta.Lwwregister =
+    deltaLWWRegister(value, CrdtClock.DEFAULT)
+
+  def deltaLWWRegister(value: ScalaPbMessage, clock: CrdtClock): CrdtDelta.Delta.Lwwregister =
+    deltaLWWRegister(value, clock, customClock = 0L)
+
+  def deltaLWWRegister(value: ScalaPbMessage, clock: CrdtClock, customClock: Long): CrdtDelta.Delta.Lwwregister =
+    deltaLWWRegister(messagePayload(value), clock, customClock)
+
+  def deltaLWWRegister(value: Option[ScalaPbAny]): CrdtDelta.Delta.Lwwregister =
+    deltaLWWRegister(value, CrdtClock.DEFAULT)
+
+  def deltaLWWRegister(value: Option[ScalaPbAny], clock: CrdtClock): CrdtDelta.Delta.Lwwregister =
+    deltaLWWRegister(value, clock, customClock = 0L)
+
+  def deltaLWWRegister(value: Option[ScalaPbAny], clock: CrdtClock, customClock: Long): CrdtDelta.Delta.Lwwregister =
+    CrdtDelta.Delta.Lwwregister(LWWRegisterDelta(value, clock, customClock))
+
+  def deltaFlag(value: Boolean): CrdtDelta.Delta.Flag =
+    CrdtDelta.Delta.Flag(FlagDelta(value))
+
+  case class DeltaORMap(cleared: Boolean = false,
+                        removed: Seq[ScalaPbAny] = Seq.empty,
+                        updated: Seq[(ScalaPbAny, CrdtDelta)] = Seq.empty,
+                        added: Seq[(ScalaPbAny, CrdtDelta)] = Seq.empty) {
+
+    def add(key: JavaPbMessage, delta: CrdtDelta): DeltaORMap =
+      add(protobufAny(key), delta)
+
+    def add(key: ScalaPbMessage, delta: CrdtDelta): DeltaORMap =
+      add(protobufAny(key), delta)
+
+    def add(key: ScalaPbAny, delta: CrdtDelta): DeltaORMap =
+      add(Seq(key -> delta))
+
+    def add(entries: Seq[(ScalaPbAny, CrdtDelta)]): DeltaORMap =
+      copy(added = added ++ entries)
+
+    def update(key: JavaPbMessage, delta: CrdtDelta): DeltaORMap =
+      update(protobufAny(key), delta)
+
+    def update(key: ScalaPbMessage, delta: CrdtDelta): DeltaORMap =
+      update(protobufAny(key), delta)
+
+    def update(key: ScalaPbAny, delta: CrdtDelta): DeltaORMap =
+      update(Seq(key -> delta))
+
+    def update(entries: Seq[(ScalaPbAny, CrdtDelta)]): DeltaORMap =
+      copy(updated = updated ++ entries)
+
+    def remove(key: JavaPbMessage, keys: JavaPbMessage*): DeltaORMap =
+      remove(protobufAny(key), keys.map(protobufAny): _*)
+
+    def remove(key: ScalaPbMessage, keys: ScalaPbMessage*): DeltaORMap =
+      remove(protobufAny(key), keys.map(protobufAny): _*)
+
+    def remove(key: ScalaPbAny, keys: ScalaPbAny*): DeltaORMap =
+      remove(key +: keys)
+
+    def remove(keys: Seq[ScalaPbAny]): DeltaORMap =
+      copy(removed = removed ++ keys)
+
+    def clear(cleared: Boolean = true): DeltaORMap =
+      copy(cleared = cleared)
+
+    def crdtDelta(): CrdtDelta.Delta.Ormap = {
+      val updatedEntries = updated map { case (key, delta) => ORMapEntryDelta(Option(key), Option(delta)) }
+      val addedEntries = added map { case (key, delta) => ORMapEntryDelta(Option(key), Option(delta)) }
+      CrdtDelta.Delta.Ormap(ORMapDelta(cleared, removed, updatedEntries, addedEntries))
+    }
+  }
+
+  object DeltaORMap {
+    val empty: DeltaORMap = DeltaORMap()
+  }
+
+  def deltaVote(selfVote: Boolean, votesFor: Int = 0, totalVoters: Int = 0): CrdtDelta.Delta.Vote =
+    CrdtDelta.Delta.Vote(VoteDelta(selfVote, votesFor, totalVoters))
+
+  val crdtDelete: Option[CrdtStateAction] =
+    Some(CrdtStateAction(CrdtStateAction.Action.Delete(CrdtDelete())))
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/crdt/TestCrdtProtocol.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/crdt/TestCrdtProtocol.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.crdt
+
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.scaladsl.TestSink
+import io.cloudstate.protocol.crdt._
+import io.cloudstate.testkit.TestProtocol.TestProtocolContext
+
+final class TestCrdtProtocol(context: TestProtocolContext) {
+  private val client = CrdtClient(context.clientSettings)(context.system)
+
+  def connect(): TestCrdtProtocol.Connection = new TestCrdtProtocol.Connection(client, context)
+
+  def terminate(): Unit = client.close()
+}
+
+object TestCrdtProtocol {
+  final class Connection(client: CrdtClient, context: TestProtocolContext) {
+    import context.system
+
+    private val in = TestPublisher.probe[CrdtStreamIn]()
+    private val out = client.handle(Source.fromPublisher(in)).runWith(TestSink.probe[CrdtStreamOut])
+
+    out.ensureSubscription()
+
+    def send(message: CrdtStreamIn.Message): Connection = {
+      in.sendNext(CrdtStreamIn(message))
+      this
+    }
+
+    def expect(message: CrdtStreamOut.Message): Connection = {
+      out.request(1).expectNext(CrdtStreamOut(message))
+      this
+    }
+
+    def expect(message: CrdtStreamOut.Message, transformReceived: CrdtStreamOut => CrdtStreamOut): Connection = {
+      val received = transformReceived(out.request(1).expectNext())
+      assert(CrdtStreamOut(message) == received, s"expected $message, found $received")
+      this
+    }
+
+    def expectClosed(): Unit = {
+      out.expectComplete()
+      in.expectCancellation()
+    }
+
+    def passivate(): Unit = close()
+
+    def close(): Unit = {
+      in.sendComplete()
+      out.expectComplete()
+    }
+  }
+}

--- a/testkit/src/main/scala/io/cloudstate/testkit/entity/EntityMessages.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/entity/EntityMessages.scala
@@ -58,6 +58,12 @@ trait EntityMessages {
   def sideEffect(service: String, command: String, payload: Option[ScalaPbAny], synchronous: Boolean): SideEffect =
     SideEffect(service, command, payload, synchronous)
 
+  def streamCancelled(entityId: String): StreamCancelled =
+    streamCancelled(id = 0, entityId)
+
+  def streamCancelled(id: Long, entityId: String): StreamCancelled =
+    StreamCancelled(entityId, id)
+
   def messagePayload(message: JavaPbMessage): Option[ScalaPbAny] =
     Option(message).map(protobufAny)
 
@@ -76,4 +82,11 @@ trait EntityMessages {
 
   def primitiveString(value: String): ScalaPbAny =
     ScalaPbAny("p.cloudstate.io/string", StringValue.of(value).toByteString)
+
+  def readPrimitiveString(any: ScalaPbAny): String =
+    if (any.typeUrl == "p.cloudstate.io/string") {
+      val stream = any.value.newCodedInput
+      stream.readTag // assume it's for string
+      stream.readString
+    } else ""
 }


### PR DESCRIPTION
Add tests for CRDT entities to the TCK. Currently only implemented for Java support, with some small changes: tweaks to LWWRegister, and support for configuring write consistencies.

The TCK test class is getting quite long now. Will follow-up with some reorganisation to break this into multiple files.

And will follow-up with the rename of CRDT Entity to Replicated Entity once this is merged.