### PR TITLE
Get GraalVM container images from GitHub packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     - run:
         name: Build sbt native image
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
+          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
           sbt "dockerBuildNativeCore publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-core.tar
@@ -107,7 +107,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
+          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
           sbt "dockerBuildNativePostgres publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-postgres.tar
@@ -130,7 +130,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
+          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
           sbt "dockerBuildNativeCassandra publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-cassandra.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     - run:
         name: Build sbt native image
         command: |
-          echo "$GITHUB_TOKEN" | docker login https://docker.pkg.github.com -u cloudstatebot --password-stdin
+          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
           sbt "dockerBuildNativeCore publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-core.tar
@@ -107,7 +107,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          echo "$GITHUB_TOKEN" | docker login https://docker.pkg.github.com -u cloudstatebot --password-stdin
+          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
           sbt "dockerBuildNativePostgres publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-postgres.tar
@@ -130,7 +130,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          echo "$GITHUB_TOKEN" | docker login https://docker.pkg.github.com -u cloudstatebot --password-stdin
+          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
           sbt "dockerBuildNativeCassandra publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-cassandra.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     - run:
         name: Build sbt native image
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
+          docker login https://docker.pkg.github.com -u cloudstatebot -p "${GITHUB_TOKEN}"
           sbt "dockerBuildNativeCore publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-core.tar
@@ -107,7 +107,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
+          docker login https://docker.pkg.github.com -u cloudstatebot -p "${GITHUB_TOKEN}"
           sbt "dockerBuildNativePostgres publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-postgres.tar
@@ -130,7 +130,8 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
+          echo $GITHUB_TOKEN | wc
+          docker login https://docker.pkg.github.com -u cloudstatebot -p "${GITHUB_TOKEN}"
           sbt "dockerBuildNativeCassandra publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-cassandra.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     - run:
         name: Build sbt native image
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p "${GITHUB_TOKEN}"
+          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
           sbt "dockerBuildNativeCore publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-core.tar
@@ -107,7 +107,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p "${GITHUB_TOKEN}"
+          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
           sbt "dockerBuildNativePostgres publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-postgres.tar
@@ -130,8 +130,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          echo $GITHUB_TOKEN | wc
-          docker login https://docker.pkg.github.com -u cloudstatebot -p "${GITHUB_TOKEN}"
+          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
           sbt "dockerBuildNativeCassandra publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-cassandra.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,9 @@ jobs:
     - restore_sbt_cache
     - run:
         name: Build sbt native image
-        command: sbt "dockerBuildNativeCore publishLocal"
+        command: |
+          echo "$GITHUB_TOKEN" | docker login https://docker.pkg.github.com -u cloudstatebot --password-stdin
+          sbt "dockerBuildNativeCore publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-core.tar
         docker_image: cloudstateio/cloudstate-proxy-native-core:latest
@@ -104,7 +106,9 @@ jobs:
     - restore_sbt_cache
     - run:
         name: Build sbt native images
-        command: sbt "dockerBuildNativePostgres publishLocal"
+        command: |
+          echo "$GITHUB_TOKEN" | docker login https://docker.pkg.github.com -u cloudstatebot --password-stdin
+          sbt "dockerBuildNativePostgres publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-postgres.tar
         docker_image: cloudstateio/cloudstate-proxy-native-postgres:latest
@@ -125,7 +129,9 @@ jobs:
     - restore_sbt_cache
     - run:
         name: Build sbt native images
-        command: sbt "dockerBuildNativeCassandra publishLocal"
+        command: |
+          echo "$GITHUB_TOKEN" | docker login https://docker.pkg.github.com -u cloudstatebot --password-stdin
+          sbt "dockerBuildNativeCassandra publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-cassandra.tar
         docker_image: cloudstateio/cloudstate-proxy-native-cassandra:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     - run:
         name: Build sbt native image
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
+          echo "$GITHUB_TOKEN" | docker login https://docker.pkg.github.com -u cloudstatebot --password-stdin
           sbt "dockerBuildNativeCore publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-core.tar
@@ -107,7 +107,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
+          echo "$GITHUB_TOKEN" | docker login https://docker.pkg.github.com -u cloudstatebot --password-stdin
           sbt "dockerBuildNativePostgres publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-postgres.tar
@@ -130,7 +130,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
+          echo "$GITHUB_TOKEN" | docker login https://docker.pkg.github.com -u cloudstatebot --password-stdin
           sbt "dockerBuildNativeCassandra publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-cassandra.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     - run:
         name: Build sbt native image
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
+          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
           sbt "dockerBuildNativeCore publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-core.tar
@@ -107,7 +107,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
+          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
           sbt "dockerBuildNativePostgres publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-postgres.tar
@@ -130,7 +130,7 @@ jobs:
     - run:
         name: Build sbt native images
         command: |
-          docker login https://docker.pkg.github.com -u cloudstatebot -p $GITHUB_TOKEN
+          docker login https://docker.pkg.github.com -u cloudstatebot -p ${GITHUB_TOKEN}
           sbt "dockerBuildNativeCassandra publishLocal"
     - save_docker_image:
         tar_file: cloudstate-proxy-native-cassandra.tar

--- a/build.sbt
+++ b/build.sbt
@@ -257,7 +257,7 @@ commands ++= Seq(
 def nativeImageDockerSettings: Seq[Setting[_]] = dockerSettings ++ Seq(
   // If this is Some(…): run the native-image generation inside a Docker image
   // If this is None: run the native-image generation using a local GraalVM installation
-  graalVMVersion := Some(GraalVersion + "-java11"), // make sure we use the java11 version
+  graalVMVersion := Some("java11-" + GraalVersion), // make sure we use the java11 version
   graalVMNativeImageOptions ++= sharedNativeImageSettings({
       graalVMVersion.value match {
         case Some(_) => new File("/opt/docker/graal-resources/")

--- a/project/GraalVMPlugin.scala
+++ b/project/GraalVMPlugin.scala
@@ -41,7 +41,7 @@ object GraalVMPlugin extends AutoPlugin {
   import DockerPlugin.autoImport._
   import UniversalPlugin.autoImport._
 
-  private val GraalVMBaseImage = "oracle/graalvm-ce"
+  private val GraalVMBaseImage = "docker.pkg.github.com/graalvm/container/community"
   private val NativeImageCommand = "native-image"
 
   override def requires: Plugins = JavaAppPackaging && DockerPlugin


### PR DESCRIPTION
Since they have disappeared from Docker Hub:
https://www.graalvm.org/docs/getting-started/#graalvm-community-container-images

May need an update to CircleCI to set up credentials to log in to
GitHub, let's see.