### PR TITLE
Fix empty streamed responses (for CRDT entities)

### DIFF
--- a/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/crdt/CrdtTckModelEntity.java
+++ b/java-support/tck/src/main/java/io/cloudstate/javasupport/tck/model/crdt/CrdtTckModelEntity.java
@@ -131,7 +131,7 @@ public class CrdtTckModelEntity {
   }
 
   @CommandHandler
-  public Response processStreamed(
+  public Optional<Response> processStreamed(
       StreamedRequest request, StreamedCommandContext<Response> context) {
     if (context.isStreamed()) {
       context.onChange(
@@ -140,12 +140,13 @@ public class CrdtTckModelEntity {
               subscription.effect(serviceTwoRequest(effect.getId()), effect.getSynchronous());
             if (request.hasEndState() && crdtState(crdt).equals(request.getEndState()))
               subscription.endStream();
-            return Optional.of(responseValue());
+            return request.getEmpty() ? Optional.empty() : Optional.of(responseValue());
           });
       if (request.hasCancelUpdate())
         context.onCancel(cancelled -> applyUpdate(crdt, request.getCancelUpdate()));
     }
-    return responseValue();
+    if (request.hasInitialUpdate()) applyUpdate(crdt, request.getInitialUpdate());
+    return request.getEmpty() ? Optional.empty() : Optional.of(responseValue());
   }
 
   private void applyUpdate(Crdt crdt, Update update) {

--- a/protocols/tck/cloudstate/tck/model/crdt.proto
+++ b/protocols/tck/cloudstate/tck/model/crdt.proto
@@ -68,12 +68,17 @@ message Request {
 // If `end_state` is set, it specifies a target state for ending the stream.
 // If `cancel_update` is set, it specifies an update to apply when the stream is cancelled.
 // If `effects` is set, it specifies side effects to return with every streamed response.
+// If `initial_update` is set, it specifies an update to apply on the initial request.
+// If `empty` is set, then no responses should be streamed (for testing empty stream connections).
+// Otherwise, the current state should be streamed on changes.
 //
 message StreamedRequest {
   string id = 1 [(.cloudstate.entity_key) = true];
   State end_state = 2;
   Update cancel_update = 3;
   repeated Effect effects = 4;
+  Update initial_update = 5;
+  bool empty = 6;
 }
 
 //

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/UserFunctionRouter.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/UserFunctionRouter.scala
@@ -80,8 +80,6 @@ class UserFunctionRouter(val entities: Seq[ServableEntity], entityDiscovery: Ent
             synchronous = true,
             metadata.getOrElse(Metadata.defaultInstance)
           )
-        case None | Some(ClientAction(ClientAction.Action.Empty, _)) =>
-          Source.empty
         case _ =>
           Source.single(response)
       }

--- a/testkit/src/main/scala/io/cloudstate/testkit/crdt/CrdtMessages.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/crdt/CrdtMessages.scala
@@ -156,6 +156,9 @@ object CrdtMessages extends EntityMessages {
   def crdtStreamedMessage(id: Long, clientAction: Option[ClientAction], effects: Effects): OutMessage =
     OutMessage.StreamedMessage(CrdtStreamedMessage(id, clientAction, effects.sideEffects, effects.endStream))
 
+  def streamCancelledResponse(id: Long): OutMessage =
+    streamCancelledResponse(id, Effects.empty)
+
   def streamCancelledResponse(id: Long, effects: Effects): OutMessage =
     OutMessage.StreamCancelledResponse(CrdtStreamCancelledResponse(id, effects.sideEffects, effects.stateAction))
 

--- a/testkit/src/main/scala/io/cloudstate/testkit/crdt/InterceptCrdtService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/crdt/InterceptCrdtService.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudstate.testkit.crdt
+
+import akka.NotUsed
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestProbe
+import io.cloudstate.protocol.crdt._
+import io.cloudstate.testkit.InterceptService.InterceptorContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+final class InterceptCrdtService(context: InterceptorContext) {
+  import InterceptCrdtService._
+
+  private val interceptor = new CrdtInterceptor(context)
+
+  def expectConnection(): Connection = context.probe.expectMsgType[Connection]
+
+  def handler: PartialFunction[HttpRequest, Future[HttpResponse]] =
+    CrdtHandler.partial(interceptor)(context.system)
+
+  def terminate(): Unit = interceptor.terminate()
+}
+
+object InterceptCrdtService {
+  final class CrdtInterceptor(context: InterceptorContext) extends Crdt {
+    private val client = CrdtClient(context.clientSettings)(context.system)
+
+    override def handle(in: Source[CrdtStreamIn, NotUsed]): Source[CrdtStreamOut, NotUsed] = {
+      val connection = new Connection(context)
+      context.probe.ref ! connection
+      client.handle(in.alsoTo(connection.inSink)).alsoTo(connection.outSink)
+    }
+
+    def terminate(): Unit = client.close()
+  }
+
+  object Connection {
+    case object Complete
+    final case class Error(cause: Throwable)
+  }
+
+  final class Connection(context: InterceptorContext) {
+    import Connection._
+
+    private[this] val in = TestProbe("CrdtInProbe")(context.system)
+    private[this] val out = TestProbe("CrdtOutProbe")(context.system)
+
+    private[testkit] def inSink: Sink[CrdtStreamIn, NotUsed] = Sink.actorRef(in.ref, Complete, Error.apply)
+    private[testkit] def outSink: Sink[CrdtStreamOut, NotUsed] = Sink.actorRef(out.ref, Complete, Error.apply)
+
+    def expectClient(message: CrdtStreamIn.Message): Connection = {
+      in.expectMsg(CrdtStreamIn(message))
+      this
+    }
+
+    def expectService(message: CrdtStreamOut.Message): Connection = {
+      out.expectMsg(CrdtStreamOut(message))
+      this
+    }
+
+    def expectServiceMessage[T](implicit classTag: ClassTag[T]): T =
+      expectServiceMessageClass(classTag.runtimeClass.asInstanceOf[Class[T]])
+
+    def expectServiceMessageClass[T](messageClass: Class[T]): T = {
+      val message = out.expectMsgType[CrdtStreamOut].message
+      assert(messageClass.isInstance(message), s"expected message $messageClass, found ${message.getClass} ($message)")
+      message.asInstanceOf[T]
+    }
+
+    def expectNoInteraction(timeout: FiniteDuration = 0.seconds): Connection = {
+      in.expectNoMessage(timeout)
+      out.expectNoMessage(timeout)
+      this
+    }
+
+    def expectClosed(): Unit = {
+      in.expectMsg(Complete)
+      out.expectMsg(Complete)
+    }
+  }
+}


### PR DESCRIPTION
Resolves #493. Fix for this was simple: don't filter out empty client actions in `UserFunctionRouter`. We need a first empty response to always be sent downstream, otherwise an HttpResponse is never created due to waiting for the first response to extract metadata. Empty client actions will be filtered out in `CommandHandler.processReplies` instead.

Added tests to the TCK for this, including a proxy intercept test that has same behaviour as the presence example but using the CRDT TCK model entity.

@marcellanz, some updates to the CRDT TCK to include for Go support.