### PR TITLE
Update native image TCK integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,15 @@ jobs:
           name: Load docker images
           command: docker image load < /tmp/workspace/cloudstate-proxy-native-core.tar
       - run:
+          name: Run npm install
+          command: |
+            source /opt/circleci/.nvm/nvm.sh
+            cd node-support && nvm install && npm install && cd -
+            cd node-support/tck && nvm install && npm install && cd -
+      - run:
           name: Run TCK with native image
           command: |
+            source /opt/circleci/.nvm/nvm.sh && cd node-support && nvm use && cd -
             sbt -Dconfig.resource=native-image.conf \
               'set concurrentRestrictions in Global += Tags.limitAll(1)' \
               'set scalafmtOnCompile := false' \

--- a/tck/src/it/resources/native-image.conf
+++ b/tck/src/it/resources/native-image.conf
@@ -1,4 +1,4 @@
-cloudstate-tck.verify = ["Akka + Java", "Akka + Go"]
+cloudstate-tck.verify = ["Akka + Node.js", "Akka + Java", "Akka + Go"]
 #cloudstate-tck.verify = ["Akka + Node.js", "Akka + Java", "Akka + Go", "Akka + Kotlin"]
 cloudstate-tck.combinations = [{
   name = "Akka + Node.js"
@@ -14,7 +14,9 @@ cloudstate-tck.combinations = [{
 
   service {
     hostname = "127.0.0.1"
-    command = ["docker", "run", "--rm", "-p", "127.0.0.1:8080:8080", "cloudstateio/samples-js-shopping-cart"]
+    port = 8080
+    directory = ${user.dir}/node-support/tck
+    command = ["node", "index.js"]
     env-vars {
       DEBUG = "cloudstate-*"
     }

--- a/tck/src/it/resources/reference.conf
+++ b/tck/src/it/resources/reference.conf
@@ -23,6 +23,7 @@ cloudstate-tck {
     # If specified, will start a docker container, with the environment variable USER_FUNCTION_HOST set to the host
     # to connect to, USER_FUNCTION_PORT set to the port to connect to, and HTTP_PORT set to the port above.
     docker-image = ""
+    docker-pull = false
     docker-args = []
   }
 
@@ -38,6 +39,7 @@ cloudstate-tck {
     }
     # If specified, will start a docker container, with the environment variable PORT set to the port above.
     docker-image = ""
+    docker-pull = true
     docker-args = []
   }
 }

--- a/tck/src/it/scala/io/cloudstate/tck/TckConfiguration.scala
+++ b/tck/src/it/scala/io/cloudstate/tck/TckConfiguration.scala
@@ -30,6 +30,7 @@ final case class TckProcessConfig private (
     stopCommand: Option[List[String]],
     envVars: Map[String, String],
     dockerImage: String,
+    dockerPull: Boolean,
     dockerArgs: List[String],
 ) {
   def validate(): Unit =
@@ -56,6 +57,7 @@ object TckProcessConfig {
         case (key, value: AnyRef) => key -> value.toString
       },
       dockerImage = config.getString("docker-image"),
+      dockerPull = config.getBoolean("docker-pull"),
       dockerArgs = config.getStringList("docker-args").asScala.toList
     )
 }

--- a/tck/src/it/scala/io/cloudstate/tck/TckProcesses.scala
+++ b/tck/src/it/scala/io/cloudstate/tck/TckProcesses.scala
@@ -103,8 +103,10 @@ object TckProcesses {
       private val logger = new TckProcessLogger
 
       override def start(): Unit = {
-        val pullExitCode = Process(Seq("docker", "pull", spec.dockerImage)) ! logger
-        if (pullExitCode != 0) sys.error(s"Docker pull failed with exit code: $pullExitCode")
+        if (spec.dockerPull) {
+          val pullExitCode = Process(Seq("docker", "pull", spec.dockerImage)) ! logger
+          if (pullExitCode != 0) sys.error(s"Docker pull failed with exit code: $pullExitCode")
+        }
 
         val env = extraEnv ++ spec.envVars
 


### PR DESCRIPTION
Add a setting for whether to docker pull in TCK integration tests, so we have this on for TCK implementation docker images, and off for native image proxy so it uses the locally built one. Currently pulling a published image instead in #511 which is failing.

Also try enabling the node-support TCK in the native image integration tests.

