### PR TITLE
TCK pre-command support for initial docker image pulls

### DIFF
--- a/tck/src/it/resources/application.conf
+++ b/tck/src/it/resources/application.conf
@@ -80,14 +80,8 @@ cloudstate-tck.combinations = [{
   }
 
   service {
-    hostname = "127.0.0.1"
     port = 8080
-    directory = ${user.dir}
-    command = ["docker", "run", "--rm", "-p", "127.0.0.1:8080:8080", "cloudstateio/cloudstate-go-tck:latest"]
-    env-vars {
-      HOST = "127.0.0.1"
-      PORT = "8080"
-    }
+    docker-image = "cloudstateio/cloudstate-go-tck:latest"
   }
 },{
   name = "Akka + Kotlin"

--- a/tck/src/it/resources/native-image.conf
+++ b/tck/src/it/resources/native-image.conf
@@ -54,14 +54,8 @@ cloudstate-tck.combinations = [{
   }
 
   service {
-    hostname = "127.0.0.1"
     port = 8080
-    directory = ${user.dir}
-    command = ["docker", "run", "--rm", "-p", "127.0.0.1:8080:8080", "cloudstateio/cloudstate-go-tck:latest"]
-    env-vars {
-      HOST = "127.0.0.1"
-      PORT = "8080"
-    }
+    docker-image = "cloudstateio/cloudstate-go-tck:latest"
   }
 },{
   name = "Akka + Kotlin"

--- a/tck/src/it/resources/reference.conf
+++ b/tck/src/it/resources/reference.conf
@@ -15,6 +15,7 @@ cloudstate-tck {
     hostname = ${?HOST}
     port = 9000
     directory = ${user.dir}
+    pre-command = []
     command = []
     stop-command = []
     env-vars {
@@ -30,6 +31,7 @@ cloudstate-tck {
     hostname = ${?HOST}
     port = 8080
     directory = ${user.dir}
+    pre-command = []
     command = []
     stop-command = []
     env-vars {

--- a/tck/src/it/scala/io/cloudstate/tck/TckConfiguration.scala
+++ b/tck/src/it/scala/io/cloudstate/tck/TckConfiguration.scala
@@ -25,6 +25,7 @@ final case class TckProcessConfig private (
     hostname: String,
     port: Int,
     directory: File,
+    preCommand: List[String],
     command: List[String],
     stopCommand: Option[List[String]],
     envVars: Map[String, String],
@@ -48,6 +49,7 @@ object TckProcessConfig {
       hostname = config.getString("hostname"),
       port = config.getInt("port"),
       directory = new File(config.getString("directory")),
+      preCommand = config.getStringList("pre-command").asScala.toList,
       command = config.getStringList("command").asScala.toList,
       stopCommand = Some(config.getStringList("stop-command").asScala.toList).filter(_.nonEmpty),
       envVars = config.getConfig("env-vars").root.unwrapped.asScala.toMap.map {


### PR DESCRIPTION
Should resolve #514. Add general support for running another command before starting TCK implementations. It waits for that command to complete first. Add built-in support for pulling (and waiting for) docker images before running. Tried out both with an extra sleep to create a long retrying docker pull. Switched the Go TCK over to using the built-in docker image support. Let's see how this goes in the Travis builds, should be fine now.