### PR TITLE
More specific NPE in registerEventSourcedEntity

### DIFF
--- a/java-support/src/main/java/io/cloudstate/javasupport/CloudState.java
+++ b/java-support/src/main/java/io/cloudstate/javasupport/CloudState.java
@@ -149,6 +149,10 @@ public final class CloudState {
       throw new IllegalArgumentException(
           entityClass + " does not declare an " + EventSourcedEntity.class + " annotation!");
     }
+    if (descriptor == null) {
+      throw new NullPointerException(
+          "The ServiceDescriptor may not be null, verify the service lookup name.");
+    }
 
     final String persistenceId;
     final int snapshotEvery;


### PR DESCRIPTION
If the `findServiceByName` fails the user ends up with NPE.
This makes the exception point to the most likely wrong name in the lookup.