### PR TITLE
Invoke postinstall script directly using node 

### DIFF
--- a/node-support/package.json
+++ b/node-support/package.json
@@ -77,6 +77,6 @@
     "jsdoc": "jsdoc -c jsdoc.json",
     "test": "mocha --recursive",
     "prepare": "bin/prepare.sh",
-    "postinstall": "bin/download-protoc.js"
+    "postinstall": "node bin/download-protoc.js"
   }
 }


### PR DESCRIPTION
Avoids issue with unix-style paths in windows.
Fixes #538 