### PR TITLE
Update to Graal 20.3.1 and use github container registry

### DIFF
--- a/project/GraalVMPlugin.scala
+++ b/project/GraalVMPlugin.scala
@@ -41,7 +41,7 @@ object GraalVMPlugin extends AutoPlugin {
   import DockerPlugin.autoImport._
   import UniversalPlugin.autoImport._
 
-  private val GraalVMBaseImage = "oracle/graalvm-ce"
+  private val GraalVMBaseImage = "ghcr.io/graalvm/graalvm-ce"
   private val NativeImageCommand = "native-image"
 
   override def requires: Plugins = JavaAppPackaging && DockerPlugin

--- a/proxy/core/src/main/scala/io/cloudstate/proxy/CloudStateProxyMain.scala
+++ b/proxy/core/src/main/scala/io/cloudstate/proxy/CloudStateProxyMain.scala
@@ -130,10 +130,11 @@ object CloudStateProxyMain {
     start(Option(config))
 
   private def start(configuration: Option[Config]): ActorSystem = {
+    // This should be fixed in Graal already
     // Must do this first, before anything uses ThreadLocalRandom
-    if (isGraalVM) {
-      initializeThreadLocalRandom()
-    }
+    // if (isGraalVM) {
+    //   initializeThreadLocalRandom()
+    // }
 
     implicit val system = configuration.fold(ActorSystem("cloudstate-proxy"))(c => ActorSystem("cloudstate-proxy", c))
     implicit val materializer = SystemMaterializer(system)


### PR DESCRIPTION
Alternative to #515. Use `ghcr.io/graalvm/graalvm-ce` for docker images, and update to `20.3.1` (closest version published there). A couple of options had errors, which I've just commented out for now. Let's see how the integration tests go.