### PR TITLE
Fix proto descriptor extract service

### DIFF
--- a/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
@@ -255,7 +255,7 @@ class EntityDiscoveryManager(config: EntityDiscoveryManager.Configuration)(
 
   private[this] final def extractService(serviceName: String, descriptor: FileDescriptor): Option[ServiceDescriptor] = {
     val (pkg, name) = Names.splitPrev(serviceName)
-    Some(descriptor).filter(_.getPackage == pkg).map(_.findServiceByName(name))
+    if (descriptor.getPackage == pkg) Option(descriptor.findServiceByName(name)) else None
   }
 
   private[this] final def binding(eventManager: Option[RunnableGraph[Future[Done]]]): Receive = {


### PR DESCRIPTION
Resolves #496.

If there are multiple entities registered, which have separate file descriptors but share the same package name, then subsequent services can't be found. The `extractService` method is used to collect the first matching service. Previously it would filter on the package, and then do a `findServiceByName`, but this will return a `Some(null)` on an earlier file descriptor if the service is actually in a later file descriptor. Update to only return `Some(serviceDescriptor)` if found, otherwise `None` to continue the search. I'm assuming this was the original intention.

Can follow up with a test...