### PR TITLE
Update to Akka gRPC 1.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,11 +35,11 @@ name := "cloudstate"
 val ProtocolMajorVersion = 0
 val ProtocolMinorVersion = 2
 
-val GrpcJavaVersion = "1.30.2" // Note: sync with gRPC version in Akka gRPC
+val GrpcJavaVersion = "1.35.0" // Note: sync with gRPC version in Akka gRPC
 // Unfortunately we need to downgrade grpc-netty-shaded
-// in the proxy until we have a fix to make it work with
-// native-image
-val GrpcNettyShadedVersion = "1.28.1"
+// to 1.28.1 in the proxy until we have a fix to make it work with
+// native-image... but that no longer works
+val GrpcNettyShadedVersion = "1.35.0"
 val GraalAkkaVersion = "0.5.0"
 val AkkaVersion = "2.6.9"
 val AkkaHttpVersion = "10.2.3" // Note: should be newer than Akka HTTP version in Akka gRPC

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ val GrpcJavaVersion = "1.30.2" // Note: sync with gRPC version in Akka gRPC
 val GrpcNettyShadedVersion = "1.28.1"
 val GraalAkkaVersion = "0.5.0"
 val AkkaVersion = "2.6.9"
-val AkkaHttpVersion = "10.1.12" // Note: sync with Akka HTTP version in Akka gRPC
+val AkkaHttpVersion = "10.2.3" // Note: should be newer than Akka HTTP version in Akka gRPC
 val AkkaManagementVersion = "1.0.8"
 val AkkaPersistenceCassandraVersion = "0.102"
 val AkkaPersistenceJdbcVersion = "3.5.2"
@@ -773,6 +773,7 @@ lazy val `testkit` = (project in file("testkit"))
     buildInfoPackage := "io.cloudstate.testkit",
     libraryDependencies ++= Seq(
         akkaDependency("akka-stream-testkit"),
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
         "com.google.protobuf" % "protobuf-java" % ProtobufVersion % "protobuf",
         "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"
       ),

--- a/java-support/src/main/scala/io/cloudstate/javasupport/CloudStateRunner.scala
+++ b/java-support/src/main/scala/io/cloudstate/javasupport/CloudStateRunner.scala
@@ -142,10 +142,8 @@ final class CloudStateRunner private[this] (
   def run(): CompletionStage[Done] = {
     val serverBindingFuture = Http
       .get(system)
-      .bindAndHandleAsync(createRoutes(),
-                          configuration.userFunctionInterface,
-                          configuration.userFunctionPort,
-                          HttpConnectionContext(UseHttp2.Always))
+      .newServerAt(configuration.userFunctionInterface, configuration.userFunctionPort)
+      .bind(createRoutes())
     // FIXME Register an onTerminate callback to unbind the Http server
     FutureConverters
       .toJava(serverBindingFuture)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.4")
 
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "1.0.1") // When updating, also update GrpcJavaVersion in build.sbt to be in sync
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "1.1.0-M2") // When updating, also update GrpcJavaVersion in build.sbt to be in sync
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/EntityDiscoveryManager.scala
@@ -261,11 +261,9 @@ class EntityDiscoveryManager(config: EntityDiscoveryManager.Configuration)(
 
         // Don't actually bind until we have a cluster
         Cluster(context.system).registerOnMemberUp {
-          Http().bindAndHandleAsync(
-            handler = route,
-            interface = config.httpInterface,
-            port = config.httpPort
-          ) pipeTo self
+          Http()
+            .newServerAt(config.httpInterface, config.httpPort)
+            .bind(route) pipeTo self
 
           EventingManager.startConsumers(router, entities, topicSupport, eventLogEventing, projectionSupport)
         }

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/telemetry/PrometheusExporter.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/telemetry/PrometheusExporter.scala
@@ -56,7 +56,7 @@ class PrometheusExporter(registry: CollectorRegistry, metricsHost: String, metri
 
   def start(): Unit = {
     import system.dispatcher
-    Http().bindAndHandle(routes, metricsHost, metricsPort).onComplete {
+    Http().newServerAt(metricsHost, metricsPort).bind(routes).onComplete {
       case Success(binding) =>
         system.log.info("Prometheus exporter started on {}", binding.localAddress)
       case Failure(error) =>

--- a/testkit/src/main/scala/io/cloudstate/testkit/InterceptService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/InterceptService.scala
@@ -47,15 +47,15 @@ final class InterceptService(settings: InterceptorSettings) {
     import context.system
     entityDiscovery.expectOnline(60.seconds)
     Await.result(
-      Http().bindAndHandleAsync(
-        handler = entityDiscovery.handler
+      Http()
+        .newServerAt(settings.bind.host, settings.bind.port)
+        .bind(
+          entityDiscovery.handler
           orElse action.handler
           orElse valueEntity.handler
           orElse eventSourcedEntity.handler
-          orElse crdtEntity.handler,
-        interface = settings.bind.host,
-        port = settings.bind.port
-      ),
+          orElse crdtEntity.handler
+        ),
       10.seconds
     )
   }

--- a/testkit/src/main/scala/io/cloudstate/testkit/TestService.scala
+++ b/testkit/src/main/scala/io/cloudstate/testkit/TestService.scala
@@ -43,11 +43,9 @@ final class TestService {
   import context.system
 
   Await.result(
-    Http().bindAndHandleAsync(
-      handler = entityDiscovery.handler orElse eventSourced.handler orElse valueEntity.handler,
-      interface = "localhost",
-      port = port
-    ),
+    Http()
+      .newServerAt("localhost", port)
+      .bind(entityDiscovery.handler orElse eventSourced.handler orElse valueEntity.handler),
     10.seconds
   )
 


### PR DESCRIPTION
depends on #516 

Holding back the grpc-netty version for the native image no longer appears to work. We should probably investigate if that problem with newer grpc-netty versions in native images still exists.

Alternatively we could start trying out the experimental Akka HTTP-based client backend.