### PR TITLE
Switch to cloudstate-go-tck stable version 0.3.0

### DIFF
--- a/tck/src/it/resources/application.conf
+++ b/tck/src/it/resources/application.conf
@@ -81,7 +81,7 @@ cloudstate-tck.combinations = [{
 
   service {
     port = 8080
-    docker-image = "cloudstateio/cloudstate-go-tck:latest"
+    docker-image = "cloudstateio/cloudstate-go-tck:0.3.0"
   }
 },{
   name = "Akka + Kotlin"

--- a/tck/src/it/resources/native-image.conf
+++ b/tck/src/it/resources/native-image.conf
@@ -57,7 +57,7 @@ cloudstate-tck.combinations = [{
 
   service {
     port = 8080
-    docker-image = "cloudstateio/cloudstate-go-tck:latest"
+    docker-image = "cloudstateio/cloudstate-go-tck:0.3.0"
   }
 },{
   name = "Akka + Kotlin"


### PR DESCRIPTION
So that CI builds are stable, and `latest` can be used for more experimental builds such as in #511