### PR TITLE
Disable git clone depth in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ jdk:
   - openjdk11
 before_install:
   - sudo apt-get -qq -y install conntrack jq
+git:
+  # disable git clone depth for dynamic versions from tags
+  depth: false
 env:
   global:
   - CACHE_NAME=cloudstate-cache-01


### PR DESCRIPTION
Travis has a default git clone depth of 50, so when the most recent tag is further than 50 commits away then the version for latest docker images will be `0.0.0`. This should disable the clone depth so we always have a version in the docker images.