### PR TITLE
Use full service name in default mappings for HTTP API

### DIFF
--- a/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/HttpApi.scala
@@ -674,7 +674,7 @@ object HttpApi {
             body = "*", // Parse all input
             responseBody = "", // Include all output
             additionalBindings = Nil, // No need for additional bindings
-            pattern = HttpRule.Pattern.Post((Path / "v1" / method.getName).toString)
+            pattern = HttpRule.Pattern.Post((Path / service.getFullName / method.getName).toString)
           )
           log.info(s"Using generated HTTP API endpoint using [$rule]")
           rule

--- a/tck/src/main/scala/io/cloudstate/tck/CrdtEntityTCK.scala
+++ b/tck/src/main/scala/io/cloudstate/tck/CrdtEntityTCK.scala
@@ -1953,6 +1953,15 @@ trait CrdtEntityTCK extends TCKSpec {
         .expectOutgoing(reply(1, PNCounter.state(0)))
 
       client.http
+        .request("cloudstate.tck.model.crdt.CrdtTwo/Call", s"""{"id": "$id"}""")
+        .futureValue mustBe "{}"
+      interceptor
+        .expectCrdtEntityConnection()
+        .expectIncoming(init(ServiceTwo, id))
+        .expectIncoming(command(1, id, "Call", Request(id)))
+        .expectOutgoing(reply(1, Response()))
+
+      client.http
         .request(s"tck/model/crdt/$id", """{"actions": [{"update": {"pncounter": {"change": 42} }}]}""")
         .futureValue mustBe """{"state":{"pncounter":{"value":"42"}}}"""
       connection

--- a/tck/src/main/scala/io/cloudstate/tck/EntityTCK.scala
+++ b/tck/src/main/scala/io/cloudstate/tck/EntityTCK.scala
@@ -426,6 +426,15 @@ trait EntityTCK extends TCKSpec {
         .expectOutgoing(reply(1, Response()))
 
       client.http
+        .request("cloudstate.tck.model.valueentity.ValueEntityTwo/Call", s"""{"id": "$id"}""")
+        .futureValue mustBe """{"message":""}"""
+      interceptor
+        .expectEntityConnection()
+        .expectIncoming(init(ServiceTwo, id))
+        .expectIncoming(command(1, id, "Call", Request(id)))
+        .expectOutgoing(reply(1, Response()))
+
+      client.http
         .request(s"tck/model/entity/$id", """{"actions": [{"update": {"value": "one"}}]}""")
         .futureValue mustBe """{"message":"one"}"""
       connection

--- a/tck/src/main/scala/io/cloudstate/tck/EventSourcedEntityTCK.scala
+++ b/tck/src/main/scala/io/cloudstate/tck/EventSourcedEntityTCK.scala
@@ -479,6 +479,15 @@ trait EventSourcedEntityTCK extends TCKSpec {
         .expectOutgoing(reply(1, Response()))
 
       client.http
+        .request("cloudstate.tck.model.EventSourcedTwo/Call", s"""{"id": "$id"}""")
+        .futureValue mustBe """{"message":""}"""
+      interceptor
+        .expectEventSourcedEntityConnection()
+        .expectIncoming(init(ServiceTwo, id))
+        .expectIncoming(command(1, id, "Call", Request(id)))
+        .expectOutgoing(reply(1, Response()))
+
+      client.http
         .request(s"tck/model/eventsourced/$id", """{"actions": [{"emit": {"value": "x"}}]}""")
         .futureValue mustBe """{"message":"x"}"""
       connection


### PR DESCRIPTION
Resolves #501. Use the full service name in the default mappings for HTTP API, so that multiple services with the same methods can be served (previously `/v1/MethodName`, now `/fully.qualified.ServiceName/MethodName`). Adds a check for gRPC requests so that gRPC and HTTP can serve the same paths, since these are the same now — is it reasonable to assume HTTP/2 and application/grpc content types for checking gRPC requests?